### PR TITLE
chore(deps): bump ACP schema to 1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,12 +138,13 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "1.1.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac542aba230234b1591ace7286a47c0514fe3efc3037d43296bde31ba7ee5728"
+checksum = "06679e1542356341f4550ccfb16338b64f37f6af70de2105446ef6fbb078234c"
 dependencies = [
  "anyhow",
  "derive_more",
+ "diffy",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -793,6 +794,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "diffy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05264ab2aab4fb952fc4b0f3f6eff1ddfb4563064053a4ea174d91537584a769"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,6 +916,12 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1095,6 +1111,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "heck"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ agent-client-protocol-trace-viewer = { path = "src/agent-client-protocol-trace-v
 yopo = { package = "agent-client-protocol-yopo", path = "src/yopo" }
 
 # Protocol
-agent-client-protocol-schema = { version = "=1.1.0", features = ["tracing"] }
+agent-client-protocol-schema = { version = "=1.4.0", features = ["tracing"] }
 
 # Core async runtime
 tokio = { version = "1.52", default-features = false }

--- a/md/testy.md
+++ b/md/testy.md
@@ -58,5 +58,5 @@ available commands, mode/config/session info, and usage.
 
 With default features, `elicitations`, `callbacks`, and `full` cover `elicitation/create` form mode,
 URL mode, session scope, request scope, accept, decline, cancel, and `elicitation/complete`.
-If the client advertises form elicitation but not URL elicitation, the URL part returns a
-`UrlElicitationRequired` prompt error with deterministic error data.
+If the client advertises form elicitation but not URL elicitation, the URL portion is skipped and
+the scenario completes normally with a skipped-unsupported report.

--- a/src/agent-client-protocol-conductor/tests/initialization_sequence.rs
+++ b/src/agent-client-protocol-conductor/tests/initialization_sequence.rs
@@ -152,10 +152,9 @@ async fn test_single_component_gets_initialize_request() -> Result<(), agent_cli
     // Single component (agent) should receive InitializeRequest - we use ElizaAgent
     // which properly handles InitializeRequest
     run_test_with_components(vec![], async |connection_to_editor| {
-        let init_response = recv(
-            connection_to_editor.send_request(InitializeRequest::new(ProtocolVersion::LATEST)),
-        )
-        .await;
+        let init_response =
+            recv(connection_to_editor.send_request(InitializeRequest::new(ProtocolVersion::V1)))
+                .await;
 
         assert!(
             init_response.is_ok(),
@@ -180,7 +179,7 @@ async fn test_two_components_proxy_gets_initialize_proxy()
         vec![InitComponent::new(&component1)],
         async |connection_to_editor| {
             let init_response = recv(
-                connection_to_editor.send_request(InitializeRequest::new(ProtocolVersion::LATEST)),
+                connection_to_editor.send_request(InitializeRequest::new(ProtocolVersion::V1)),
             )
             .await;
 
@@ -221,7 +220,7 @@ async fn test_three_components_all_proxies_get_initialize_proxy()
         ],
         async |connection_to_editor| {
             let init_response = recv(
-                connection_to_editor.send_request(InitializeRequest::new(ProtocolVersion::LATEST)),
+                connection_to_editor.send_request(InitializeRequest::new(ProtocolVersion::V1)),
             )
             .await;
 
@@ -323,7 +322,7 @@ async fn test_conductor_rejects_initialize_proxy_forwarded_to_agent()
         DynConnectTo::new(Testy::new()),
         async |connection_to_editor| {
             let init_response = recv(
-                connection_to_editor.send_request(InitializeRequest::new(ProtocolVersion::LATEST)),
+                connection_to_editor.send_request(InitializeRequest::new(ProtocolVersion::V1)),
             )
             .await;
 
@@ -365,7 +364,7 @@ async fn test_conductor_rejects_initialize_proxy_forwarded_to_proxy()
         DynConnectTo::new(Testy::new()), // Agent
         async |connection_to_editor| {
             let init_response = recv(
-                connection_to_editor.send_request(InitializeRequest::new(ProtocolVersion::LATEST)),
+                connection_to_editor.send_request(InitializeRequest::new(ProtocolVersion::V1)),
             )
             .await;
 

--- a/src/agent-client-protocol-conductor/tests/mcp-integration.rs
+++ b/src/agent-client-protocol-conductor/tests/mcp-integration.rs
@@ -80,7 +80,7 @@ async fn test_proxy_provides_mcp_tools_stdio() -> Result<(), agent_client_protoc
         async |connection_to_editor| {
             // Send initialization request
             let init_response = recv(
-                connection_to_editor.send_request(InitializeRequest::new(ProtocolVersion::LATEST)),
+                connection_to_editor.send_request(InitializeRequest::new(ProtocolVersion::V1)),
             )
             .await;
 
@@ -123,7 +123,7 @@ async fn test_proxy_provides_mcp_tools_http() -> Result<(), agent_client_protoco
         async |connection_to_editor| {
             // Send initialization request
             let init_response = recv(
-                connection_to_editor.send_request(InitializeRequest::new(ProtocolVersion::LATEST)),
+                connection_to_editor.send_request(InitializeRequest::new(ProtocolVersion::V1)),
             )
             .await;
 
@@ -214,8 +214,7 @@ async fn test_agent_handles_prompt() -> Result<(), agent_client_protocol::Error>
             async |connection_to_editor| {
                 // Initialize
                 recv(
-                    connection_to_editor
-                        .send_request(InitializeRequest::new(ProtocolVersion::LATEST)),
+                    connection_to_editor.send_request(InitializeRequest::new(ProtocolVersion::V1)),
                 )
                 .await?;
 

--- a/src/agent-client-protocol-conductor/tests/mcp_server_handler_chain.rs
+++ b/src/agent-client-protocol-conductor/tests/mcp_server_handler_chain.rs
@@ -199,10 +199,9 @@ async fn test_new_session_handler_invoked_with_mcp_server()
 
     run_test(vec![proxy], agent, async |connection_to_editor| {
         // Initialize first
-        let _init_response = recv(
-            connection_to_editor.send_request(InitializeRequest::new(ProtocolVersion::LATEST)),
-        )
-        .await?;
+        let _init_response =
+            recv(connection_to_editor.send_request(InitializeRequest::new(ProtocolVersion::V1)))
+                .await?;
 
         // Create a new session - this should trigger the handler in the proxy
         let session_response =

--- a/src/agent-client-protocol-conductor/tests/meta_propagation.rs
+++ b/src/agent-client-protocol-conductor/tests/meta_propagation.rs
@@ -170,7 +170,7 @@ async fn conductor_proxy_chain_preserves_prompt_meta() -> Result<(), agent_clien
     run_with_conductor(
         ProxiesAndAgent::new(agent).proxy(PassthroughProxy),
         async |connection| {
-            recv(connection.send_request(InitializeRequest::new(ProtocolVersion::LATEST))).await?;
+            recv(connection.send_request(InitializeRequest::new(ProtocolVersion::V1))).await?;
 
             let session = recv(connection.send_request(NewSessionRequest::new("/"))).await?;
             recv(

--- a/src/agent-client-protocol-conductor/tests/scoped_mcp_server.rs
+++ b/src/agent-client-protocol-conductor/tests/scoped_mcp_server.rs
@@ -62,7 +62,7 @@ async fn test_scoped_mcp_server_through_session() -> Result<(), agent_client_pro
             async |cx| {
                 // Initialize first
                 cx.send_request(agent_client_protocol::schema::v1::InitializeRequest::new(
-                    agent_client_protocol::schema::ProtocolVersion::LATEST,
+                    agent_client_protocol::schema::ProtocolVersion::V1,
                 ))
                 .block_task()
                 .await?;

--- a/src/agent-client-protocol-conductor/tests/trace_client_mcp_server.rs
+++ b/src/agent-client-protocol-conductor/tests/trace_client_mcp_server.rs
@@ -253,7 +253,7 @@ async fn test_trace_client_mcp_server() -> Result<(), agent_client_protocol::Err
                 ),
                 async |cx| {
                     // Initialize
-                    cx.send_request(InitializeRequest::new(ProtocolVersion::LATEST))
+                    cx.send_request(InitializeRequest::new(ProtocolVersion::V1))
                         .block_task()
                         .await?;
 

--- a/src/agent-client-protocol-conductor/tests/trace_mcp_tool_call.rs
+++ b/src/agent-client-protocol-conductor/tests/trace_mcp_tool_call.rs
@@ -252,7 +252,7 @@ async fn test_trace_mcp_tool_call() -> Result<(), agent_client_protocol::Error> 
                 ),
                 async |cx| {
                     // Initialize
-                    recv(cx.send_request(InitializeRequest::new(ProtocolVersion::LATEST))).await?;
+                    recv(cx.send_request(InitializeRequest::new(ProtocolVersion::V1))).await?;
 
                     // Create session
                     let session = recv(

--- a/src/agent-client-protocol-test/CHANGELOG.md
+++ b/src/agent-client-protocol-test/CHANGELOG.md
@@ -8,4 +8,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Expand the `testy` binary into a deterministic ACP test agent that can exercise stable v1 agent methods, notifications, session updates, and client callbacks.
-- Add default `testy` coverage through the `unstable` cargo feature for elicitation form/URL requests, session/request scopes, response actions, completion notifications, URL-required prompt errors, and a direct `elicitations` prompt trigger.
+- Add default `testy` coverage through the `unstable` cargo feature for elicitation form/URL requests, session/request scopes, response actions, completion notifications, unsupported URL-mode skips, and a direct `elicitations` prompt trigger.

--- a/src/agent-client-protocol-test/src/testy.rs
+++ b/src/agent-client-protocol-test/src/testy.rs
@@ -30,8 +30,8 @@ use agent_client_protocol::schema::v1::{
 use agent_client_protocol::schema::v1::{
     CompleteElicitationNotification, CreateElicitationRequest, ElicitationAction,
     ElicitationCapabilities, ElicitationFormMode, ElicitationRequestScope, ElicitationSchema,
-    ElicitationSessionScope, ElicitationUrlMode, ErrorCode, MultiSelectPropertySchema, RequestId,
-    StringPropertySchema, UrlElicitationRequiredData, UrlElicitationRequiredItem,
+    ElicitationSessionScope, ElicitationUrlMode, MultiSelectPropertySchema, RequestId,
+    StringPropertySchema,
 };
 use agent_client_protocol::{
     Agent, Client, ConnectTo, ConnectionTo, JsonRpcRequest, Responder, SentRequest,
@@ -636,10 +636,6 @@ impl Testy {
             Ok(response) => response,
             Err(error) => {
                 self.finish_prompt(&session_id, StopReason::EndTurn);
-                #[cfg(feature = "unstable")]
-                if error.code == ErrorCode::UrlElicitationRequired {
-                    return responder.respond_with_error(error);
-                }
                 return Err(error);
             }
         };
@@ -1188,7 +1184,9 @@ impl Testy {
         }
 
         if !self.client_supports_url_elicitation() {
-            return Err(url_elicitation_required_error());
+            report.push("elicitation/url: skipped unsupported".to_string());
+            report.push("elicitations: completed".to_string());
+            return Ok(());
         }
 
         let session_url_id = "testy-url-session";
@@ -1760,19 +1758,6 @@ fn elicitation_cancelled(agent: &Testy, session_id: &SessionId, report: &mut Vec
         true
     } else {
         false
-    }
-}
-
-#[cfg(feature = "unstable")]
-fn url_elicitation_required_error() -> agent_client_protocol::Error {
-    let data = UrlElicitationRequiredData::new(vec![UrlElicitationRequiredItem::new(
-        "testy-url-required",
-        "https://example.com/testy/required",
-        "Complete the Testy URL elicitation before continuing",
-    )]);
-    match serde_json::to_value(data) {
-        Ok(data) => agent_client_protocol::Error::url_elicitation_required().data(data),
-        Err(error) => agent_client_protocol::Error::into_internal_error(error),
     }
 }
 

--- a/src/agent-client-protocol-test/tests/testy.rs
+++ b/src/agent-client-protocol-test/tests/testy.rs
@@ -12,7 +12,6 @@ use agent_client_protocol::schema::v1::{
     CompleteElicitationNotification, CreateElicitationRequest, CreateElicitationResponse,
     ElicitationAcceptAction, ElicitationAction, ElicitationCapabilities, ElicitationContentValue,
     ElicitationFormCapabilities, ElicitationMode, ElicitationScope, ElicitationUrlCapabilities,
-    ErrorCode, UrlElicitationRequiredData,
 };
 use agent_client_protocol::{
     Client, Responder,
@@ -1840,12 +1839,29 @@ async fn testy_elicitations_prompt_exercises_all_elicitation_create_and_complete
 
 #[cfg(feature = "unstable")]
 #[tokio::test]
-async fn testy_callbacks_with_unstable_feature_returns_url_required_when_url_elicitation_is_unsupported()
+async fn testy_callbacks_with_unstable_feature_skips_url_elicitation_when_unsupported()
 -> Result<(), agent_client_protocol::Error> {
     let requests = Arc::new(Mutex::new(Vec::<&'static str>::new()));
+    let agent_messages = Arc::new(Mutex::new(Vec::<String>::new()));
 
     Client
         .builder()
+        .on_receive_notification(
+            {
+                let agent_messages = Arc::clone(&agent_messages);
+                async move |notification: SessionNotification, _cx| {
+                    let SessionUpdate::AgentMessageChunk(chunk) = notification.update else {
+                        return Ok(());
+                    };
+                    let ContentBlock::Text(text) = chunk.content else {
+                        return Ok(());
+                    };
+                    agent_messages.lock().unwrap().push(text.text);
+                    Ok(())
+                }
+            },
+            agent_client_protocol::on_receive_notification!(),
+        )
         .on_receive_request(
             async move |request: RequestPermissionRequest, responder, _cx| {
                 let option_id = request.options.first().map_or_else(
@@ -1925,7 +1941,7 @@ async fn testy_callbacks_with_unstable_feature_returns_url_required_when_url_eli
                         ),
                         "form_session_decline" => ElicitationAction::Decline,
                         "form_request_cancel" => ElicitationAction::Cancel,
-                        other => panic!("unexpected elicitation request before URL error: {other}"),
+                        other => panic!("unexpected elicitation request: {other}"),
                     };
                     responder.respond(CreateElicitationResponse::new(action))
                 }
@@ -1944,7 +1960,7 @@ async fn testy_callbacks_with_unstable_feature_returns_url_required_when_url_eli
                 .block_task()
                 .await?;
 
-            let error = cx
+            let response = cx
                 .send_request(PromptRequest::new(
                     session.session_id,
                     vec![
@@ -1956,21 +1972,8 @@ async fn testy_callbacks_with_unstable_feature_returns_url_required_when_url_eli
                     ],
                 ))
                 .block_task()
-                .await
-                .expect_err("url-required elicitation scenario should fail the prompt request");
-            assert_eq!(error.code, ErrorCode::UrlElicitationRequired);
-
-            let data: UrlElicitationRequiredData =
-                serde_json::from_value(error.data.expect("url-required error should include data"))
-                    .expect("url-required error data should deserialize");
-            assert_eq!(data.elicitations.len(), 1);
-            let elicitation = &data.elicitations[0];
-            assert_eq!(elicitation.elicitation_id.to_string(), "testy-url-required");
-            assert_eq!(elicitation.url, "https://example.com/testy/required");
-            assert_eq!(
-                elicitation.message,
-                "Complete the Testy URL elicitation before continuing"
-            );
+                .await?;
+            assert_eq!(response.stop_reason, StopReason::EndTurn);
             Ok(())
         })
         .await?;
@@ -1983,6 +1986,10 @@ async fn testy_callbacks_with_unstable_feature_returns_url_required_when_url_eli
             "form_request_cancel",
         ]
     );
+
+    let messages = agent_messages.lock().unwrap().join("\n");
+    assert!(messages.contains("elicitation/url: skipped unsupported"));
+    assert!(messages.contains("elicitations: completed"));
 
     Ok(())
 }

--- a/src/agent-client-protocol/Cargo.toml
+++ b/src/agent-client-protocol/Cargo.toml
@@ -29,8 +29,9 @@ unstable = [
     "unstable_session_fork",
 ]
 unstable_auth_methods = ["agent-client-protocol-schema/unstable_auth_methods"]
-unstable_boolean_config = ["agent-client-protocol-schema/unstable_boolean_config"]
-unstable_cancel_request = ["agent-client-protocol-schema/unstable_cancel_request"]
+# Kept as compatibility aliases for schema features that stabilized before schema 1.4.0.
+unstable_boolean_config = []
+unstable_cancel_request = []
 unstable_elicitation = ["agent-client-protocol-schema/unstable_elicitation"]
 unstable_end_turn_token_usage = ["agent-client-protocol-schema/unstable_end_turn_token_usage"]
 unstable_mcp_over_acp = ["agent-client-protocol-schema/unstable_mcp_over_acp"]

--- a/src/agent-client-protocol/src/capabilities.rs
+++ b/src/agent-client-protocol/src/capabilities.rs
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn test_add_capability_to_request() {
-        let request = InitializeRequest::new(ProtocolVersion::LATEST);
+        let request = InitializeRequest::new(ProtocolVersion::V1);
 
         let request = request.add_meta_capability(TestCapability);
 
@@ -165,8 +165,8 @@ mod tests {
         );
         let client_capabilities = ClientCapabilities::new().meta(meta);
 
-        let request = InitializeRequest::new(ProtocolVersion::LATEST)
-            .client_capabilities(client_capabilities);
+        let request =
+            InitializeRequest::new(ProtocolVersion::V1).client_capabilities(client_capabilities);
 
         let request = request.remove_meta_capability(TestCapability);
 
@@ -175,7 +175,7 @@ mod tests {
 
     #[test]
     fn test_add_capability_to_response() {
-        let response = InitializeResponse::new(ProtocolVersion::LATEST);
+        let response = InitializeResponse::new(ProtocolVersion::V1);
 
         let response = response.add_meta_capability(TestCapability);
 
@@ -198,8 +198,8 @@ mod tests {
         );
         let client_capabilities = ClientCapabilities::new().meta(meta);
 
-        let request = InitializeRequest::new(ProtocolVersion::LATEST)
-            .client_capabilities(client_capabilities);
+        let request =
+            InitializeRequest::new(ProtocolVersion::V1).client_capabilities(client_capabilities);
 
         assert!(!request.has_meta_capability(TestCapability));
     }
@@ -216,8 +216,8 @@ mod tests {
         );
         let client_capabilities = ClientCapabilities::new().meta(meta);
 
-        let request = InitializeRequest::new(ProtocolVersion::LATEST)
-            .client_capabilities(client_capabilities);
+        let request =
+            InitializeRequest::new(ProtocolVersion::V1).client_capabilities(client_capabilities);
 
         assert!(!request.has_meta_capability(TestCapability));
     }

--- a/src/agent-client-protocol/src/jsonrpc/protocol_compat.rs
+++ b/src/agent-client-protocol/src/jsonrpc/protocol_compat.rs
@@ -728,6 +728,10 @@ mod imp {
                 .negotiated
         }
 
+        fn v2_test_implementation(name: &str) -> v2::Implementation {
+            v2::Implementation::new(name, "0.0.0")
+        }
+
         #[test]
         fn initialize_request_sets_active_wire_version_before_response() -> Result<(), crate::Error>
         {
@@ -736,7 +740,10 @@ mod imp {
 
             compat.incoming_message(UntypedMessage::new(
                 "initialize",
-                v2::InitializeRequest::new(ProtocolVersion::V2),
+                v2::InitializeRequest::new(
+                    ProtocolVersion::V2,
+                    v2_test_implementation("test-client"),
+                ),
             )?)?;
 
             assert_eq!(negotiated(&compat), ProtocolVersionKind::V1);
@@ -746,6 +753,7 @@ mod imp {
                 "initialize",
                 Ok(serde_json::to_value(v2::InitializeResponse::new(
                     ProtocolVersion::V2,
+                    v2_test_implementation("test-agent"),
                 ))?),
             )?;
 
@@ -762,7 +770,10 @@ mod imp {
 
             compat.outgoing_message(UntypedMessage::new(
                 "initialize",
-                v2::InitializeRequest::new(ProtocolVersion::V1),
+                v2::InitializeRequest::new(
+                    ProtocolVersion::V1,
+                    v2_test_implementation("test-client"),
+                ),
             )?)?;
 
             assert_eq!(negotiated(&compat), ProtocolVersionKind::V1);
@@ -772,6 +783,7 @@ mod imp {
                 "initialize",
                 Ok(serde_json::to_value(v2::InitializeResponse::new(
                     ProtocolVersion::V2,
+                    v2_test_implementation("test-agent"),
                 ))?),
             )?;
 
@@ -788,7 +800,10 @@ mod imp {
 
             compat.outgoing_message(UntypedMessage::new(
                 "initialize",
-                v2::InitializeRequest::new(ProtocolVersion::V1),
+                v2::InitializeRequest::new(
+                    ProtocolVersion::V1,
+                    v2_test_implementation("test-client"),
+                ),
             )?)?;
 
             assert_eq!(negotiated(&compat), ProtocolVersionKind::V1);
@@ -814,7 +829,10 @@ mod imp {
                 let compat = ProtocolCompat::new(ProtocolMode::v2_client());
                 compat.outgoing_message(UntypedMessage::new(
                     "initialize",
-                    v2::InitializeRequest::new(ProtocolVersion::V1),
+                    v2::InitializeRequest::new(
+                        ProtocolVersion::V1,
+                        v2_test_implementation("test-client"),
+                    ),
                 )?)?;
 
                 let error = compat
@@ -838,7 +856,7 @@ mod imp {
             let compat = ProtocolCompat::new(ProtocolMode::v2_agent());
             let messages = compat.outgoing_notification(UntypedMessage::new(
                 "session/update",
-                v2::SessionNotification::new(
+                v2::UpdateSessionNotification::new(
                     "sess",
                     v2::SessionUpdate::AgentMessage(v2::AgentMessage::new("msg_agent").content(
                         vec![

--- a/src/agent-client-protocol/src/schema/v2_impls.rs
+++ b/src/agent-client-protocol/src/schema/v2_impls.rs
@@ -102,15 +102,15 @@ macro_rules! impl_v2_jsonrpc_request_enum {
                 params: &impl serde::Serialize,
             ) -> Result<Self, crate::Error> {
                 match method {
-                    $( $(#[$meta])* $method => crate::util::json_cast_params(params).map(Self::$variant), )*
+                    $( $(#[$meta])* $method => crate::util::json_cast_params(params).map(|value| Self::$variant(Box::new(value))), )*
                     _ => {
                         if method.starts_with('_') {
                             crate::util::json_cast_params(params).map(
                                 |ext_req: v2::ExtRequest| {
-                                    Self::$ext_variant(v2::ExtRequest::new(
+                                    Self::$ext_variant(Box::new(v2::ExtRequest::new(
                                         method.to_string(),
                                         ext_req.params,
-                                    ))
+                                    )))
                                 },
                             )
                         } else {
@@ -154,15 +154,15 @@ macro_rules! impl_v2_jsonrpc_notification_enum {
                 params: &impl serde::Serialize,
             ) -> Result<Self, crate::Error> {
                 match method {
-                    $( $(#[$meta])* $method => crate::util::json_cast_params(params).map(Self::$variant), )*
+                    $( $(#[$meta])* $method => crate::util::json_cast_params(params).map(|value| Self::$variant(Box::new(value))), )*
                     _ => {
                         if method.starts_with('_') {
                             crate::util::json_cast_params(params).map(
                                 |ext_notif: v2::ExtNotification| {
-                                    Self::$ext_variant(v2::ExtNotification::new(
+                                    Self::$ext_variant(Box::new(v2::ExtNotification::new(
                                         method.to_string(),
                                         ext_notif.params,
-                                    ))
+                                    )))
                                 },
                             )
                         } else {
@@ -195,10 +195,11 @@ macro_rules! impl_v2_jsonrpc_response_enum {
                 value: serde_json::Value,
             ) -> Result<Self, crate::Error> {
                 match method {
-                    $( $(#[$meta])* $method => crate::util::json_cast(value).map(Self::$variant), )*
+                    $( $(#[$meta])* $method => crate::util::json_cast(value).map(|value| Self::$variant(Box::new(value))), )*
                     _ => {
                         if method.starts_with('_') {
-                            crate::util::json_cast(value).map(Self::$ext_variant)
+                            crate::util::json_cast(value)
+                                .map(|value| Self::$ext_variant(Box::new(value)))
                         } else {
                             Err(crate::Error::method_not_found())
                         }
@@ -210,18 +211,9 @@ macro_rules! impl_v2_jsonrpc_response_enum {
 }
 
 impl_v2_jsonrpc_request!(v2::InitializeRequest, v2::InitializeResponse, "initialize");
-impl_v2_jsonrpc_request!(
-    v2::AuthenticateRequest,
-    v2::AuthenticateResponse,
-    "authenticate"
-);
-impl_v2_jsonrpc_request!(v2::LogoutRequest, v2::LogoutResponse, "logout");
+impl_v2_jsonrpc_request!(v2::LoginAuthRequest, v2::LoginAuthResponse, "auth/login");
+impl_v2_jsonrpc_request!(v2::LogoutAuthRequest, v2::LogoutAuthResponse, "auth/logout");
 impl_v2_jsonrpc_request!(v2::NewSessionRequest, v2::NewSessionResponse, "session/new");
-impl_v2_jsonrpc_request!(
-    v2::LoadSessionRequest,
-    v2::LoadSessionResponse,
-    "session/load"
-);
 impl_v2_jsonrpc_request!(
     v2::ListSessionsRequest,
     v2::ListSessionsResponse,
@@ -259,7 +251,7 @@ impl_v2_jsonrpc_request!(v2::MessageMcpRequest, v2::MessageMcpResponse, "mcp/mes
 
 #[cfg(feature = "unstable_cancel_request")]
 impl_v2_jsonrpc_notification!(v2::CancelRequestNotification, "$/cancel_request");
-impl_v2_jsonrpc_notification!(v2::CancelNotification, "session/cancel");
+impl_v2_jsonrpc_notification!(v2::CancelSessionNotification, "session/cancel");
 #[cfg(feature = "unstable_mcp_over_acp")]
 impl_v2_jsonrpc_notification!(v2::MessageMcpNotification, "mcp/message");
 
@@ -283,7 +275,7 @@ impl_v2_jsonrpc_request!(
     "mcp/disconnect"
 );
 
-impl_v2_jsonrpc_notification!(v2::SessionNotification, "session/update");
+impl_v2_jsonrpc_notification!(v2::UpdateSessionNotification, "session/update");
 #[cfg(feature = "unstable_elicitation")]
 impl_v2_jsonrpc_notification!(v2::CompleteElicitationNotification, "elicitation/complete");
 
@@ -294,10 +286,9 @@ impl_jsonrpc_protocol_level_notification_enum!(v2::ProtocolLevelNotification {
 
 impl_v2_jsonrpc_request_enum!(v2::ClientRequest {
     InitializeRequest => "initialize",
-    AuthenticateRequest => "authenticate",
-    LogoutRequest => "logout",
+    LoginAuthRequest => "auth/login",
+    LogoutAuthRequest => "auth/logout",
     NewSessionRequest => "session/new",
-    LoadSessionRequest => "session/load",
     ListSessionsRequest => "session/list",
     DeleteSessionRequest => "session/delete",
     #[cfg(feature = "unstable_session_fork")]
@@ -313,10 +304,9 @@ impl_v2_jsonrpc_request_enum!(v2::ClientRequest {
 
 impl_v2_jsonrpc_response_enum!(v2::AgentResponse {
     InitializeResponse => "initialize",
-    AuthenticateResponse => "authenticate",
-    LogoutResponse => "logout",
+    LoginAuthResponse => "auth/login",
+    LogoutAuthResponse => "auth/logout",
     NewSessionResponse => "session/new",
-    LoadSessionResponse => "session/load",
     ListSessionsResponse => "session/list",
     DeleteSessionResponse => "session/delete",
     #[cfg(feature = "unstable_session_fork")]
@@ -331,7 +321,7 @@ impl_v2_jsonrpc_response_enum!(v2::AgentResponse {
 });
 
 impl_v2_jsonrpc_notification_enum!(v2::ClientNotification {
-    CancelNotification => "session/cancel",
+    CancelSessionNotification => "session/cancel",
     #[cfg(feature = "unstable_mcp_over_acp")]
     MessageMcpNotification => "mcp/message",
     [ext] ExtNotification,
@@ -364,7 +354,7 @@ impl_v2_jsonrpc_response_enum!(v2::ClientResponse {
 });
 
 impl_v2_jsonrpc_notification_enum!(v2::AgentNotification {
-    SessionNotification => "session/update",
+    UpdateSessionNotification => "session/update",
     #[cfg(feature = "unstable_elicitation")]
     CompleteElicitationNotification => "elicitation/complete",
     #[cfg(feature = "unstable_mcp_over_acp")]

--- a/src/agent-client-protocol/tests/protocol_v2.rs
+++ b/src/agent-client-protocol/tests/protocol_v2.rs
@@ -49,10 +49,14 @@ fn cwd() -> Result<PathBuf, Error> {
     std::env::current_dir().map_err(Error::into_internal_error)
 }
 
+fn v2_test_implementation(name: &str) -> v2::Implementation {
+    v2::Implementation::new(name, "0.0.0")
+}
+
 fn v2_initialize_response_with_session(
     protocol_version: ProtocolVersion,
 ) -> v2::InitializeResponse {
-    v2::InitializeResponse::new(protocol_version)
+    v2::InitializeResponse::new(protocol_version, v2_test_implementation("test-agent"))
         .capabilities(v2::AgentCapabilities::new().session(v2::SessionCapabilities::new()))
 }
 
@@ -110,7 +114,10 @@ async fn assert_v2_client_rejected_by_v1_agent(agent: impl ConnectTo<Client>) ->
         .v2()
         .connect_with(agent, async |cx| {
             let error = cx
-                .send_request(v2::InitializeRequest::new(ProtocolVersion::V2))
+                .send_request(v2::InitializeRequest::new(
+                    ProtocolVersion::V2,
+                    v2_test_implementation("test-client"),
+                ))
                 .block_task()
                 .await
                 .expect_err("v1 agent protocol mode should reject v2 clients");
@@ -173,7 +180,10 @@ async fn role_builder_v1_agent_rejects_v2_client_negotiation() -> Result<(), Err
         .v2()
         .connect_with(agent, async |cx| {
             let error = cx
-                .send_request(v2::InitializeRequest::new(ProtocolVersion::V2))
+                .send_request(v2::InitializeRequest::new(
+                    ProtocolVersion::V2,
+                    v2_test_implementation("test-client"),
+                ))
                 .block_task()
                 .await
                 .expect_err("Role::builder should preserve v1 agent protocol mode");
@@ -232,7 +242,10 @@ async fn role_builder_v1_client_downgrades_initialize_for_v2_agent() -> Result<(
     <Client as Role>::builder(Client)
         .connect_with(agent, async |cx| {
             let initialize = cx
-                .send_request(v1::InitializeRequest::new(ProtocolVersion::V2))
+                .send_request(
+                    v1::InitializeRequest::new(ProtocolVersion::V2)
+                        .client_info(v1::Implementation::new("test-client", "0.0.0")),
+                )
                 .block_task()
                 .await?;
             assert_eq!(initialize.protocol_version, ProtocolVersion::V1);
@@ -478,7 +491,10 @@ async fn v2_agent_serves_v1_client_with_v2_handlers() -> Result<(), Error> {
         .builder()
         .connect_with(agent, async |cx| {
             let initialize = cx
-                .send_request(v1::InitializeRequest::new(ProtocolVersion::V1))
+                .send_request(
+                    v1::InitializeRequest::new(ProtocolVersion::V1)
+                        .client_info(v1::Implementation::new("test-client", "0.0.0")),
+                )
                 .block_task()
                 .await?;
             assert_eq!(initialize.protocol_version, ProtocolVersion::V1);
@@ -499,7 +515,10 @@ async fn v2_client_rejects_v1_agent() -> Result<(), Error> {
         .v2()
         .connect_with(Testy::new(), async |cx| {
             let error = cx
-                .send_request(v2::InitializeRequest::new(ProtocolVersion::V1))
+                .send_request(v2::InitializeRequest::new(
+                    ProtocolVersion::V1,
+                    v2_test_implementation("test-client"),
+                ))
                 .block_task()
                 .await
                 .expect_err("v2 clients require a v2 agent");
@@ -524,7 +543,10 @@ async fn v2_client_and_agent_negotiate_v2() -> Result<(), Error> {
         .on_receive_request(
             async |initialize: v2::InitializeRequest, responder, _cx| {
                 assert_eq!(initialize.protocol_version, ProtocolVersion::V2);
-                responder.respond(v2::InitializeResponse::new(initialize.protocol_version))
+                responder.respond(v2::InitializeResponse::new(
+                    initialize.protocol_version,
+                    v2_test_implementation("test-agent"),
+                ))
             },
             agent_client_protocol::on_receive_request!(),
         )
@@ -542,7 +564,10 @@ async fn v2_client_and_agent_negotiate_v2() -> Result<(), Error> {
         .v2()
         .connect_with(agent, async |cx| {
             let initialize = cx
-                .send_request(v2::InitializeRequest::new(ProtocolVersion::V1))
+                .send_request(v2::InitializeRequest::new(
+                    ProtocolVersion::V1,
+                    v2_test_implementation("test-client"),
+                ))
                 .block_task()
                 .await?;
             assert_eq!(initialize.protocol_version, ProtocolVersion::V2);
@@ -596,7 +621,10 @@ async fn v2_client_can_cancel_request_to_v2_agent() -> Result<(), Error> {
         .v2()
         .connect_with(v2_agent_with_cancellable_new_session(), async |cx| {
             let initialize = cx
-                .send_request(v2::InitializeRequest::new(ProtocolVersion::V2))
+                .send_request(v2::InitializeRequest::new(
+                    ProtocolVersion::V2,
+                    v2_test_implementation("test-client"),
+                ))
                 .block_task()
                 .await?;
             assert_eq!(initialize.protocol_version, ProtocolVersion::V2);
@@ -620,7 +648,10 @@ async fn v1_client_can_cancel_request_to_v2_agent() -> Result<(), Error> {
         .builder()
         .connect_with(v2_agent_with_cancellable_new_session(), async |cx| {
             let initialize = cx
-                .send_request(v1::InitializeRequest::new(ProtocolVersion::V1))
+                .send_request(
+                    v1::InitializeRequest::new(ProtocolVersion::V1)
+                        .client_info(v1::Implementation::new("test-client", "0.0.0")),
+                )
                 .block_task()
                 .await?;
             assert_eq!(initialize.protocol_version, ProtocolVersion::V1);

--- a/src/agent-client-protocol/tests/schema_elicitation.rs
+++ b/src/agent-client-protocol/tests/schema_elicitation.rs
@@ -4,8 +4,7 @@ use agent_client_protocol::schema::v1::{
     AgentNotification, AgentRequest, ClientCapabilities, ClientResponse,
     CompleteElicitationNotification, CreateElicitationRequest, CreateElicitationResponse,
     ElicitationAction, ElicitationCapabilities, ElicitationFormCapabilities, ElicitationFormMode,
-    ElicitationSchema, ElicitationSessionScope, ElicitationUrlCapabilities, Error, ErrorCode,
-    UrlElicitationRequiredData, UrlElicitationRequiredItem,
+    ElicitationSchema, ElicitationSessionScope, ElicitationUrlCapabilities, EnumOption, Error,
 };
 use agent_client_protocol::{JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse};
 use serde::Serialize;
@@ -124,24 +123,15 @@ fn client_capabilities_can_declare_elicitation_modes() {
 }
 
 #[test]
-fn url_elicitation_required_error_helper_is_available() {
-    let data = UrlElicitationRequiredData::new(vec![UrlElicitationRequiredItem::new(
-        "elicit_1",
-        "https://example.com/connect",
-        "Connect your account",
-    )]);
-    let error = Error::url_elicitation_required().data(json_value(data).unwrap());
+fn enum_options_can_carry_descriptions() {
+    let option = EnumOption::new("balanced", "Balanced").description("Recommended default");
 
-    assert_eq!(error.code, ErrorCode::UrlElicitationRequired);
     assert_eq!(
-        error.data.unwrap(),
+        json_value(option).unwrap(),
         json!({
-            "elicitations": [{
-                "mode": "url",
-                "elicitationId": "elicit_1",
-                "url": "https://example.com/connect",
-                "message": "Connect your account"
-            }]
+            "const": "balanced",
+            "title": "Balanced",
+            "description": "Recommended default"
         })
     );
 }
@@ -194,8 +184,11 @@ async fn v2_agent_can_elicit_from_v1_client_before_prompt_completion() -> Result
     fn v2_initialize_response_with_session(
         protocol_version: ProtocolVersion,
     ) -> v2::InitializeResponse {
-        v2::InitializeResponse::new(protocol_version)
-            .capabilities(v2::AgentCapabilities::new().session(v2::SessionCapabilities::new()))
+        v2::InitializeResponse::new(
+            protocol_version,
+            v2::Implementation::new("test-agent", "0.0.0"),
+        )
+        .capabilities(v2::AgentCapabilities::new().session(v2::SessionCapabilities::new()))
     }
 
     let agent = Agent
@@ -257,7 +250,10 @@ async fn v2_agent_can_elicit_from_v1_client_before_prompt_completion() -> Result
         )
         .connect_with(agent, async |cx| {
             let initialize = cx
-                .send_request(v1::InitializeRequest::new(ProtocolVersion::V1))
+                .send_request(
+                    v1::InitializeRequest::new(ProtocolVersion::V1)
+                        .client_info(v1::Implementation::new("test-client", "0.0.0")),
+                )
                 .block_task()
                 .await?;
             assert_eq!(initialize.protocol_version, ProtocolVersion::V1);


### PR DESCRIPTION
## Summary
- Bumps the generated ACP schema dependency from 1.1.0 to 1.4.0 so the Rust SDK exposes the latest unstable elicitation option description field.
- Updates v2 JSON-RPC mappings for the schema 1.4.0 generated names and boxed enum payloads.
- Keeps removed schema feature flags as empty compatibility aliases in the SDK feature surface.
- Removes the obsolete URL-required error fallback from Testy coverage; unsupported URL elicitation is now skipped according to client capabilities.
- Adjusts compatibility tests for schema 1.4.0 initialize metadata requirements and adds coverage that enum options serialize descriptions.
