### PR TITLE
feat(unstable): add elicitation support to unstable feature

### DIFF
--- a/src/agent-client-protocol/Cargo.toml
+++ b/src/agent-client-protocol/Cargo.toml
@@ -18,6 +18,7 @@ default = []
 unstable = [
     "unstable_auth_methods",
     "unstable_boolean_config",
+    "unstable_elicitation",
     "unstable_logout",
     "unstable_message_id",
     "unstable_session_additional_directories",
@@ -27,6 +28,7 @@ unstable = [
 ]
 unstable_auth_methods = ["agent-client-protocol-schema/unstable_auth_methods"]
 unstable_boolean_config = ["agent-client-protocol-schema/unstable_boolean_config"]
+unstable_elicitation = ["agent-client-protocol-schema/unstable_elicitation"]
 unstable_logout = ["agent-client-protocol-schema/unstable_logout"]
 unstable_message_id = ["agent-client-protocol-schema/unstable_message_id"]
 unstable_session_additional_directories = ["agent-client-protocol-schema/unstable_session_additional_directories"]


### PR DESCRIPTION
This is needed in codex-acp for device code auth.

I think this was possibly just an accidental omission from the `unstable` feature?