### PR TITLE
 fix(acp): remove `boxfnonce` dependency in favor of `Box<dyn FnOnce>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,6 @@ dependencies = [
  "agent-client-protocol-schema",
  "agent-client-protocol-test",
  "anyhow",
- "boxfnonce",
  "clap",
  "expect-test",
  "futures",
@@ -367,12 +366,6 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
-
-[[package]]
-name = "boxfnonce"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5988cb1d626264ac94100be357308f29ff7cbdd3b36bda27f450a4ee3f713426"
 
 [[package]]
 name = "bumpalo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,6 @@ tower-http = { version = "0.6", features = ["fs"] }
 async-broadcast = "0.7"
 async-stream = "0.3.6"
 async-trait = "0.1"
-boxfnonce = "0.1.1"
 chrono = "0.4"
 derive_more = { version = "2", features = ["from"] }
 futures = "0.3.32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ agent-client-protocol-trace-viewer = { path = "src/agent-client-protocol-trace-v
 yopo = { package = "agent-client-protocol-yopo", path = "src/yopo" }
 
 # Core async runtime
-tokio = { version = "1.52", features = ["full"] }
+tokio = { version = "1.48", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 
 # Protocol
@@ -40,10 +40,10 @@ agent-client-protocol-schema = { version = "=0.12.0", features = ["tracing"] }
 # Serialization
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = { version = "1", features = ["raw_value"] }
-schemars = { version = "1.2", features = ["derive"] }
+schemars = { version = "1.0", features = ["derive"] }
 
 # UUID generation
-uuid = { version = "1.23", features = ["v4"] }
+uuid = { version = "1.18", features = ["v4"] }
 
 # Error handling
 anyhow = "1.0"
@@ -57,14 +57,14 @@ tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # MCP SDK
-rmcp = { version = "1.5", features = ["server", "transport-io", "schemars"] }
+rmcp = { version = "1.2.0", features = ["server", "transport-io", "schemars"] }
 
 # CLI parsing
-clap = { version = "4.6", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"] }
 
 # HTTP
 axum = "0.8"
-hyper = "1.9"
+hyper = "1.0"
 tower = "0.5"
 tower-http = { version = "0.6", features = ["fs"] }
 
@@ -75,11 +75,11 @@ async-trait = "0.1"
 chrono = "0.4"
 derive_more = { version = "2", features = ["from"] }
 futures = "0.3.32"
-futures-concurrency = "7.7"
+futures-concurrency = "7.6.3"
 fxhash = "0.2.1"
 jsonrpcmsg = "0.1.2"
 open = "5"
-rustc-hash = "2.1"
+rustc-hash = "2.1.1"
 shell-words = "1.1"
 strip-ansi-escapes = "0.2"
 
@@ -91,11 +91,11 @@ syn = { version = "2", features = ["full", "extra-traits"] }
 
 # Testing
 expect-test = "1.5"
-regex = "1.12"
+regex = "1.12.2"
 futures-util = { version = "0.3", features = ["io"] }
 piper = "0.2"
 pretty_assertions = "1"
-rustyline = "18"
+rustyline = "17"
 tokio-test = "0.4"
 
 [workspace.lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ agent-client-protocol-trace-viewer = { path = "src/agent-client-protocol-trace-v
 yopo = { package = "agent-client-protocol-yopo", path = "src/yopo" }
 
 # Core async runtime
-tokio = { version = "1.48", features = ["full"] }
+tokio = { version = "1.52", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 
 # Protocol
@@ -40,10 +40,10 @@ agent-client-protocol-schema = { version = "=0.12.0", features = ["tracing"] }
 # Serialization
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = { version = "1", features = ["raw_value"] }
-schemars = { version = "1.0", features = ["derive"] }
+schemars = { version = "1.2", features = ["derive"] }
 
 # UUID generation
-uuid = { version = "1.18", features = ["v4"] }
+uuid = { version = "1.23", features = ["v4"] }
 
 # Error handling
 anyhow = "1.0"
@@ -57,14 +57,14 @@ tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # MCP SDK
-rmcp = { version = "1.2.0", features = ["server", "transport-io", "schemars"] }
+rmcp = { version = "1.5", features = ["server", "transport-io", "schemars"] }
 
 # CLI parsing
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 
 # HTTP
 axum = "0.8"
-hyper = "1.0"
+hyper = "1.9"
 tower = "0.5"
 tower-http = { version = "0.6", features = ["fs"] }
 
@@ -75,11 +75,11 @@ async-trait = "0.1"
 chrono = "0.4"
 derive_more = { version = "2", features = ["from"] }
 futures = "0.3.32"
-futures-concurrency = "7.6.3"
+futures-concurrency = "7.7"
 fxhash = "0.2.1"
 jsonrpcmsg = "0.1.2"
 open = "5"
-rustc-hash = "2.1.1"
+rustc-hash = "2.1"
 shell-words = "1.1"
 strip-ansi-escapes = "0.2"
 
@@ -91,11 +91,11 @@ syn = { version = "2", features = ["full", "extra-traits"] }
 
 # Testing
 expect-test = "1.5"
-regex = "1.12.2"
+regex = "1.12"
 futures-util = { version = "0.3", features = ["io"] }
 piper = "0.2"
 pretty_assertions = "1"
-rustyline = "17"
+rustyline = "18"
 tokio-test = "0.4"
 
 [workspace.lints.rust]

--- a/src/agent-client-protocol/Cargo.toml
+++ b/src/agent-client-protocol/Cargo.toml
@@ -42,7 +42,6 @@ unstable_session_usage = ["agent-client-protocol-schema/unstable_session_usage"]
 agent-client-protocol-schema.workspace = true
 agent-client-protocol-derive.workspace = true
 anyhow.workspace = true
-boxfnonce.workspace = true
 futures.workspace = true
 futures-concurrency.workspace = true
 rustc-hash.workspace = true

--- a/src/agent-client-protocol/src/jsonrpc.rs
+++ b/src/agent-client-protocol/src/jsonrpc.rs
@@ -1921,17 +1921,15 @@ impl Responder<serde_json::Value> {
         Self {
             method,
             id,
-            send_fn: Box::new(
-                move |response: Result<serde_json::Value, crate::Error>| {
-                    send_raw_message(
-                        &message_tx,
-                        OutgoingMessage::Response {
-                            id: id_clone,
-                            response,
-                        },
-                    )
-                },
-            ),
+            send_fn: Box::new(move |response: Result<serde_json::Value, crate::Error>| {
+                send_raw_message(
+                    &message_tx,
+                    OutgoingMessage::Response {
+                        id: id_clone,
+                        response,
+                    },
+                )
+            }),
         }
     }
 
@@ -2069,18 +2067,16 @@ impl ResponseRouter<serde_json::Value> {
             method,
             id,
             role_id,
-            send_fn: Box::new(
-                move |response: Result<serde_json::Value, crate::Error>| {
-                    sender
-                        .send(ResponsePayload {
-                            result: response,
-                            ack_tx: None,
-                        })
-                        .map_err(|_| {
-                            crate::util::internal_error("failed to send response, receiver dropped")
-                        })
-                },
-            ),
+            send_fn: Box::new(move |response: Result<serde_json::Value, crate::Error>| {
+                sender
+                    .send(ResponsePayload {
+                        result: response,
+                        ack_tx: None,
+                    })
+                    .map_err(|_| {
+                        crate::util::internal_error("failed to send response, receiver dropped")
+                    })
+            }),
         }
     }
 

--- a/src/agent-client-protocol/src/jsonrpc.rs
+++ b/src/agent-client-protocol/src/jsonrpc.rs
@@ -11,7 +11,6 @@ use std::panic::Location;
 use std::pin::pin;
 use uuid::Uuid;
 
-use boxfnonce::SendBoxFnOnce;
 use futures::channel::{mpsc, oneshot};
 use futures::future::{self, BoxFuture, Either};
 use futures::{AsyncRead, AsyncWrite, StreamExt};
@@ -1900,7 +1899,7 @@ pub struct Responder<T: JsonRpcResponse = serde_json::Value> {
     ///
     /// For incoming requests: serializes to JSON and sends over the wire.
     /// For incoming responses: sends to the waiting oneshot channel.
-    send_fn: SendBoxFnOnce<'static, (Result<T, crate::Error>,), Result<(), crate::Error>>,
+    send_fn: Box<dyn FnOnce(Result<T, crate::Error>) -> Result<(), crate::Error> + Send>,
 }
 
 impl<T: JsonRpcResponse> std::fmt::Debug for Responder<T> {
@@ -1922,7 +1921,7 @@ impl Responder<serde_json::Value> {
         Self {
             method,
             id,
-            send_fn: SendBoxFnOnce::new(
+            send_fn: Box::new(
                 move |response: Result<serde_json::Value, crate::Error>| {
                     send_raw_message(
                         &message_tx,
@@ -1988,9 +1987,9 @@ impl<T: JsonRpcResponse> Responder<T> {
         Responder {
             method: self.method,
             id: self.id,
-            send_fn: SendBoxFnOnce::new(move |input: Result<U, crate::Error>| {
+            send_fn: Box::new(move |input: Result<U, crate::Error>| {
                 let t_value = wrap_fn(&method, input);
-                self.send_fn.call(t_value)
+                (self.send_fn)(t_value)
             }),
         }
     }
@@ -2001,7 +2000,7 @@ impl<T: JsonRpcResponse> Responder<T> {
         response: Result<T, crate::Error>,
     ) -> Result<(), crate::Error> {
         tracing::debug!(id = ?self.id, "respond called");
-        self.send_fn.call(response)
+        (self.send_fn)(response)
     }
 
     /// Respond to the JSON-RPC request with a value.
@@ -2042,7 +2041,7 @@ pub struct ResponseRouter<T: JsonRpcResponse = serde_json::Value> {
     role_id: RoleId,
 
     /// Function to send the response to the waiting task.
-    send_fn: SendBoxFnOnce<'static, (Result<T, crate::Error>,), Result<(), crate::Error>>,
+    send_fn: Box<dyn FnOnce(Result<T, crate::Error>) -> Result<(), crate::Error> + Send>,
 }
 
 impl<T: JsonRpcResponse> std::fmt::Debug for ResponseRouter<T> {
@@ -2070,7 +2069,7 @@ impl ResponseRouter<serde_json::Value> {
             method,
             id,
             role_id,
-            send_fn: SendBoxFnOnce::new(
+            send_fn: Box::new(
                 move |response: Result<serde_json::Value, crate::Error>| {
                     sender
                         .send(ResponsePayload {
@@ -2137,9 +2136,9 @@ impl<T: JsonRpcResponse> ResponseRouter<T> {
             method: self.method,
             id: self.id,
             role_id: self.role_id,
-            send_fn: SendBoxFnOnce::new(move |input: Result<U, crate::Error>| {
+            send_fn: Box::new(move |input: Result<U, crate::Error>| {
                 let t_value = wrap_fn(&method, input);
-                self.send_fn.call(t_value)
+                (self.send_fn)(t_value)
             }),
         }
     }
@@ -2150,7 +2149,7 @@ impl<T: JsonRpcResponse> ResponseRouter<T> {
         response: Result<T, crate::Error>,
     ) -> Result<(), crate::Error> {
         tracing::debug!(id = ?self.id, "response routed to awaiter");
-        self.send_fn.call(response)
+        (self.send_fn)(response)
     }
 
     /// Complete the response by sending a value to the waiting task.

--- a/src/agent-client-protocol/src/session.rs
+++ b/src/agent-client-protocol/src/session.rs
@@ -565,11 +565,7 @@ where
                 PromptRequest::new(self.session_id.clone(), vec![prompt.to_string().into()]),
             )
             .on_receiving_result(async move |result| {
-                let PromptResponse {
-                    stop_reason,
-                    meta: _,
-                    ..
-                } = result?;
+                let PromptResponse { stop_reason, .. } = result?;
 
                 update_tx
                     .unbounded_send(SessionMessage::StopReason(stop_reason))
@@ -602,7 +598,6 @@ where
                     .if_notification(async |notif: SessionNotification| match notif.update {
                         SessionUpdate::AgentMessageChunk(ContentChunk {
                             content: ContentBlock::Text(text),
-                            meta: _,
                             ..
                         }) => {
                             output.push_str(&text.text);


### PR DESCRIPTION
## Summary

- Remove the `boxfnonce` crate from workspace and `agent-client-protocol` dependencies
- Replace `SendBoxFnOnce` with `Box<dyn FnOnce(...) -> ... + Send>` in `Responder` and `ResponseRouter`
- `boxfnonce` has been superseded by stable Rust since 1.35.0

## Test Runs

- [x] `cargo check -p agent-client-protocol` passes
- [x] `cargo test --features agent-client-protocol/unstable_auth_methods,agent-client-protocol/unstable_logout` passes
- [x] `cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings` passes