### PR TITLE
fix(unstable-v2): Require matching v2 protocol negotiation

### DIFF
--- a/md/protocol-v2.md
+++ b/md/protocol-v2.md
@@ -70,16 +70,14 @@ The SDK handles the `initialize` negotiation at the JSON-RPC boundary:
 - A v2 client requires a v2 agent. If the agent responds with v1, the
   `initialize` request resolves with an error and the caller must explicitly
   fall back to a v1 client implementation if that is acceptable.
-- A v2 agent responds with v2 when the client supports it, or v1 when the client
-  only supports v1. Agent handlers still receive v2 schema types; the SDK tracks
-  the negotiated wire version separately and adapts supported behavior at the
-  transport boundary.
+- A v2 agent requires a v2 client. If a client initializes with v1, the
+  `initialize` request resolves with an error and the caller must use a v1
+  agent implementation instead.
 - If the agent responds with any other unsupported version, the request resolves
   with an error so the client can close the connection.
-- After initialization, the SDK converts supported messages and responses between
-  the local API version and the negotiated wire version.
+- After initialization, the local API version and negotiated wire version must
+  match. The SDK does not convert traffic between v1 and v2.
 
-That means an agent can be implemented against v2 request and response types
-while still serving v1 clients. The goal is for agent-side v1 compatibility to
-live in the SDK wherever it can be represented as protocol adaptation. Clients
-should opt into v2 separately and should not assume v2 behavior from v1 agents.
+That means v1 and v2 implementations need separate handlers today. A future SDK
+API can route traffic to a registered implementation for the negotiated protocol
+version, but `Agent.v2()` and `Client.v2()` are currently v2-only.

--- a/src/agent-client-protocol/src/jsonrpc/outgoing_actor.rs
+++ b/src/agent-client-protocol/src/jsonrpc/outgoing_actor.rs
@@ -50,7 +50,7 @@ pub(super) async fn outgoing_protocol_actor(
                 {
                     Ok(request) => request,
                     Err(error) => {
-                        tracing::warn!(?id, %method, ?error, "Failed to convert outgoing request");
+                        tracing::warn!(?id, %method, ?error, "Failed to prepare outgoing request");
                         cancellation_disarm.disarm();
                         complete_request_with_error(response_tx, error);
                         continue;
@@ -76,7 +76,7 @@ pub(super) async fn outgoing_protocol_actor(
                     Err(error) => {
                         tracing::warn!(
                             ?error,
-                            "Dropping outgoing notification after conversion failed"
+                            "Dropping outgoing notification after preparation failed"
                         );
                         continue;
                     }
@@ -140,105 +140,5 @@ fn complete_request_with_error(
         .is_err()
     {
         tracing::debug!("Dropped failed outgoing request because receiver was gone");
-    }
-}
-
-#[cfg(all(test, feature = "unstable_protocol_v2"))]
-mod tests {
-    use futures::StreamExt as _;
-    use futures::channel::{mpsc, oneshot};
-
-    use super::*;
-    use crate::Role as _;
-
-    fn malformed_v2_known_method() -> Result<crate::UntypedMessage, crate::Error> {
-        crate::UntypedMessage::new("session/new", serde_json::json!({}))
-    }
-
-    fn malformed_v2_known_notification() -> Result<crate::UntypedMessage, crate::Error> {
-        crate::UntypedMessage::new("session/update", serde_json::json!({}))
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn failed_request_conversion_completes_request_locally() -> Result<(), crate::Error> {
-        let (outgoing_tx, outgoing_rx) = mpsc::unbounded();
-        let (reply_tx, mut reply_rx) = mpsc::unbounded();
-        let (transport_tx, mut transport_rx) = mpsc::unbounded();
-        let (response_tx, response_rx) = oneshot::channel();
-
-        outgoing_tx
-            .unbounded_send(OutgoingMessage::Request {
-                id: RequestId::Number(1),
-                role_id: crate::Agent.role_id(),
-                method: "session/new".into(),
-                untyped: malformed_v2_known_method()?,
-                response_tx,
-                cancellation_disarm: crate::jsonrpc::SentRequestCancellationDisarm::new(),
-            })
-            .map_err(crate::Error::into_internal_error)?;
-        drop(outgoing_tx);
-
-        outgoing_protocol_actor(
-            outgoing_rx,
-            reply_tx,
-            transport_tx,
-            ProtocolCompat::new(crate::jsonrpc::protocol_compat::ProtocolMode::v2_agent()),
-        )
-        .await?;
-
-        let response = response_rx
-            .await
-            .map_err(crate::Error::into_internal_error)?;
-        assert!(
-            response.result.is_err(),
-            "conversion failure should complete the local request"
-        );
-        assert!(response.ack_tx.is_none());
-        assert!(reply_rx.next().await.is_none());
-        assert!(transport_rx.next().await.is_none());
-
-        Ok(())
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn failed_notification_conversion_does_not_stop_actor() -> Result<(), crate::Error> {
-        let (outgoing_tx, outgoing_rx) = mpsc::unbounded();
-        let (reply_tx, _reply_rx) = mpsc::unbounded();
-        let (transport_tx, mut transport_rx) = mpsc::unbounded();
-
-        outgoing_tx
-            .unbounded_send(OutgoingMessage::Notification {
-                untyped: malformed_v2_known_notification()?,
-            })
-            .map_err(crate::Error::into_internal_error)?;
-        outgoing_tx
-            .unbounded_send(OutgoingMessage::Notification {
-                untyped: crate::UntypedMessage::new(
-                    "_local/notify",
-                    serde_json::json!({ "ok": true }),
-                )?,
-            })
-            .map_err(crate::Error::into_internal_error)?;
-        drop(outgoing_tx);
-
-        outgoing_protocol_actor(
-            outgoing_rx,
-            reply_tx,
-            transport_tx,
-            ProtocolCompat::new(crate::jsonrpc::protocol_compat::ProtocolMode::v2_agent()),
-        )
-        .await?;
-
-        let message = transport_rx
-            .next()
-            .await
-            .expect("valid notification should still be sent")?;
-        let RawJsonRpcMessage::Notification(request) = message else {
-            panic!("expected outgoing notification request, got {message:?}");
-        };
-        assert_eq!(&*request.method, "_local/notify");
-        assert!(transport_rx.next().await.is_none());
-
-        Ok(())
     }
 }

--- a/src/agent-client-protocol/src/jsonrpc/protocol_compat.rs
+++ b/src/agent-client-protocol/src/jsonrpc/protocol_compat.rs
@@ -82,17 +82,8 @@ mod imp {
 mod imp {
     use std::sync::{Arc, Mutex};
 
-    use agent_client_protocol_schema::v2::{
-        self,
-        conversion::{IntoV1, IntoV1Many, IntoV2, v1_to_v2, v2_to_v1, v2_to_v1_many},
-    };
-
+    use crate::UntypedMessage;
     use crate::schema::ProtocolVersion;
-    use crate::schema::v1::{
-        AgentNotification, AgentRequest, AgentResponse, ClientNotification, ClientRequest,
-        ClientResponse, ErrorCode,
-    };
-    use crate::{JsonRpcMessage, JsonRpcResponse, UntypedMessage};
 
     #[derive(Clone, Copy, Debug)]
     pub(crate) enum ProtocolMode {
@@ -103,8 +94,6 @@ mod imp {
     #[derive(Clone, Copy, Debug)]
     pub(crate) struct AcpProtocolMode {
         api: ProtocolVersionKind,
-        latest_supported: ProtocolVersionKind,
-        require_latest_response: bool,
     }
 
     impl ProtocolMode {
@@ -115,32 +104,24 @@ mod imp {
         pub(crate) fn v1_agent() -> Self {
             Self::Acp(AcpProtocolMode {
                 api: ProtocolVersionKind::V1,
-                latest_supported: ProtocolVersionKind::V1,
-                require_latest_response: false,
             })
         }
 
         pub(crate) fn v1_client() -> Self {
             Self::Acp(AcpProtocolMode {
                 api: ProtocolVersionKind::V1,
-                latest_supported: ProtocolVersionKind::V1,
-                require_latest_response: true,
             })
         }
 
         pub(crate) fn v2_agent() -> Self {
             Self::Acp(AcpProtocolMode {
                 api: ProtocolVersionKind::V2,
-                latest_supported: ProtocolVersionKind::V2,
-                require_latest_response: false,
             })
         }
 
         pub(crate) fn v2_client() -> Self {
             Self::Acp(AcpProtocolMode {
                 api: ProtocolVersionKind::V2,
-                latest_supported: ProtocolVersionKind::V2,
-                require_latest_response: true,
             })
         }
 
@@ -154,11 +135,7 @@ mod imp {
                         "cannot merge ACP builders with different API protocol versions; \
                          handler chains share a single API surface",
                     );
-                    if this.latest_supported >= other.latest_supported {
-                        Self::Acp(this)
-                    } else {
-                        Self::Acp(other)
-                    }
+                    Self::Acp(this)
                 }
             }
         }
@@ -203,13 +180,16 @@ mod imp {
 
     impl ProtocolCompat {
         pub(crate) fn new(mode: ProtocolMode) -> Self {
+            let mode = match mode {
+                ProtocolMode::Disabled => None,
+                ProtocolMode::Acp(mode) => Some(mode),
+            };
+            let negotiated = mode.map(|mode| mode.api).unwrap_or(ProtocolVersionKind::V1);
+
             Self {
-                mode: match mode {
-                    ProtocolMode::Disabled => None,
-                    ProtocolMode::Acp(mode) => Some(mode),
-                },
+                mode,
                 state: Arc::new(Mutex::new(ProtocolState {
-                    negotiated: ProtocolVersionKind::V1,
+                    negotiated,
                     pending_initialize: None,
                 })),
             }
@@ -227,7 +207,12 @@ mod imp {
                 return self.incoming_initialize_request(mode, message);
             }
 
-            convert_message(message, self.active_wire_version(), mode.api)
+            ensure_matching_protocol_version(
+                message.method(),
+                self.active_wire_version(),
+                mode.api,
+            )?;
+            Ok(message)
         }
 
         pub(crate) fn outgoing_message(
@@ -239,14 +224,15 @@ mod imp {
             };
 
             let wire_version = if message.method() == "initialize" {
-                set_protocol_version(&mut message.params, mode.latest_supported)?;
-                self.set_pending_initialize(mode.latest_supported);
-                mode.latest_supported
+                set_protocol_version(&mut message.params, mode.api)?;
+                self.set_pending_initialize(mode.api);
+                mode.api
             } else {
                 self.active_wire_version()
             };
 
-            convert_message(message, mode.api, wire_version)
+            ensure_matching_protocol_version(message.method(), mode.api, wire_version)?;
+            Ok(message)
         }
 
         pub(crate) fn incoming_notification(
@@ -257,7 +243,12 @@ mod imp {
                 return Ok(vec![message]);
             };
 
-            convert_notification(message, self.active_wire_version(), mode.api)
+            ensure_matching_protocol_version(
+                message.method(),
+                self.active_wire_version(),
+                mode.api,
+            )?;
+            Ok(vec![message])
         }
 
         pub(crate) fn outgoing_notification(
@@ -268,7 +259,12 @@ mod imp {
                 return Ok(vec![message]);
             };
 
-            convert_notification(message, mode.api, self.active_wire_version())
+            ensure_matching_protocol_version(
+                message.method(),
+                mode.api,
+                self.active_wire_version(),
+            )?;
+            Ok(vec![message])
         }
 
         pub(crate) fn incoming_response(
@@ -285,7 +281,8 @@ mod imp {
             }
 
             let value = result?;
-            convert_response(method, value, self.active_wire_version(), mode.api)
+            ensure_matching_protocol_version(method, self.active_wire_version(), mode.api)?;
+            Ok(value)
         }
 
         pub(crate) fn outgoing_response(
@@ -308,11 +305,8 @@ mod imp {
             let mut value = result?;
 
             let wire_version = if method == "initialize" {
-                let negotiated = pending_initialize.unwrap_or_else(|| {
-                    protocol_version_from_value(&value)
-                        .and_then(ProtocolVersionKind::from_protocol_version)
-                        .unwrap_or(mode.latest_supported)
-                });
+                let negotiated = pending_initialize.unwrap_or(mode.api);
+                ensure_matching_protocol_version(method, mode.api, negotiated)?;
                 set_protocol_version(&mut value, negotiated)?;
                 self.set_negotiated(negotiated);
                 negotiated
@@ -320,7 +314,8 @@ mod imp {
                 self.active_wire_version()
             };
 
-            convert_response(method, value, mode.api, wire_version)
+            ensure_matching_protocol_version(method, mode.api, wire_version)?;
+            Ok(value)
         }
 
         fn incoming_initialize_request(
@@ -329,12 +324,13 @@ mod imp {
             mut message: UntypedMessage,
         ) -> Result<UntypedMessage, crate::Error> {
             let requested = required_protocol_version_from_value(message.params())?;
-            let requested_kind = ProtocolVersionKind::from_protocol_version(requested);
-            let wire_version = requested_kind.unwrap_or(mode.latest_supported);
-            let negotiated = self.negotiate(requested);
-            self.set_pending_initialize(negotiated);
+            let requested_kind = ProtocolVersionKind::from_protocol_version(requested)
+                .ok_or_else(|| unsupported_protocol_version(requested, mode.api))?;
+            if requested_kind != mode.api {
+                return Err(unsupported_protocol_version(requested, mode.api));
+            }
 
-            message = convert_message(message, wire_version, mode.api)?;
+            self.set_pending_initialize(mode.api);
             set_protocol_version(&mut message.params, mode.api)?;
             Ok(message)
         }
@@ -347,46 +343,15 @@ mod imp {
             let _pending_initialize = self.take_pending_initialize();
             let mut value = result?;
             let response_version = required_protocol_version_from_value(&value)?;
-            if !self.supports(response_version) {
-                return Err(unsupported_protocol_version(response_version));
-            }
-
             let wire_version = ProtocolVersionKind::from_protocol_version(response_version)
-                .ok_or_else(|| unsupported_protocol_version(response_version))?;
-            if mode.require_latest_response && wire_version != mode.latest_supported {
-                return Err(required_protocol_version(
-                    mode.latest_supported,
-                    wire_version,
-                ));
+                .ok_or_else(|| unsupported_protocol_version(response_version, mode.api))?;
+            if wire_version != mode.api {
+                return Err(required_protocol_version(mode.api, wire_version));
             }
             self.set_negotiated(wire_version);
 
-            value = convert_response("initialize", value, wire_version, mode.api)?;
             set_protocol_version(&mut value, wire_version)?;
             Ok(value)
-        }
-
-        fn supports(&self, version: ProtocolVersion) -> bool {
-            let Some(mode) = self.mode else {
-                return false;
-            };
-
-            version == ProtocolVersion::V1
-                || (mode.latest_supported == ProtocolVersionKind::V2
-                    && version == ProtocolVersion::V2)
-        }
-
-        fn negotiate(&self, requested: ProtocolVersion) -> ProtocolVersionKind {
-            let mode = self
-                .mode
-                .expect("ACP protocol mode should be enabled while negotiating");
-
-            if self.supports(requested) {
-                ProtocolVersionKind::from_protocol_version(requested)
-                    .unwrap_or(mode.latest_supported)
-            } else {
-                mode.latest_supported
-            }
         }
 
         fn active_wire_version(&self) -> ProtocolVersionKind {
@@ -420,10 +385,6 @@ mod imp {
         }
     }
 
-    fn protocol_version_from_value(value: &serde_json::Value) -> Option<ProtocolVersion> {
-        serde_json::from_value(value.get("protocolVersion")?.clone()).ok()
-    }
-
     fn required_protocol_version_from_value(
         value: &serde_json::Value,
     ) -> Result<ProtocolVersion, crate::Error> {
@@ -453,255 +414,29 @@ mod imp {
         Ok(())
     }
 
-    fn convert_message(
-        message: UntypedMessage,
+    fn ensure_matching_protocol_version(
+        method: &str,
         from: ProtocolVersionKind,
         to: ProtocolVersionKind,
-    ) -> Result<UntypedMessage, crate::Error> {
-        if message.method().starts_with('_') || from == to {
-            return Ok(message);
+    ) -> Result<(), crate::Error> {
+        if from == to {
+            return Ok(());
         }
 
-        match (from, to) {
-            (ProtocolVersionKind::V1, ProtocolVersionKind::V2) => public_to_v2_message(message),
-            (ProtocolVersionKind::V2, ProtocolVersionKind::V1) => v2_to_public_message(message),
-            _ => Ok(message),
-        }
+        Err(crate::Error::invalid_request().data(format!(
+            "ACP protocol translation from {} to {} is not supported for `{method}`; register a handler for the negotiated protocol version",
+            from.as_protocol_version(),
+            to.as_protocol_version(),
+        )))
     }
 
-    fn convert_response(
-        method: &str,
-        value: serde_json::Value,
-        from: ProtocolVersionKind,
-        to: ProtocolVersionKind,
-    ) -> Result<serde_json::Value, crate::Error> {
-        if method.starts_with('_') || from == to {
-            return Ok(value);
-        }
-
-        match (from, to) {
-            (ProtocolVersionKind::V1, ProtocolVersionKind::V2) => {
-                public_to_v2_response(method, value)
-            }
-            (ProtocolVersionKind::V2, ProtocolVersionKind::V1) => {
-                v2_to_public_response(method, value)
-            }
-            _ => Ok(value),
-        }
-    }
-
-    fn convert_notification(
-        message: UntypedMessage,
-        from: ProtocolVersionKind,
-        to: ProtocolVersionKind,
-    ) -> Result<Vec<UntypedMessage>, crate::Error> {
-        if message.method().starts_with('_') || from == to {
-            return Ok(vec![message]);
-        }
-
-        match (from, to) {
-            (ProtocolVersionKind::V1, ProtocolVersionKind::V2) => {
-                public_to_v2_notification(message)
-            }
-            (ProtocolVersionKind::V2, ProtocolVersionKind::V1) => {
-                v2_to_public_notification(message)
-            }
-            _ => Ok(vec![message]),
-        }
-    }
-
-    fn public_to_v2_notification(
-        message: UntypedMessage,
-    ) -> Result<Vec<UntypedMessage>, crate::Error> {
-        public_to_v2_message(message).map(|message| vec![message])
-    }
-
-    fn v2_to_public_notification(
-        message: UntypedMessage,
-    ) -> Result<Vec<UntypedMessage>, crate::Error> {
-        let UntypedMessage { method, params } = message;
-
-        if let Some(message) =
-            try_convert_message_to_v1::<v2::ClientNotification>(&method, &params)?
-        {
-            return Ok(vec![message]);
-        }
-        if let Some(messages) =
-            try_convert_message_to_v1_many::<v2::AgentNotification>(&method, &params)?
-        {
-            return Ok(messages);
-        }
-
-        Ok(vec![UntypedMessage { method, params }])
-    }
-
-    fn public_to_v2_message(message: UntypedMessage) -> Result<UntypedMessage, crate::Error> {
-        let UntypedMessage { method, params } = message;
-
-        if let Some(message) = try_convert_message_to_v2::<ClientRequest>(&method, &params)? {
-            return Ok(message);
-        }
-        if let Some(message) = try_convert_message_to_v2::<AgentRequest>(&method, &params)? {
-            return Ok(message);
-        }
-        if let Some(message) = try_convert_message_to_v2::<ClientNotification>(&method, &params)? {
-            return Ok(message);
-        }
-        if let Some(message) = try_convert_message_to_v2::<AgentNotification>(&method, &params)? {
-            return Ok(message);
-        }
-
-        Ok(UntypedMessage { method, params })
-    }
-
-    fn v2_to_public_message(message: UntypedMessage) -> Result<UntypedMessage, crate::Error> {
-        let UntypedMessage { method, params } = message;
-
-        if let Some(message) = try_convert_message_to_v1::<v2::ClientRequest>(&method, &params)? {
-            return Ok(message);
-        }
-        if let Some(message) = try_convert_message_to_v1::<v2::AgentRequest>(&method, &params)? {
-            return Ok(message);
-        }
-        if let Some(message) =
-            try_convert_message_to_v1::<v2::ClientNotification>(&method, &params)?
-        {
-            return Ok(message);
-        }
-        Ok(UntypedMessage { method, params })
-    }
-
-    fn public_to_v2_response(
-        method: &str,
-        value: serde_json::Value,
-    ) -> Result<serde_json::Value, crate::Error> {
-        if let Some(value) = try_convert_response_to_v2::<AgentResponse>(method, &value)? {
-            return Ok(value);
-        }
-        if let Some(value) = try_convert_response_to_v2::<ClientResponse>(method, &value)? {
-            return Ok(value);
-        }
-
-        Ok(value)
-    }
-
-    fn v2_to_public_response(
-        method: &str,
-        value: serde_json::Value,
-    ) -> Result<serde_json::Value, crate::Error> {
-        if let Some(value) = try_convert_response_to_v1::<v2::AgentResponse>(method, &value)? {
-            return Ok(value);
-        }
-        if let Some(value) = try_convert_response_to_v1::<v2::ClientResponse>(method, &value)? {
-            return Ok(value);
-        }
-
-        Ok(value)
-    }
-
-    fn try_convert_message_to_v2<T>(
-        method: &str,
-        params: &serde_json::Value,
-    ) -> Result<Option<UntypedMessage>, crate::Error>
-    where
-        T: JsonRpcMessage + IntoV2,
-        T::Output: JsonRpcMessage,
-    {
-        let Some(message) = try_parse_message::<T>(method, params)? else {
-            return Ok(None);
-        };
-        let wire_message = v1_to_v2(message)?;
-        wire_message.to_untyped_message().map(Some)
-    }
-
-    fn try_convert_message_to_v1<T>(
-        method: &str,
-        params: &serde_json::Value,
-    ) -> Result<Option<UntypedMessage>, crate::Error>
-    where
-        T: JsonRpcMessage + IntoV1,
-        T::Output: JsonRpcMessage,
-    {
-        let Some(message) = try_parse_message::<T>(method, params)? else {
-            return Ok(None);
-        };
-        let public_message = v2_to_v1(message)?;
-        public_message.to_untyped_message().map(Some)
-    }
-
-    fn try_convert_message_to_v1_many<T>(
-        method: &str,
-        params: &serde_json::Value,
-    ) -> Result<Option<Vec<UntypedMessage>>, crate::Error>
-    where
-        T: JsonRpcMessage + IntoV1Many,
-        T::Output: JsonRpcMessage,
-    {
-        let Some(message) = try_parse_message::<T>(method, params)? else {
-            return Ok(None);
-        };
-        v2_to_v1_many(message)?
-            .into_iter()
-            .map(|public_message| public_message.to_untyped_message())
-            .collect::<Result<Vec<_>, _>>()
-            .map(Some)
-    }
-
-    fn try_parse_message<T: JsonRpcMessage>(
-        method: &str,
-        params: &serde_json::Value,
-    ) -> Result<Option<T>, crate::Error> {
-        match T::parse_message(method, params) {
-            Ok(message) => Ok(Some(message)),
-            Err(error) if error.code == ErrorCode::MethodNotFound => Ok(None),
-            Err(error) => Err(error),
-        }
-    }
-
-    fn try_convert_response_to_v2<T>(
-        method: &str,
-        value: &serde_json::Value,
-    ) -> Result<Option<serde_json::Value>, crate::Error>
-    where
-        T: JsonRpcResponse + IntoV2,
-        T::Output: JsonRpcResponse,
-    {
-        let Some(response) = try_parse_response::<T>(method, value)? else {
-            return Ok(None);
-        };
-        let wire_response = v1_to_v2(response)?;
-        wire_response.into_json(method).map(Some)
-    }
-
-    fn try_convert_response_to_v1<T>(
-        method: &str,
-        value: &serde_json::Value,
-    ) -> Result<Option<serde_json::Value>, crate::Error>
-    where
-        T: JsonRpcResponse + IntoV1,
-        T::Output: JsonRpcResponse,
-    {
-        let Some(response) = try_parse_response::<T>(method, value)? else {
-            return Ok(None);
-        };
-        let public_response = v2_to_v1(response)?;
-        public_response.into_json(method).map(Some)
-    }
-
-    fn try_parse_response<T: JsonRpcResponse>(
-        method: &str,
-        value: &serde_json::Value,
-    ) -> Result<Option<T>, crate::Error> {
-        match T::from_value(method, value.clone()) {
-            Ok(response) => Ok(Some(response)),
-            Err(error) if error.code == ErrorCode::MethodNotFound => Ok(None),
-            Err(error) => Err(error),
-        }
-    }
-
-    fn unsupported_protocol_version(version: ProtocolVersion) -> crate::Error {
+    fn unsupported_protocol_version(
+        version: ProtocolVersion,
+        supported: ProtocolVersionKind,
+    ) -> crate::Error {
         crate::Error::invalid_request().data(format!(
-            "unsupported ACP protocol version {version}; this endpoint does not support that version"
+            "unsupported ACP protocol version {version}; this endpoint only supports ACP protocol version {}",
+            supported.as_protocol_version(),
         ))
     }
 
@@ -710,7 +445,7 @@ mod imp {
         negotiated: ProtocolVersionKind,
     ) -> crate::Error {
         crate::Error::invalid_request().data(format!(
-            "required ACP protocol version {} but peer negotiated {}; use a v1 client implementation for v1 agents",
+            "required ACP protocol version {} but peer negotiated {}; use a matching implementation for the negotiated protocol version",
             required.as_protocol_version(),
             negotiated.as_protocol_version(),
         ))
@@ -719,6 +454,7 @@ mod imp {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use agent_client_protocol_schema::v2;
 
         fn negotiated(compat: &ProtocolCompat) -> ProtocolVersionKind {
             compat
@@ -744,14 +480,14 @@ mod imp {
         fn initialize_request_sets_active_wire_version_before_response() -> Result<(), crate::Error>
         {
             let compat = ProtocolCompat::new(ProtocolMode::v2_agent());
-            assert_eq!(compat.active_wire_version(), ProtocolVersionKind::V1);
+            assert_eq!(compat.active_wire_version(), ProtocolVersionKind::V2);
 
             compat.incoming_message(UntypedMessage::new(
                 "initialize",
                 v2_initialize_request(ProtocolVersion::V2),
             )?)?;
 
-            assert_eq!(negotiated(&compat), ProtocolVersionKind::V1);
+            assert_eq!(negotiated(&compat), ProtocolVersionKind::V2);
             assert_eq!(compat.active_wire_version(), ProtocolVersionKind::V2);
 
             compat.outgoing_response(
@@ -770,14 +506,14 @@ mod imp {
         fn outgoing_initialize_sets_active_wire_version_before_response() -> Result<(), crate::Error>
         {
             let compat = ProtocolCompat::new(ProtocolMode::v2_client());
-            assert_eq!(compat.active_wire_version(), ProtocolVersionKind::V1);
+            assert_eq!(compat.active_wire_version(), ProtocolVersionKind::V2);
 
             compat.outgoing_message(UntypedMessage::new(
                 "initialize",
                 v2_initialize_request(ProtocolVersion::V1),
             )?)?;
 
-            assert_eq!(negotiated(&compat), ProtocolVersionKind::V1);
+            assert_eq!(negotiated(&compat), ProtocolVersionKind::V2);
             assert_eq!(compat.active_wire_version(), ProtocolVersionKind::V2);
 
             compat.incoming_response(
@@ -796,14 +532,14 @@ mod imp {
         fn failed_incoming_initialize_response_clears_pending_wire_version()
         -> Result<(), crate::Error> {
             let compat = ProtocolCompat::new(ProtocolMode::v2_client());
-            assert_eq!(compat.active_wire_version(), ProtocolVersionKind::V1);
+            assert_eq!(compat.active_wire_version(), ProtocolVersionKind::V2);
 
             compat.outgoing_message(UntypedMessage::new(
                 "initialize",
                 v2_initialize_request(ProtocolVersion::V1),
             )?)?;
 
-            assert_eq!(negotiated(&compat), ProtocolVersionKind::V1);
+            assert_eq!(negotiated(&compat), ProtocolVersionKind::V2);
             assert_eq!(compat.active_wire_version(), ProtocolVersionKind::V2);
 
             let result = compat.incoming_response(
@@ -812,8 +548,8 @@ mod imp {
             );
 
             assert!(result.is_err());
-            assert_eq!(negotiated(&compat), ProtocolVersionKind::V1);
-            assert_eq!(compat.active_wire_version(), ProtocolVersionKind::V1);
+            assert_eq!(negotiated(&compat), ProtocolVersionKind::V2);
+            assert_eq!(compat.active_wire_version(), ProtocolVersionKind::V2);
             Ok(())
         }
 
@@ -838,64 +574,34 @@ mod imp {
                     .and_then(|data| data.as_str())
                     .unwrap_or_default();
                 assert!(data.contains("protocolVersion"), "{error:?}");
-                assert_eq!(negotiated(&compat), ProtocolVersionKind::V1);
-                assert_eq!(compat.active_wire_version(), ProtocolVersionKind::V1);
+                assert_eq!(negotiated(&compat), ProtocolVersionKind::V2);
+                assert_eq!(compat.active_wire_version(), ProtocolVersionKind::V2);
             }
 
             Ok(())
         }
 
         #[test]
-        fn outgoing_v2_agent_notification_fans_out_for_v1_wire() -> Result<(), crate::Error> {
+        fn incoming_initialize_request_rejects_unsupported_protocol_version()
+        -> Result<(), crate::Error> {
             let compat = ProtocolCompat::new(ProtocolMode::v2_agent());
-            let messages = compat.outgoing_notification(UntypedMessage::new(
-                "session/update",
-                v2::UpdateSessionNotification::new(
-                    "sess",
-                    v2::SessionUpdate::AgentMessage(v2::AgentMessage::new("msg_agent").content(
-                        vec![
-                            v2::ContentBlock::Text(v2::TextContent::new("hello")),
-                            v2::ContentBlock::Text(v2::TextContent::new("world")),
-                        ],
-                    )),
-                ),
-            )?)?;
-
-            assert_eq!(messages.len(), 2);
-            let json = messages
-                .into_iter()
-                .map(|message| {
-                    assert_eq!(message.method(), "session/update");
-                    Ok(message.params)
-                })
-                .collect::<Result<Vec<_>, crate::Error>>()?;
-            assert_eq!(
-                json,
-                vec![
-                    serde_json::json!({
-                        "sessionId": "sess",
-                        "update": {
-                            "sessionUpdate": "agent_message_chunk",
-                            "content": {
-                                "type": "text",
-                                "text": "hello"
-                            },
-                            "messageId": "msg_agent"
-                        }
-                    }),
-                    serde_json::json!({
-                        "sessionId": "sess",
-                        "update": {
-                            "sessionUpdate": "agent_message_chunk",
-                            "content": {
-                                "type": "text",
-                                "text": "world"
-                            },
-                            "messageId": "msg_agent"
-                        }
-                    }),
-                ]
+            let error = compat
+                .incoming_message(UntypedMessage::new(
+                    "initialize",
+                    v2_initialize_request(ProtocolVersion::V1),
+                )?)
+                .expect_err("v2 agents should reject v1 initialization without a v1 handler");
+            let data = error
+                .data
+                .as_ref()
+                .and_then(|data| data.as_str())
+                .unwrap_or_default();
+            assert!(
+                data.contains("only supports ACP protocol version 2"),
+                "{error:?}"
             );
+            assert_eq!(negotiated(&compat), ProtocolVersionKind::V2);
+            assert_eq!(compat.active_wire_version(), ProtocolVersionKind::V2);
 
             Ok(())
         }

--- a/src/agent-client-protocol/src/jsonrpc/protocol_compat.rs
+++ b/src/agent-client-protocol/src/jsonrpc/protocol_compat.rs
@@ -184,7 +184,7 @@ mod imp {
                 ProtocolMode::Disabled => None,
                 ProtocolMode::Acp(mode) => Some(mode),
             };
-            let negotiated = mode.map(|mode| mode.api).unwrap_or(ProtocolVersionKind::V1);
+            let negotiated = mode.map_or(ProtocolVersionKind::V1, |mode| mode.api);
 
             Self {
                 mode,

--- a/src/agent-client-protocol/src/role/acp.rs
+++ b/src/agent-client-protocol/src/role/acp.rs
@@ -129,9 +129,8 @@ impl Agent {
 
     /// Create an agent builder that uses the ACP protocol v2 API.
     ///
-    /// The SDK will negotiate v1 or v2 during initialization and convert
-    /// supported messages at the transport boundary, so handlers can be written
-    /// against v2 types while still serving v1 clients.
+    /// This builder requires clients to negotiate protocol v2 during
+    /// initialization. Use a v1 builder for v1 clients.
     ///
     /// Requires the `unstable_protocol_v2` crate feature.
     #[cfg(feature = "unstable_protocol_v2")]

--- a/src/agent-client-protocol/tests/protocol_v2.rs
+++ b/src/agent-client-protocol/tests/protocol_v2.rs
@@ -136,7 +136,7 @@ async fn assert_v2_client_rejected_by_v1_agent(agent: impl ConnectTo<Client>) ->
                 .and_then(|data| data.as_str())
                 .unwrap_or_default();
             assert!(
-                data.contains("required ACP protocol version 2"),
+                data.contains("only supports ACP protocol version 1"),
                 "{error:?}"
             );
             Ok(())
@@ -185,26 +185,7 @@ async fn role_builder_v1_agent_rejects_v2_client_negotiation() -> Result<(), Err
         agent_client_protocol::on_receive_request!(),
     );
 
-    Client
-        .v2()
-        .connect_with(agent, async |cx| {
-            let error = cx
-                .send_request(v2_initialize_request(ProtocolVersion::V2))
-                .block_task()
-                .await
-                .expect_err("Role::builder should preserve v1 agent protocol mode");
-            let data = error
-                .data
-                .as_ref()
-                .and_then(|data| data.as_str())
-                .unwrap_or_default();
-            assert!(
-                data.contains("required ACP protocol version 2"),
-                "{error:?}"
-            );
-            Ok(())
-        })
-        .await
+    assert_v2_client_rejected_by_v1_agent(agent).await
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -234,24 +215,30 @@ async fn builder_new_with_v1_agent_rejects_v2_client_negotiation() -> Result<(),
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn role_builder_v1_client_downgrades_initialize_for_v2_agent() -> Result<(), Error> {
+async fn role_builder_v1_client_is_rejected_by_v2_agent() -> Result<(), Error> {
     let agent = Agent.v2().on_receive_request(
-        async |initialize: v2::InitializeRequest, responder, _cx| {
-            assert_eq!(initialize.protocol_version, ProtocolVersion::V2);
-            responder.respond(v2_initialize_response_with_session(
-                initialize.protocol_version,
-            ))
+        async |_initialize: v2::InitializeRequest, responder, _cx| {
+            responder.respond_with_internal_error("handler should not run")
         },
         agent_client_protocol::on_receive_request!(),
     );
 
     <Client as Role>::builder(Client)
         .connect_with(agent, async |cx| {
-            let initialize = cx
-                .send_request(v1_initialize_request(ProtocolVersion::V2))
+            let error = cx
+                .send_request(v1_initialize_request(ProtocolVersion::V1))
                 .block_task()
-                .await?;
-            assert_eq!(initialize.protocol_version, ProtocolVersion::V1);
+                .await
+                .expect_err("v2 agents require a v2 client implementation");
+            let data = error
+                .data
+                .as_ref()
+                .and_then(|data| data.as_str())
+                .unwrap_or_default();
+            assert!(
+                data.contains("only supports ACP protocol version 2"),
+                "{error:?}"
+            );
             Ok(())
         })
         .await
@@ -544,47 +531,6 @@ fn mcp_over_acp_variants_are_jsonrpc_mapped() -> Result<(), Error> {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn v2_agent_serves_v1_client_with_v2_handlers() -> Result<(), Error> {
-    let agent = Agent
-        .v2()
-        .on_receive_request(
-            async |initialize: v2::InitializeRequest, responder, _cx| {
-                assert_eq!(initialize.protocol_version, ProtocolVersion::V2);
-                // The compatibility layer should force this back to the negotiated v1 wire version.
-                responder.respond(v2_initialize_response_with_session(ProtocolVersion::V2))
-            },
-            agent_client_protocol::on_receive_request!(),
-        )
-        .on_receive_request(
-            async |request: v2::NewSessionRequest, responder, _cx| {
-                assert!(request.cwd.is_absolute());
-                responder.respond(v2::NewSessionResponse::new(v2::SessionId::new(
-                    "v2-session",
-                )))
-            },
-            agent_client_protocol::on_receive_request!(),
-        );
-
-    Client
-        .builder()
-        .connect_with(agent, async |cx| {
-            let initialize = cx
-                .send_request(v1_initialize_request(ProtocolVersion::V1))
-                .block_task()
-                .await?;
-            assert_eq!(initialize.protocol_version, ProtocolVersion::V1);
-
-            let session = cx
-                .send_request(v1::NewSessionRequest::new(cwd()?))
-                .block_task()
-                .await?;
-            assert_eq!(session.session_id.0.as_ref(), "v2-session");
-            Ok(())
-        })
-        .await
-}
-
-#[tokio::test(flavor = "current_thread")]
 async fn v2_client_rejects_v1_agent() -> Result<(), Error> {
     Client
         .v2()
@@ -600,7 +546,7 @@ async fn v2_client_rejects_v1_agent() -> Result<(), Error> {
                 .and_then(|data| data.as_str())
                 .unwrap_or_default();
             assert!(
-                data.contains("required ACP protocol version 2"),
+                data.contains("only supports ACP protocol version 1"),
                 "{error:?}"
             );
             Ok(())
@@ -693,29 +639,6 @@ async fn v2_client_can_cancel_request_to_v2_agent() -> Result<(), Error> {
             assert_eq!(initialize.protocol_version, ProtocolVersion::V2);
 
             let request = cx.send_request(v2::NewSessionRequest::new(cwd()?));
-            request.cancel()?;
-            let error = request
-                .block_task()
-                .await
-                .expect_err("request should be cancelled");
-            assert_eq!(i32::from(error.code), -32800);
-            Ok(())
-        })
-        .await
-}
-
-#[tokio::test(flavor = "current_thread")]
-async fn v1_client_can_cancel_request_to_v2_agent() -> Result<(), Error> {
-    Client
-        .builder()
-        .connect_with(v2_agent_with_cancellable_new_session(), async |cx| {
-            let initialize = cx
-                .send_request(v1_initialize_request(ProtocolVersion::V1))
-                .block_task()
-                .await?;
-            assert_eq!(initialize.protocol_version, ProtocolVersion::V1);
-
-            let request = cx.send_request(v1::NewSessionRequest::new(cwd()?));
             request.cancel()?;
             let error = request
                 .block_task()

--- a/src/agent-client-protocol/tests/schema_elicitation.rs
+++ b/src/agent-client-protocol/tests/schema_elicitation.rs
@@ -162,8 +162,8 @@ fn protocol_v2_elicitation_variants_are_jsonrpc_mapped() -> Result<(), Error> {
 
 #[cfg(feature = "unstable_protocol_v2")]
 #[tokio::test(flavor = "current_thread")]
-async fn v2_agent_can_elicit_from_v1_client_before_prompt_completion() -> Result<(), Error> {
-    use agent_client_protocol::schema::{ProtocolVersion, v1, v2};
+async fn v2_agent_can_elicit_from_v2_client_before_prompt_completion() -> Result<(), Error> {
+    use agent_client_protocol::schema::{ProtocolVersion, v2};
     use agent_client_protocol::{Agent, Client};
     use std::collections::BTreeMap;
 
@@ -175,13 +175,6 @@ async fn v2_agent_can_elicit_from_v1_client_before_prompt_completion() -> Result
             v2::Implementation::new("schema-elicitation-test", env!("CARGO_PKG_VERSION")),
         )
         .capabilities(v2::AgentCapabilities::new().session(v2::SessionCapabilities::new()))
-    }
-
-    fn v1_initialize_request(protocol_version: ProtocolVersion) -> v1::InitializeRequest {
-        v1::InitializeRequest::new(protocol_version).client_info(v1::Implementation::new(
-            "schema-elicitation-test",
-            env!("CARGO_PKG_VERSION"),
-        ))
     }
 
     let agent = Agent
@@ -225,31 +218,39 @@ async fn v2_agent_can_elicit_from_v1_client_before_prompt_completion() -> Result
         );
 
     Client
-        .builder()
+        .v2()
         .on_receive_request(
-            async |request: CreateElicitationRequest, responder, _cx| {
+            async |request: v2::CreateElicitationRequest, responder, _cx| {
                 assert_eq!(request.method(), "elicitation/create");
                 assert!(matches!(
                     request.mode,
-                    v1::ElicitationMode::Form(v1::ElicitationFormMode { .. })
+                    v2::ElicitationMode::Form(v2::ElicitationFormMode { .. })
                 ));
 
-                let content = BTreeMap::from([("name".to_string(), "Ada".into())]);
-                responder.respond(CreateElicitationResponse::new(ElicitationAction::Accept(
-                    v1::ElicitationAcceptAction::new().content(content),
-                )))
+                let content = BTreeMap::from([(
+                    "name".to_string(),
+                    v2::ElicitationContentValue::from("Ada"),
+                )]);
+                responder.respond(v2::CreateElicitationResponse::new(
+                    v2::ElicitationAction::Accept(
+                        v2::ElicitationAcceptAction::new().content(content),
+                    ),
+                ))
             },
             agent_client_protocol::on_receive_request!(),
         )
         .connect_with(agent, async |cx| {
             let initialize = cx
-                .send_request(v1_initialize_request(ProtocolVersion::V1))
+                .send_request(v2::InitializeRequest::new(
+                    ProtocolVersion::V2,
+                    v2::Implementation::new("schema-elicitation-test", env!("CARGO_PKG_VERSION")),
+                ))
                 .block_task()
                 .await?;
-            assert_eq!(initialize.protocol_version, ProtocolVersion::V1);
+            assert_eq!(initialize.protocol_version, ProtocolVersion::V2);
 
             let error = cx
-                .send_request(v1::PromptRequest::new(
+                .send_request(v2::PromptRequest::new(
                     "sess_abc123",
                     vec!["continue".into()],
                 ))


### PR DESCRIPTION
Removes the attempt to represent v2 as v1 as this is going to be
potentially lossy and problemeatic. We'll try another approach.
