### PR TITLE
docs: add missing READMEs for sacp-tee, sacp-test, and yopo crates

### DIFF
--- a/src/sacp-tee/README.md
+++ b/src/sacp-tee/README.md
@@ -1,0 +1,61 @@
+# sacp-tee
+
+A debugging proxy that transparently logs all ACP traffic to a file.
+
+## What's in this crate?
+
+This crate provides a pass-through proxy that sits between two ACP endpoints, forwarding all messages while recording them to a log file for debugging purposes:
+
+- **`Tee`** - A `Component` that can be inserted into any proxy chain to capture traffic
+- **`TeeHandler`** - The message handler that logs requests, responses, and notifications
+- **`LogWriter`** - An async actor that writes log entries to disk
+- **`LogEntry`** - Structured log entries with timestamps and direction metadata
+
+## Usage
+
+### As a standalone binary
+
+```bash
+# Log all traffic between a client and an agent
+sacp-tee --log-file debug.log
+```
+
+### As a component in a proxy chain
+
+```rust
+use sacp_tee::Tee;
+use sacp::component::Component;
+use std::path::PathBuf;
+
+// Insert the tee into a proxy chain
+Tee::new(PathBuf::from("debug.log"))
+    .serve(downstream_component)
+    .await?;
+```
+
+## Log format
+
+Each line in the log file is a JSON object:
+
+```json
+{"timestamp":"2026-03-01T12:00:00Z","direction":"downstream","message":{"id":1,"method":"initialize","params":{...}}}
+{"timestamp":"2026-03-01T12:00:01Z","direction":"upstream","message":{"id":1,"result":{...}}}
+```
+
+## When to use this crate
+
+Use `sacp-tee` when you need to:
+- Debug message flow between ACP clients and agents
+- Capture traffic for analysis or replay
+- Diagnose protocol-level issues in a proxy chain
+
+## Related Crates
+
+- **[sacp](../sacp/)** - Core ACP SDK
+- **[sacp-proxy](../sacp-proxy/)** - Framework for building ACP proxies
+- **[sacp-conductor](../sacp-conductor/)** - Binary for orchestrating proxy chains
+- **[sacp-tokio](../sacp-tokio/)** - Tokio-specific utilities for spawning agents
+
+## License
+
+MIT OR Apache-2.0

--- a/src/sacp-test/README.md
+++ b/src/sacp-test/README.md
@@ -1,0 +1,53 @@
+# sacp-test
+
+Test utilities and mock types for testing ACP agents and proxies.
+
+## What's in this crate?
+
+This crate provides helpers for writing tests and documentation examples:
+
+- **Mock types** - Pre-defined request, response, and notification types (`MyRequest`, `ProcessRequest`, `SessionUpdate`, etc.)
+- **`MockTransport`** - A transport for doctests that don't need to actually run
+- **`test_client::yolo_prompt`** - A helper function to connect to an agent, send a prompt, and collect the response
+- **`arrow_proxy`** - An example proxy for integration tests
+- **Helper functions** - `mock_connection()`, `expensive_analysis()`, and other utilities for examples
+
+## Usage
+
+### Integration testing with `yolo_prompt`
+
+```rust
+use sacp_test::test_client::yolo_prompt;
+
+let (write, read) = create_streams_to_agent();
+let result = yolo_prompt(write, read, "Hello, agent!").await?;
+assert!(result.contains("response text"));
+```
+
+### Using mock types in tests
+
+```rust
+use sacp_test::{MyRequest, MyResponse, ProcessRequest, ProcessResponse};
+
+// Mock types implement JrRequest/JrNotification traits
+// so they can be used directly with JrHandlerChain
+```
+
+## When to use this crate
+
+Use `sacp-test` when you need to:
+- Write integration tests for ACP agents or proxies
+- Provide runnable examples in documentation
+- Build test fixtures that need mock ACP message types
+
+This crate is not published (`publish = false`) and is intended for internal testing only.
+
+## Related Crates
+
+- **[sacp](../sacp/)** - Core ACP SDK
+- **[sacp-conductor](../sacp-conductor/)** - Uses this crate for integration tests
+- **[sacp-proxy](../sacp-proxy/)** - Framework for building ACP proxies
+
+## License
+
+MIT OR Apache-2.0

--- a/src/yopo/README.md
+++ b/src/yopo/README.md
@@ -1,0 +1,46 @@
+# yopo
+
+**YOPO** (You Only Prompt Once) - A simple ACP client for one-shot prompts.
+
+## What's in this crate?
+
+YOPO is a minimal ACP client that sends a single prompt to an agent and prints the response. It auto-approves all permission requests, making it useful for quick testing and scripting.
+
+## Usage
+
+```bash
+# With a simple command
+yopo "What is 2+2?" "python my_agent.py"
+
+# With a JSON agent configuration
+yopo "Hello!" '{"type":"stdio","name":"my-agent","command":"python","args":["agent.py"],"env":[]}'
+```
+
+## How it works
+
+1. Parses the agent configuration (command string or JSON)
+2. Spawns the agent process via `sacp-tokio`
+3. Initializes the ACP connection
+4. Creates a new session
+5. Sends the prompt
+6. Prints all `AgentMessageChunk` text to stdout
+7. Auto-approves any permission requests from the agent
+8. Exits when the agent completes
+
+## When to use this crate
+
+Use `yopo` when you need to:
+- Quickly test an agent from the command line
+- Script agent interactions in shell pipelines
+- Verify that an agent responds correctly to a prompt
+
+For interactive or multi-turn sessions, use a full ACP client like Zed or a JetBrains IDE.
+
+## Related Crates
+
+- **[sacp](../sacp/)** - Core ACP SDK (use this for building agents)
+- **[sacp-tokio](../sacp-tokio/)** - Tokio-specific utilities for spawning agents
+
+## License
+
+MIT OR Apache-2.0


### PR DESCRIPTION
## Summary

Adds README files for three crates that currently lack documentation:

- **sacp-tee**: Debugging proxy that transparently logs all ACP traffic to a file for inspection
- **sacp-test**: Test utilities, mock types, and helper functions for testing ACP components
- **yopo**: "You Only Prompt Once" — a minimal CLI client for single-prompt agent interactions

Each README documents the crate's purpose, key types/functions, and usage examples. Content was cross-referenced against the source code for accuracy. Style follows the existing READMEs in `sacp-proxy/` and `elizacp/`.

## Changes
- `src/sacp-tee/README.md` (new)
- `src/sacp-test/README.md` (new)
- `src/yopo/README.md` (new)