### PR TITLE
fix(acp)!: stop responding to JSON-RPC notifications

### DIFF
--- a/md/request-cancellation.md
+++ b/md/request-cancellation.md
@@ -39,8 +39,8 @@ The requesting side always receives a response to the original request;
 cancellation only changes _which_ response that is. A `$/cancel_request` for
 an unknown or already-completed request ID is silently ignored. A
 `$/cancel_request` with malformed params (for example, a `requestId` that is
-not a string, number, or null) is different: it is reported back with an
-out-of-band error notification, like any other malformed notification.
+not a string, number, or null) is logged and ignored without a reply, like any
+other malformed notification.
 
 ## Interoperability
 

--- a/src/agent-client-protocol-conductor/src/conductor.rs
+++ b/src/agent-client-protocol-conductor/src/conductor.rs
@@ -1158,7 +1158,7 @@ impl ConductorHostRole for Agent {
         // Not yet initialized - expect an initialize request.
         // Error if we get anything else.
         let Dispatch::Request(request, init_responder) = message else {
-            message.respond_with_error(invalid_request(), client_connection.clone())?;
+            message.respond_with_error(invalid_request())?;
             return Err(invalid_request());
         };
         if !InitializeRequest::matches_method(request.method()) {
@@ -1256,7 +1256,7 @@ impl ConductorHostRole for Proxy {
         // Not yet initialized - expect an InitializeProxy request.
         // Error if we get anything else.
         let Dispatch::Request(request, init_responder) = message else {
-            message.respond_with_error(invalid_request(), client_connection.clone())?;
+            message.respond_with_error(invalid_request())?;
             return Err(invalid_request());
         };
         if !InitializeProxyRequest::matches_method(request.method()) {

--- a/src/agent-client-protocol-cookbook/src/lib.rs
+++ b/src/agent-client-protocol-cookbook/src/lib.rs
@@ -248,9 +248,10 @@ pub mod building_an_agent {
     //!             // Return final response
     //!             responder.respond(PromptResponse::new(StopReason::EndTurn))
     //!         }, agent_client_protocol::on_receive_request!())
-    //!         // Reject unknown messages
-    //!         .on_receive_dispatch(async |message: Dispatch, connection: ConnectionTo<Client>| {
-    //!             message.respond_with_error(agent_client_protocol::Error::method_not_found(), connection)
+    //!         // Reject unknown requests. Notifications are ignored because
+    //!         // they cannot receive responses.
+    //!         .on_receive_dispatch(async |message: Dispatch, _connection: ConnectionTo<Client>| {
+    //!             message.respond_with_error(agent_client_protocol::Error::method_not_found())
     //!         }, agent_client_protocol::on_receive_dispatch!())
     //!         .connect_to(transport)
     //!         .await

--- a/src/agent-client-protocol/examples/simple_agent.rs
+++ b/src/agent-client-protocol/examples/simple_agent.rs
@@ -17,12 +17,12 @@ async fn main() -> Result<()> {
             agent_client_protocol::on_receive_request!(),
         )
         .on_receive_dispatch(
-            async move |message: Dispatch, cx: ConnectionTo<Client>| {
-                // Respond to any other message with an error
-                message.respond_with_error(
-                    agent_client_protocol::util::internal_error("unhandled message"),
-                    cx,
-                )
+            async move |message: Dispatch, _cx: ConnectionTo<Client>| {
+                // Reject unhandled requests. Notifications are ignored because
+                // JSON-RPC notifications cannot receive responses.
+                message.respond_with_error(agent_client_protocol::util::internal_error(
+                    "unhandled message",
+                ))
             },
             agent_client_protocol::on_receive_dispatch!(),
         )

--- a/src/agent-client-protocol/src/concepts/error_handling.rs
+++ b/src/agent-client-protocol/src/concepts/error_handling.rs
@@ -43,10 +43,8 @@
 //! application needs to report a one-way failure, define a notification method for
 //! that purpose.
 //!
-//! [`send_error_notification`][crate::ConnectionTo::send_error_notification] is a
-//! low-level method for parse and invalid-request errors whose request id cannot be
-//! recovered. Despite its historical name, it sends an Error Response with a null
-//! id; it is not a reply mechanism for notifications.
+//! Malformed JSON and invalid request envelopes are handled at the SDK's transport
+//! boundary. Applications do not need to construct uncorrelated Error Responses.
 //!
 //! # The `into_internal_error` Helper
 //!
@@ -101,8 +99,7 @@
 //!
 //! | Situation | What to do |
 //! |-----------|------------|
-//! | Send error response to request | `responder.respond(Err(error))` then `Ok(())` |
+//! | Send error response to request | `responder.respond_with_error(error)` |
 //! | Handle notification failure | Log or return the error; the SDK sends no reply |
-//! | Send uncorrelated parse/invalid-request error | Low-level `cx.send_error_notification(error)` |
 //! | Fail connection lifecycle work | Return `Err(error)` from a lifecycle callback |
 //! | Convert external error | `.map_err(Error::into_internal_error)?` |

--- a/src/agent-client-protocol/src/jsonrpc.rs
+++ b/src/agent-client-protocol/src/jsonrpc.rs
@@ -751,9 +751,10 @@ where
 ///         // This runs first for PromptRequest
 ///         responder.respond(PromptResponse::make())
 ///     }, agent_client_protocol::on_receive_request!())
-///     .on_receive_dispatch(async |msg: Dispatch, cx| {
-///         // This runs for any message not handled above
-///         msg.respond_with_error(agent_client_protocol::util::internal_error("unknown method"), cx)
+///     .on_receive_dispatch(async |msg: Dispatch, _cx| {
+///         // Reject unhandled requests. Notifications are ignored because they
+///         // cannot receive responses.
+///         msg.respond_with_error(agent_client_protocol::util::internal_error("unknown method"))
 ///     }, agent_client_protocol::on_receive_dispatch!())
 /// # .connect_to(agent_client_protocol_test::MockTransport).await?;
 /// # Ok(())
@@ -2554,8 +2555,8 @@ enum OutgoingMessage {
         destination: ResponseDestination,
     },
 
-    /// Send a generalized error message
-    Error {
+    /// Send an Error Response that cannot be correlated to a request ID.
+    UncorrelatedErrorResponse {
         error: crate::Error,
         destination: ResponseDestination,
     },
@@ -3281,21 +3282,6 @@ impl<Counterpart: Role> ConnectionTo<Counterpart> {
         )
     }
 
-    /// Send a JSON-RPC error response with a null id.
-    ///
-    /// This low-level method is intended for parse and invalid-request errors when
-    /// the request id cannot be recovered. Despite its historical name, it sends a
-    /// Response object and must not be used to reply to a JSON-RPC notification.
-    pub fn send_error_notification(&self, error: crate::Error) -> Result<(), crate::Error> {
-        send_raw_message(
-            &self.message_tx,
-            OutgoingMessage::Error {
-                error,
-                destination: ResponseDestination::Individual,
-            },
-        )
-    }
-
     /// Register a dynamic message handler, used to intercept messages specific to a particular session
     /// or some similar modal thing.
     ///
@@ -3901,11 +3887,7 @@ impl<Req: JsonRpcRequest, Notif: JsonRpcMessage> Dispatch<Req, Notif> {
     /// JSON-RPC notifications cannot be answered.
     ///
     /// If this message is a response, the error is forwarded to the waiting handler.
-    pub fn respond_with_error<R: Role>(
-        self,
-        error: crate::Error,
-        _cx: ConnectionTo<R>,
-    ) -> Result<(), crate::Error> {
+    pub fn respond_with_error(self, error: crate::Error) -> Result<(), crate::Error> {
         match self {
             Dispatch::Request(_, responder) => responder.respond_with_error(error),
             Dispatch::Notification(_) => {

--- a/src/agent-client-protocol/src/jsonrpc/incoming_actor.rs
+++ b/src/agent-client-protocol/src/jsonrpc/incoming_actor.rs
@@ -127,8 +127,8 @@ pub(super) async fn incoming_protocol_actor<Counterpart: Role>(
                                 new_pending_messages.push(m);
                             }
                             Err(err) => {
-                                tracing::warn!(?err, handler = ?handler.dyn_describe_chain(), "Dynamic handler errored on pending message, reporting back");
-                                report_handler_error(connection, reply_target, method, err)?;
+                                tracing::warn!(?err, handler = ?handler.dyn_describe_chain(), "Dynamic handler errored on pending message");
+                                handle_handler_error(connection, reply_target, method, err)?;
                             }
                         }
                     }
@@ -176,7 +176,7 @@ pub(super) async fn incoming_protocol_actor<Counterpart: Role>(
                                     }
                                 }
                                 Err(error) => {
-                                    report_handler_error(
+                                    handle_handler_error(
                                         connection,
                                         Some(RequestReplyTarget {
                                             id: request_id,
@@ -216,7 +216,7 @@ pub(super) async fn incoming_protocol_actor<Counterpart: Role>(
                                     }
                                 }
                                 Err(error) => {
-                                    report_handler_error(connection, None, request_method, error)?;
+                                    handle_handler_error(connection, None, request_method, error)?;
                                 }
                             }
                         }
@@ -258,7 +258,7 @@ pub(super) async fn incoming_protocol_actor<Counterpart: Role>(
                             );
                             send_raw_message(
                                 &connection.message_tx,
-                                OutgoingMessage::Error { error, destination },
+                                OutgoingMessage::UncorrelatedErrorResponse { error, destination },
                             )?;
                         }
                     }
@@ -435,7 +435,7 @@ async fn dispatch_dispatch<Counterpart: Role>(
                 ?err,
                 "Request cancellation notification errored"
             );
-            return report_handler_error(connection, reply_target, method, err);
+            return handle_handler_error(connection, reply_target, method, err);
         }
     }
 
@@ -457,8 +457,8 @@ async fn dispatch_dispatch<Counterpart: Role>(
         }
 
         Err(err) => {
-            tracing::warn!(?method, ?id, ?err, handler = ?handler.describe_chain(), "Handler errored, reporting back to remote");
-            return report_handler_error(connection, reply_target, method, err);
+            tracing::warn!(?method, ?id, ?err, handler = ?handler.describe_chain(), "Handler errored");
+            return handle_handler_error(connection, reply_target, method, err);
         }
     }
 
@@ -481,8 +481,8 @@ async fn dispatch_dispatch<Counterpart: Role>(
             }
 
             Err(err) => {
-                tracing::warn!(?method, ?id, ?err, handler = ?dynamic_handler.dyn_describe_chain(), "Dynamic handler errored, reporting back to remote");
-                return report_handler_error(connection, reply_target, method, err);
+                tracing::warn!(?method, ?id, ?err, handler = ?dynamic_handler.dyn_describe_chain(), "Dynamic handler errored");
+                return handle_handler_error(connection, reply_target, method, err);
             }
         }
     }
@@ -508,9 +508,9 @@ async fn dispatch_dispatch<Counterpart: Role>(
                 ?id,
                 ?err,
                 handler = "default",
-                "Default handler errored, reporting back to remote"
+                "Default handler errored"
             );
-            return report_handler_error(connection, reply_target, method, err);
+            return handle_handler_error(connection, reply_target, method, err);
         }
     }
 
@@ -536,10 +536,7 @@ async fn dispatch_dispatch<Counterpart: Role>(
             Dispatch::Request(..) => {
                 tracing::info!(?method, "Rejecting request with error, no handler");
                 let method = dispatch.method().to_string();
-                dispatch.respond_with_error(
-                    crate::Error::method_not_found().data(method),
-                    connection.clone(),
-                )
+                dispatch.respond_with_error(crate::Error::method_not_found().data(method))
             }
             Dispatch::Response(result, router) => {
                 tracing::trace!(?method, "Forwarding response");
@@ -549,12 +546,11 @@ async fn dispatch_dispatch<Counterpart: Role>(
     }
 }
 
-/// When a handler returns an error, report it back to the remote side instead
-/// of propagating it and tearing down the connection.
+/// Handle a message-processing error without tearing down the connection.
 ///
 /// For requests, sends a JSON-RPC error response to the request's exact output
 /// destination. For notifications and incoming responses, logs without replying.
-fn report_handler_error<Counterpart: Role>(
+fn handle_handler_error<Counterpart: Role>(
     connection: &ConnectionTo<Counterpart>,
     reply_target: Option<RequestReplyTarget>,
     method: String,
@@ -574,7 +570,7 @@ fn report_handler_error<Counterpart: Role>(
         tracing::warn!(
             %method,
             ?error,
-            "Non-request handler failed; ignoring error because there is no request to answer"
+            "Ignoring message-processing error because there is no request to answer"
         );
         Ok(())
     }

--- a/src/agent-client-protocol/src/jsonrpc/outgoing_actor.rs
+++ b/src/agent-client-protocol/src/jsonrpc/outgoing_actor.rs
@@ -136,7 +136,7 @@ pub(super) async fn outgoing_protocol_actor(
                     (RawJsonRpcMessage::response(id, Err(error)), destination)
                 }
             },
-            OutgoingMessage::Error { error, destination } => {
+            OutgoingMessage::UncorrelatedErrorResponse { error, destination } => {
                 // JSON-RPC reports parse/invalid-request errors with id null when
                 // they cannot be correlated to a specific request.
                 (

--- a/src/agent-client-protocol/src/util/typed.rs
+++ b/src/agent-client-protocol/src/util/typed.rs
@@ -819,11 +819,11 @@ impl<Counterpart: Role> MatchDispatchFrom<Counterpart> {
 /// # Example
 ///
 /// ```
-/// # use agent_client_protocol::{UntypedMessage, ConnectionTo, Agent};
+/// # use agent_client_protocol::UntypedMessage;
 /// # use agent_client_protocol::schema::v1::SessionNotification;
 /// # use agent_client_protocol::util::TypeNotification;
-/// # async fn example(message: UntypedMessage, cx: &ConnectionTo<Agent>) -> Result<(), agent_client_protocol::Error> {
-/// TypeNotification::new(message, cx)
+/// # async fn example(message: UntypedMessage) -> Result<(), agent_client_protocol::Error> {
+/// TypeNotification::new(message)
 ///     .handle_if(|notif: SessionNotification| async move {
 ///         // Handle session notifications
 ///         println!("Session update: {:?}", notif);
@@ -843,8 +843,7 @@ impl<Counterpart: Role> MatchDispatchFrom<Counterpart> {
 /// notification (not a request context).
 #[must_use]
 #[derive(Debug)]
-pub struct TypeNotification<R: Role> {
-    _cx: ConnectionTo<R>,
+pub struct TypeNotification {
     state: Option<TypeNotificationState>,
 }
 
@@ -854,12 +853,11 @@ enum TypeNotificationState {
     Handled(Result<(), crate::Error>),
 }
 
-impl<R: Role> TypeNotification<R> {
+impl TypeNotification {
     /// Create a new pattern matcher for the given untyped notification message.
-    pub fn new(request: UntypedMessage, cx: &ConnectionTo<R>) -> Self {
+    pub fn new(request: UntypedMessage) -> Self {
         let UntypedMessage { method, params } = request;
         Self {
-            _cx: cx.clone(),
             state: Some(TypeNotificationState::Unhandled(method, params)),
         }
     }
@@ -867,8 +865,9 @@ impl<R: Role> TypeNotification<R> {
     /// Try to handle the message as type `N`.
     ///
     /// If the message can be parsed as `N`, the handler `op` is called with the parsed
-    /// notification. If parsing fails or the message was already handled by a previous
-    /// `handle_if`, this call has no effect.
+    /// notification. If parsing fails, the malformed matching notification is consumed
+    /// and logged without invoking the handler or sending a response. If the message was
+    /// already handled by a previous `handle_if`, this call has no effect.
     ///
     /// Returns `self` to allow chaining multiple `handle_if` calls.
     pub async fn handle_if<N: JsonRpcNotification>(
@@ -924,5 +923,71 @@ impl<R: Role> TypeNotification<R> {
             }
             TypeNotificationState::Handled(r) => r,
         }
+    }
+}
+
+#[cfg(test)]
+mod type_notification_tests {
+    use std::{cell::Cell, rc::Rc};
+
+    use serde::{Deserialize, Serialize};
+
+    use super::{TypeNotification, UntypedMessage};
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    struct TestNotification {
+        required: String,
+    }
+
+    impl crate::JsonRpcMessage for TestNotification {
+        fn matches_method(method: &str) -> bool {
+            method == "test/notification"
+        }
+
+        fn method(&self) -> &'static str {
+            "test/notification"
+        }
+
+        fn to_untyped_message(&self) -> Result<UntypedMessage, crate::Error> {
+            UntypedMessage::new(self.method(), self)
+        }
+
+        fn parse_message(method: &str, params: &impl Serialize) -> Result<Self, crate::Error> {
+            if !Self::matches_method(method) {
+                return Err(crate::Error::method_not_found());
+            }
+            crate::util::json_cast_params(params)
+        }
+    }
+
+    impl crate::JsonRpcNotification for TestNotification {}
+
+    #[test]
+    fn invalid_matching_notification_is_consumed_without_fallback() {
+        futures::executor::block_on(async {
+            let handler_called = Rc::new(Cell::new(false));
+            let fallback_called = Rc::new(Cell::new(false));
+            let handler_called_in_callback = Rc::clone(&handler_called);
+            let fallback_called_in_callback = Rc::clone(&fallback_called);
+            let message =
+                UntypedMessage::new("test/notification", serde_json::json!({ "wrong": "field" }))
+                    .expect("test notification should serialize");
+
+            TypeNotification::new(message)
+                .handle_if(move |_: TestNotification| async move {
+                    handler_called_in_callback.set(true);
+                    Ok(())
+                })
+                .await
+                .otherwise(move |_| async move {
+                    fallback_called_in_callback.set(true);
+                    Ok(())
+                })
+                .await
+                .expect("invalid notification should be ignored");
+
+            assert!(!handler_called.get());
+            assert!(!fallback_called.get());
+        });
     }
 }

--- a/src/agent-client-protocol/tests/jsonrpc_batch.rs
+++ b/src/agent-client-protocol/tests/jsonrpc_batch.rs
@@ -803,6 +803,11 @@ async fn notification_only_batch_emits_nothing_before_following_barrier_response
                     },
                     {
                         "jsonrpc": "2.0",
+                        "method": "unknown/notification",
+                        "params": {}
+                    },
+                    {
+                        "jsonrpc": "2.0",
                         "method": "test/notify",
                         "params": { "message": "second" }
                     }

--- a/src/agent-client-protocol/tests/jsonrpc_error_handling.rs
+++ b/src/agent-client-protocol/tests/jsonrpc_error_handling.rs
@@ -8,8 +8,8 @@
 //! - Missing/invalid parameters
 
 use agent_client_protocol::{
-    ConnectionTo, JsonRpcMessage, JsonRpcRequest, JsonRpcResponse, Responder, SentRequest,
-    role::UntypedRole,
+    ConnectionTo, Dispatch, JsonRpcMessage, JsonRpcRequest, JsonRpcResponse, Responder,
+    SentRequest, role::UntypedRole,
 };
 use expect_test::expect;
 use futures::{AsyncRead, AsyncWrite};
@@ -755,11 +755,11 @@ async fn test_bad_request_params_return_invalid_params_and_connection_stays_aliv
 }
 
 // ============================================================================
-// Test 7: Bad notification params
+// Test 7: Notification errors
 // ============================================================================
 
 #[tokio::test(flavor = "current_thread")]
-async fn test_bad_notification_params_are_ignored_and_connection_stays_alive() {
+async fn test_notification_errors_are_ignored_and_connection_stays_alive() {
     use tokio::io::{AsyncWriteExt, BufReader};
     use tokio::task::LocalSet;
 
@@ -778,10 +778,10 @@ async fn test_bad_notification_params_are_ignored_and_connection_stays_alive() {
             let server = UntypedRole
                 .builder()
                 .on_receive_notification(
-                    async |_notif: SimpleNotification,
+                    async |notif: SimpleNotification,
                            _connection: ConnectionTo<UntypedRole>| {
-                        // If we get here, the notification parsed successfully.
-                        Ok(())
+                        assert_eq!(notif.message, "handler error");
+                        Err::<(), _>(agent_client_protocol::Error::internal_error())
                     },
                     agent_client_protocol::on_receive_notification!(),
                 )
@@ -804,11 +804,18 @@ async fn test_bad_notification_params_are_ignored_and_connection_stays_alive() {
 
             let mut client_reader = BufReader::new(client_reader);
 
-            // Send a notification with bad params (wrong field name), followed
-            // by a request that acts as an ordering barrier.
+            // Send notifications that fail during parsing and inside the handler,
+            // followed by a request that acts as an ordering barrier.
             client_writer
                 .write_all(
                     br#"{"jsonrpc":"2.0","method":"simple_notification","params":{"wrong_field":"hello"}}
+"#,
+                )
+                .await
+                .unwrap();
+            client_writer
+                .write_all(
+                    br#"{"jsonrpc":"2.0","method":"simple_notification","params":{"message":"handler error"}}
 "#,
                 )
                 .await
@@ -824,8 +831,8 @@ async fn test_bad_notification_params_are_ignored_and_connection_stays_alive() {
                 .unwrap();
             client_writer.flush().await.unwrap();
 
-            // The first line must be the request response. Any reply to the
-            // malformed notification would arrive before it.
+            // The first line must be the request response. Any reply to either
+            // failing notification would arrive before it.
             let ok_response = read_jsonrpc_response_line(&mut client_reader).await;
             expect![[r#"
                 {
@@ -836,6 +843,62 @@ async fn test_bad_notification_params_are_ignored_and_connection_stays_alive() {
                   }
                 }"#]]
             .assert_eq(&serde_json::to_string_pretty(&ok_response).unwrap());
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn dispatch_error_for_notification_is_ignored_and_connection_stays_alive() {
+    use tokio::io::{AsyncWriteExt, BufReader};
+    use tokio::task::LocalSet;
+
+    LocalSet::new()
+        .run_until(async {
+            let (mut client_writer, server_reader) = tokio::io::duplex(2048);
+            let (server_writer, client_reader) = tokio::io::duplex(2048);
+            let server_transport = agent_client_protocol::ByteStreams::new(
+                server_writer.compat_write(),
+                server_reader.compat(),
+            );
+            let server = UntypedRole
+                .builder()
+                .on_receive_request(
+                    async |request: SimpleRequest,
+                           responder: Responder<SimpleResponse>,
+                           _connection: ConnectionTo<UntypedRole>| {
+                        responder.respond(SimpleResponse {
+                            result: format!("echo: {}", request.message),
+                        })
+                    },
+                    agent_client_protocol::on_receive_request!(),
+                )
+                .on_receive_dispatch(
+                    async |message: Dispatch, _connection: ConnectionTo<UntypedRole>| {
+                        message.respond_with_error(agent_client_protocol::Error::internal_error())
+                    },
+                    agent_client_protocol::on_receive_dispatch!(),
+                );
+
+            tokio::task::spawn_local(async move {
+                if let Err(error) = server.connect_to(server_transport).await {
+                    panic!("server should stay alive: {error:?}");
+                }
+            });
+
+            client_writer
+                .write_all(
+                    br#"{"jsonrpc":"2.0","method":"unknown/notification","params":{}}
+{"jsonrpc":"2.0","id":11,"method":"simple_method","params":{"message":"after dispatch error"}}
+"#,
+                )
+                .await
+                .unwrap();
+            client_writer.flush().await.unwrap();
+
+            let mut client_reader = BufReader::new(client_reader);
+            let response = read_jsonrpc_response_line(&mut client_reader).await;
+            assert_eq!(response["id"], 11);
+            assert_eq!(response["result"]["result"], "echo: after dispatch error");
         })
         .await;
 }

--- a/src/agent-client-protocol/tests/jsonrpc_unhandled_messages.rs
+++ b/src/agent-client-protocol/tests/jsonrpc_unhandled_messages.rs
@@ -154,6 +154,13 @@ async fn unhandled_notifications_are_ignored() {
                 .unwrap();
             client_writer
                 .write_all(
+                    br#"{"jsonrpc":"2.0","method":"$/cancel_request","params":{"requestId":true}}
+"#,
+                )
+                .await
+                .unwrap();
+            client_writer
+                .write_all(
                     br#"{"jsonrpc":"2.0","method":"_x.ai/settings/update","params":{"theme":"auto"}}
 "#,
                 )
@@ -169,8 +176,8 @@ async fn unhandled_notifications_are_ignored() {
             client_writer.flush().await.unwrap();
 
             // The server processes messages in order: a response to this
-            // request proves the unknown notifications sent before it were
-            // ignored without erroring or closing the connection.
+            // request proves the unknown and malformed notifications sent
+            // before it were ignored without replying or closing the connection.
             client_writer
                 .write_all(
                     br#"{"jsonrpc":"2.0","id":2,"method":"simple_method","params":{"message":"after notifications"}}


### PR DESCRIPTION
This was already not really JSON-RPC compliant, and problematic for batches.
Cleaning up the apis along with it which is the breaking change.
