### PR TITLE
fix: handle escaped forward slashes in JSON-RPC method names

### DIFF
--- a/src/agent-client-protocol/src/rpc.rs
+++ b/src/agent-client-protocol/src/rpc.rs
@@ -307,7 +307,9 @@ pub struct RawIncomingMessage<'a> {
     id: Option<RequestId>,
     #[serde(borrow)]
     method: Option<Cow<'a, str>>,
+    #[serde(borrow)]
     params: Option<&'a RawValue>,
+    #[serde(borrow)]
     result: Option<&'a RawValue>,
     error: Option<Error>,
 }
@@ -333,4 +335,33 @@ pub trait MessageHandler<Local: Side> {
         &self,
         notification: Local::InNotification,
     ) -> impl Future<Output = Result<()>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_raw_incoming_message_with_escaped_slash() {
+        // JSON with escaped forward slash in method name (valid per RFC 8259).
+        // Some JSON encoders (especially behind WebSocket proxies) produce
+        // `\/` instead of `/`.  The Cow<str> field in RawIncomingMessage ensures
+        // serde can allocate a new String when unescaping is required.
+        //
+        // Before the fix, this would fail because `&'a str` cannot hold an
+        // unescaped value that differs from the source bytes.
+        let json_str = r#"{"jsonrpc":"2.0","id":1,"method":"session\/update","params":{}}"#;
+        let parsed: RawIncomingMessage<'_> = serde_json::from_str(json_str).unwrap();
+        assert_eq!(parsed.method.unwrap(), "session/update");
+        assert_eq!(parsed.params.unwrap().to_string(), "{}");
+    }
+
+    #[test]
+    fn test_raw_incoming_message_without_escape() {
+        // Normal method name without escapes should still work (zero-copy borrow via Cow::Borrowed).
+        let json_str = r#"{"jsonrpc":"2.0","id":2,"method":"session/update","params":{}}"#;
+        let parsed: RawIncomingMessage<'_> = serde_json::from_str(json_str).unwrap();
+        assert_eq!(parsed.method.unwrap(), "session/update");
+        assert_eq!(parsed.params.unwrap().to_string(), "{}");
+    }
 }

--- a/src/agent-client-protocol/src/rpc_tests.rs
+++ b/src/agent-client-protocol/src/rpc_tests.rs
@@ -927,27 +927,3 @@ async fn test_set_session_config_option() {
         })
         .await;
 }
-
-#[test]
-fn test_raw_incoming_message_with_escaped_slash() {
-    // JSON with escaped forward slash in method name (valid per RFC 8259).
-    // Some JSON encoders (especially behind WebSocket proxies) produce
-    // `\/` instead of `/`.  The Cow<str> field in RawIncomingMessage ensures
-    // serde can allocate a new String when unescaping is required.
-    //
-    // Before the fix, this would fail because `&'a str` cannot hold an
-    // unescaped value that differs from the source bytes.
-    let json_str = r#"{"jsonrpc":"2.0","id":1,"method":"session\/update","params":{}}"#;
-    let parsed: crate::rpc::RawIncomingMessage<'_> = serde_json::from_str(json_str).unwrap();
-    // Struct fields are private, but successful deserialization proves the fix works.
-    // The method field will contain "session/update" (unescaped).
-    drop(parsed);
-}
-
-#[test]
-fn test_raw_incoming_message_without_escape() {
-    // Normal method name without escapes should still work (zero-copy borrow via Cow::Borrowed).
-    let json_str = r#"{"jsonrpc":"2.0","id":2,"method":"session/update","params":{}}"#;
-    let parsed: crate::rpc::RawIncomingMessage<'_> = serde_json::from_str(json_str).unwrap();
-    drop(parsed);
-}


### PR DESCRIPTION
## Summary

- Fix deserialization failure when JSON-RPC method names contain escaped forward slashes (e.g., `session\/update`)
- Change `RawIncomingMessage.method` from `Option<&'a str>` to `Option<Cow<'a, str>>` with `#[serde(borrow)]`
- Update all call sites to work with `Cow<str>` via `&method` (auto-deref) and `&*method` (explicit deref)

Closes #62

## Context

Per RFC 8259, `\/` is a valid JSON escape sequence. When a JSON-RPC message contains an escaped slash in the method name, serde must allocate a new `String` to unescape it. The previous `&'a str` type cannot represent this allocation since it requires zero-copy borrowing from the source buffer.

`Cow<'a, str>` is the idiomatic Rust solution: it borrows from the source buffer in the common case (no escaping needed, zero overhead) and allocates only when escape sequences require it.

## Test plan

- [x] Added `test_raw_incoming_message_with_escaped_slash` — verifies `\/` in method name deserializes successfully
- [x] Added `test_raw_incoming_message_without_escape` — verifies normal method names still work
- [x] All 11 existing tests pass
- [x] `cargo clippy` clean, `cargo fmt --check` clean