### PR TITLE
fix(sacp): replace unwrap() with proper error propagation in actors

### DIFF
--- a/src/sacp/src/jsonrpc/actors.rs
+++ b/src/sacp/src/jsonrpc/actors.rs
@@ -33,14 +33,14 @@ pub(super) async fn reply_actor(
             ReplyMessage::Subscribe(id, message_tx) => {
                 // total hack: id's don't implement Eq
                 tracing::trace!(?id, "reply_actor: subscribing to response");
-                let id = serde_json::to_value(&id).unwrap();
+                let id = serde_json::to_value(&id).map_err(crate::Error::into_internal_error)?;
                 map.insert(id, message_tx);
             }
             ReplyMessage::Dispatch(id, value) => {
                 let id_debug = &id;
                 let is_ok = value.is_ok();
                 tracing::trace!(?id_debug, is_ok, "reply_actor: dispatching response");
-                let id = serde_json::to_value(&id).unwrap();
+                let id = serde_json::to_value(&id).map_err(crate::Error::into_internal_error)?;
                 if let Some(message_tx) = map.remove(&id) {
                     // If the receiver is no longer interested in the reply,
                     // that's ok with us.
@@ -212,7 +212,7 @@ pub(super) async fn transport_outgoing_actor(
                                     jsonrpc_error,
                                     response.id,
                                 ))
-                                .unwrap(),
+                                .map_err(crate::Error::into_internal_error)?,
                             )
                             .await
                             .map_err(crate::Error::into_internal_error)?;


### PR DESCRIPTION
## Summary

Replaces 3 `.unwrap()` calls in `src/sacp/src/jsonrpc/actors.rs` with `.map_err(crate::Error::into_internal_error)?`, following the existing error handling convention used throughout the file.

The affected calls are `serde_json::to_value()` (2x in `reply_actor`) and `serde_json::to_vec()` (1x in `transport_outgoing_actor`). While these serializations are unlikely to fail in practice, a panic in an async actor crashes the entire connection rather than returning a recoverable error.

The third fix is particularly important: it sits in a double-fault path — when serializing a fallback error response after the original response already failed to serialize. A panic here would be especially difficult to debug in production.

**Scope note:** `dispatch_request` at line 320 still uses `.expect("well-formed JSON")`, which was intentionally left unchanged — the input has already been parsed from JSON at that point, so the expectation is justified and has a descriptive message.

## Changes
- `src/sacp/src/jsonrpc/actors.rs`: 3 lines changed (`unwrap()` → `map_err()?`)

## Test plan
- [x] `cargo clippy --all-targets --all-features` — 0 warnings
- [x] `cargo test` — all existing tests pass