### PR TITLE
refactor(acp)!: clarify routing and handler APIs

### DIFF
--- a/md/migration_v2.0.md
+++ b/md/migration_v2.0.md
@@ -141,6 +141,37 @@ These accessors avoid implicit allocation and handle cloning. Call `.to_owned()`
 `.cloned()` on `modes` or `meta`, and `.clone()` on either connection accessor when an owned value
 is required.
 
+## Low-level helpers have a narrower surface
+
+`DynConnectTo::type_name` now returns `&'static str` without allocating. Call `.to_owned()` when
+an owned type name is required.
+
+The generic `util::both` helper was removed. Replace `util::both(a, b).await` with
+`futures::future::try_join(a, b).await.map(|((), ())| ())`.
+
+`util::process_stream_concurrently` is no longer public. An equivalent unbounded fallible loop can
+be written with `futures::{StreamExt, TryStreamExt}`:
+
+```rust,ignore
+stream
+    .map(Ok::<_, agent_client_protocol::Error>)
+    .try_for_each_concurrent(None, |item| process_fn(item))
+    .await
+```
+
+Pass a finite limit instead of `None` to bound concurrency.
+
+`ConnectionTo::attach_session` is no longer public. Create sessions through
+`ConnectionTo::build_session`, `build_session_cwd`, or `build_session_from` instead. Use
+`SessionBuilder::on_session_start` to start without blocking the calling task, or call
+`block_task()` followed by `run_until` or `start_session`. Proxy handlers can use
+`on_proxy_session_start`, or `block_task().start_session_proxy(...)`. Directly attaching an
+already-returned `NewSessionResponse` is no longer supported, so move request customization into
+`build_session_from` before the builder sends `session/new`.
+
+Construct `Lines` and `ByteStreams` with `Lines::new(outgoing, incoming)` and
+`ByteStreams::new(outgoing, incoming)`; their stream fields are no longer public.
+
 ## `AcpAgent` has its own process configuration
 
 `AcpAgent` now accepts `AcpAgentConfig` instead of the ACP wire-schema `McpServer`. An ACP agent

--- a/md/migration_v2.0.md
+++ b/md/migration_v2.0.md
@@ -118,6 +118,16 @@ respond to an individual JSON-RPC request. The builder method now reflects that 
 | --- | --- |
 | `Builder::with_responder` | `Builder::with_runner` |
 
+## Matchers use dispatch terminology
+
+The combined matchers operate on `Dispatch` values, which can represent requests, notifications,
+or responses. Their method names now reflect that input:
+
+| 1.x | 2.0 |
+| --- | --- |
+| `MatchDispatch::if_message` | `MatchDispatch::if_dispatch` |
+| `MatchDispatchFrom::if_message_from` | `MatchDispatchFrom::if_dispatch_from` |
+
 ## `AcpAgent` has its own process configuration
 
 `AcpAgent` now accepts `AcpAgentConfig` instead of the ACP wire-schema `McpServer`. An ACP agent

--- a/md/migration_v2.0.md
+++ b/md/migration_v2.0.md
@@ -128,6 +128,19 @@ or responses. Their method names now reflect that input:
 | `MatchDispatch::if_message` | `MatchDispatch::if_dispatch` |
 | `MatchDispatchFrom::if_message_from` | `MatchDispatchFrom::if_dispatch_from` |
 
+## Connection and session accessors borrow
+
+`McpConnectionTo::acp_id` now returns `&str`. The deprecated `acp_url` alias was removed; use
+`acp_id` instead. `McpConnectionTo::connection_to` is now `connection` and returns
+`&ConnectionTo<_>`.
+
+`ActiveSession::modes` and `ActiveSession::meta` now return `Option<&T>` instead of `&Option<T>`,
+and `ActiveSession::connection` returns `&ConnectionTo<_>`.
+
+These accessors avoid implicit allocation and handle cloning. Call `.to_owned()` on `acp_id`,
+`.cloned()` on `modes` or `meta`, and `.clone()` on either connection accessor when an owned value
+is required.
+
 ## `AcpAgent` has its own process configuration
 
 `AcpAgent` now accepts `AcpAgentConfig` instead of the ACP wire-schema `McpServer`. An ACP agent

--- a/md/migration_v2.0.md
+++ b/md/migration_v2.0.md
@@ -1,9 +1,51 @@
 # Migrating from `agent-client-protocol` 1.x to 2.0
 
-Version 2.0 changes the low-level in-process transport boundary so JSON-RPC frames remain intact
-across components and adapters, clarifies the distinction between responding to requests and
-routing responses, makes dynamic handler lifetimes explicit, and gives `AcpAgent` an SDK-owned
-process-launch configuration instead of reusing an MCP wire-schema type.
+Version 2.0 makes JSON-RPC notification semantics explicit, changes the low-level in-process
+transport boundary so frames remain intact across components and adapters, clarifies the
+distinction between responding to requests and routing responses, makes dynamic handler lifetimes
+explicit, and gives `AcpAgent` an SDK-owned process-launch configuration instead of reusing an MCP
+wire-schema type.
+
+## Notifications cannot receive error responses
+
+The SDK no longer exposes `ConnectionTo::send_error_notification`, and
+`Dispatch::respond_with_error` has been removed. Match the dispatch variant when a catch-all
+handler needs different behavior:
+
+```rust
+use agent_client_protocol::{Dispatch, Error};
+
+# fn handle(message: Dispatch) -> Result<(), Error> {
+match message {
+    Dispatch::Request(_, responder) => {
+        responder.respond_with_error(Error::method_not_found())
+    }
+    Dispatch::Notification(_) => Ok(()),
+    Dispatch::Response(result, router) => router.route_with_result(result),
+}
+# }
+```
+
+In most applications, omit the catch-all handler entirely. The built-in fallback responds to
+unknown requests with `Method not found`, ignores unhandled notifications, and routes responses
+to their pending requests.
+
+`TypeNotification` no longer has a role parameter or takes a connection:
+
+```rust
+use agent_client_protocol::util::TypeNotification;
+
+// 1.x
+// TypeNotification::<Peer>::new(message, &connection)
+
+// 2.0
+TypeNotification::new(message)
+# ;
+```
+
+The notification type parameter of `Dispatch<Req, Notif>` now requires
+`Notif: JsonRpcNotification`, matching the variant it can contain. The duplicate
+`Dispatch::erase_to_json` method was removed; use `into_untyped_dispatch`.
 
 ## Raw channels carry frames
 

--- a/md/migration_v2.0.md
+++ b/md/migration_v2.0.md
@@ -109,6 +109,15 @@ registration. Dropping it unregisters the handler. To leave a handler registered
 the connection, replace `run_indefinitely()` with `detach()`. Detaching no longer leaks an extra
 `ConnectionTo` handle.
 
+## Background tasks use runner terminology
+
+Builder extensions implementing `RunWithConnectionTo` run alongside the connection; they do not
+respond to an individual JSON-RPC request. The builder method now reflects that distinction:
+
+| 1.x | 2.0 |
+| --- | --- |
+| `Builder::with_responder` | `Builder::with_runner` |
+
 ## `AcpAgent` has its own process configuration
 
 `AcpAgent` now accepts `AcpAgentConfig` instead of the ACP wire-schema `McpServer`. An ACP agent

--- a/md/migration_v2.0.md
+++ b/md/migration_v2.0.md
@@ -1,8 +1,9 @@
 # Migrating from `agent-client-protocol` 1.x to 2.0
 
 Version 2.0 changes the low-level in-process transport boundary so JSON-RPC frames remain intact
-across components and adapters. It also gives `AcpAgent` an SDK-owned process-launch
-configuration instead of reusing an MCP wire-schema type.
+across components and adapters, clarifies the distinction between responding to requests and
+routing responses, and gives `AcpAgent` an SDK-owned process-launch configuration instead of
+reusing an MCP wire-schema type.
 
 ## Raw channels carry frames
 
@@ -25,6 +26,38 @@ received frame intact when relaying it so batch response grouping remains correc
 The separate, hidden `FramedChannel` and `into_framed_channel_and_future` compatibility path no
 longer exist. Implement only `ConnectTo::connect_to`, optionally overriding
 `into_channel_and_future` for a direct channel adapter.
+
+## Response routing uses routing terminology
+
+`ResponseRouter` completes a local pending request; it does not send a new JSON-RPC response.
+Its methods have therefore been renamed:
+
+| 1.x | 2.0 |
+| --- | --- |
+| `respond_with_result` | `route_with_result` |
+| `respond` | `route` |
+| `respond_with_error` | `route_with_error` |
+| `respond_with_internal_error` | `route_with_internal_error` |
+
+`Responder` still uses `respond*`, because it sends the response to an incoming request.
+
+## Request IDs remain typed
+
+`Responder::id`, `ResponseRouter::id`, and `SentRequest::id` now return `&RequestId`.
+`Dispatch::id` returns `Option<&RequestId>`. Clone the ID when it must outlive the handle:
+
+```rust
+let id = sent_request.id().clone();
+```
+
+This removes JSON round-trips and lets IDs pass directly to APIs such as request cancellation.
+If an integration still needs an untyped JSON value, serialize the borrowed ID explicitly:
+
+```rust
+let id_json = serde_json::to_value(sent_request.id())?;
+let dispatch_id_json = dispatch.id().map(serde_json::to_value).transpose()?;
+# let _ = (id_json, dispatch_id_json);
+```
 
 ## `AcpAgent` has its own process configuration
 

--- a/md/migration_v2.0.md
+++ b/md/migration_v2.0.md
@@ -2,8 +2,8 @@
 
 Version 2.0 changes the low-level in-process transport boundary so JSON-RPC frames remain intact
 across components and adapters, clarifies the distinction between responding to requests and
-routing responses, and gives `AcpAgent` an SDK-owned process-launch configuration instead of
-reusing an MCP wire-schema type.
+routing responses, makes dynamic handler lifetimes explicit, and gives `AcpAgent` an SDK-owned
+process-launch configuration instead of reusing an MCP wire-schema type.
 
 ## Raw channels carry frames
 
@@ -58,6 +58,14 @@ let id_json = serde_json::to_value(sent_request.id())?;
 let dispatch_id_json = dispatch.id().map(serde_json::to_value).transpose()?;
 # let _ = (id_json, dispatch_id_json);
 ```
+
+## Dynamic handlers use a guard
+
+`DynamicHandlerRegistration` is now `DynamicHandlerGuard` and is exported from the crate root.
+The guard is `must_use` and no longer `Clone`: keep its single owner in the object that owns the
+registration. Dropping it unregisters the handler. To leave a handler registered for the rest of
+the connection, replace `run_indefinitely()` with `detach()`. Detaching no longer leaks an extra
+`ConnectionTo` handle.
 
 ## `AcpAgent` has its own process configuration
 

--- a/src/agent-client-protocol-conductor/src/conductor.rs
+++ b/src/agent-client-protocol-conductor/src/conductor.rs
@@ -1158,7 +1158,9 @@ impl ConductorHostRole for Agent {
         // Not yet initialized - expect an initialize request.
         // Error if we get anything else.
         let Dispatch::Request(request, init_responder) = message else {
-            message.respond_with_error(invalid_request())?;
+            if let Dispatch::Response(_, router) = message {
+                router.route_with_error(invalid_request())?;
+            }
             return Err(invalid_request());
         };
         if !InitializeRequest::matches_method(request.method()) {
@@ -1256,7 +1258,9 @@ impl ConductorHostRole for Proxy {
         // Not yet initialized - expect an InitializeProxy request.
         // Error if we get anything else.
         let Dispatch::Request(request, init_responder) = message else {
-            message.respond_with_error(invalid_request())?;
+            if let Dispatch::Response(_, router) = message {
+                router.route_with_error(invalid_request())?;
+            }
             return Err(invalid_request());
         };
         if !InitializeProxyRequest::matches_method(request.method()) {

--- a/src/agent-client-protocol-conductor/src/conductor.rs
+++ b/src/agent-client-protocol-conductor/src/conductor.rs
@@ -236,7 +236,7 @@ impl<Host: ConductorHostRole> ConductorImpl<Host> {
             },
         )
         .name(self.name)
-        .with_responder(responder)
+        .with_runner(responder)
         .with_spawned(|_cx| trace_future)
         .connect_to(transport)
         .await

--- a/src/agent-client-protocol-conductor/src/conductor.rs
+++ b/src/agent-client-protocol-conductor/src/conductor.rs
@@ -695,7 +695,7 @@ where
             .on_receive_dispatch(
                 async move |dispatch: Dispatch, _connection| {
                     MatchDispatch::new(dispatch)
-                        .if_message(async |dispatch: SuccessorDispatch| {
+                        .if_dispatch(async |dispatch: SuccessorDispatch| {
                             //                         ------------------
                             // SuccessorMessages sent by the proxy go to its successor.
                             //
@@ -1230,7 +1230,7 @@ impl ConductorHostRole for Agent {
         );
         MatchDispatchFrom::new(message, &client_connection)
             // Any incoming messages from the client are client-to-agent messages targeting the first component.
-            .if_message_from(Client, async move |message: Dispatch| {
+            .if_dispatch_from(Client, async move |message: Dispatch| {
                 tracing::debug!(
                     method = ?message.method(),
                     "ConductorToClient::handle_dispatch - matched Client"
@@ -1306,7 +1306,7 @@ impl ConductorHostRole for Proxy {
             "ConductorToConductor::handle_dispatch"
         );
         MatchDispatchFrom::new(message, &client_connection)
-            .if_message_from(Agent, {
+            .if_dispatch_from(Agent, {
                 // Messages from our successor arrive already unwrapped
                 // (RemoteRoleStyle::Successor strips the SuccessorMessage envelope).
                 async |message: Dispatch| {
@@ -1321,7 +1321,7 @@ impl ConductorHostRole for Proxy {
             })
             .await
             // Any incoming messages from the client are client-to-agent messages targeting the first component.
-            .if_message_from(Client, async |message: Dispatch| {
+            .if_dispatch_from(Client, async |message: Dispatch| {
                 tracing::debug!(
                     method = ?message.method(),
                     "ConductorToConductor::handle_dispatch - matched Client"

--- a/src/agent-client-protocol-conductor/src/conductor.rs
+++ b/src/agent-client-protocol-conductor/src/conductor.rs
@@ -481,7 +481,7 @@ where
                     notification,
                 )
             }
-            Dispatch::Response(result, router) => router.respond_with_result(result),
+            Dispatch::Response(result, router) => router.route_with_result(result),
         }
     }
 

--- a/src/agent-client-protocol-conductor/tests/meta_propagation.rs
+++ b/src/agent-client-protocol-conductor/tests/meta_propagation.rs
@@ -75,12 +75,12 @@ impl HandleDispatchFrom<Conductor> for ForwardMessages {
         connection: ConnectionTo<Conductor>,
     ) -> Result<Handled<Dispatch>, agent_client_protocol::Error> {
         MatchDispatchFrom::new(message, &connection)
-            .if_message_from(Client, async |message: Dispatch| {
+            .if_dispatch_from(Client, async |message: Dispatch| {
                 connection.send_proxied_message_to(Agent, message)?;
                 Ok(Handled::Yes)
             })
             .await
-            .if_message_from(Agent, async |message: Dispatch| {
+            .if_dispatch_from(Agent, async |message: Dispatch| {
                 connection.send_proxied_message_to(Client, message)?;
                 Ok(Handled::Yes)
             })

--- a/src/agent-client-protocol-conductor/tests/request_cancellation.rs
+++ b/src/agent-client-protocol-conductor/tests/request_cancellation.rs
@@ -152,7 +152,7 @@ async fn client_cancellation_propagates_hop_by_hop_to_agent() -> Result<(), Erro
                         responder: Responder<SimpleResponse>,
                         cx: ConnectionTo<Client>| {
                 if request.message == "park" {
-                    parked_id_tx.unbounded_send(responder.id()).unwrap();
+                    parked_id_tx.unbounded_send(responder.id().clone()).unwrap();
                     let cancellation = responder.cancellation();
                     cx.spawn(async move {
                         let response = cancellation
@@ -212,7 +212,7 @@ async fn client_cancellation_propagates_hop_by_hop_to_agent() -> Result<(), Erro
                     let request: SentRequest<SimpleResponse> = cx.send_request(SimpleRequest {
                         message: "park".into(),
                     });
-                    let client_request_id = request.id();
+                    let client_request_id = request.id().clone();
                     request.cancel()?;
 
                     // The cancellation reaches the agent hop by hop, and the
@@ -252,7 +252,7 @@ async fn client_cancellation_propagates_hop_by_hop_to_agent() -> Result<(), Erro
         "each hop must re-issue the request under its own ID"
     );
     let observed = next_with_timeout(&mut agent_cancel_rx).await;
-    assert_eq!(serde_json::to_value(observed).unwrap(), parked_id);
+    assert_eq!(observed, parked_id);
     assert_no_event(&mut agent_cancel_rx);
 
     conductor_handle.abort();
@@ -334,7 +334,7 @@ async fn agent_cancellation_propagates_hop_by_hop_to_client() -> Result<(), Erro
                             responder: Responder<SimpleResponse>,
                             cx: ConnectionTo<Agent>| {
                     assert_eq!(request.message, "park");
-                    parked_id_tx.unbounded_send(responder.id()).unwrap();
+                    parked_id_tx.unbounded_send(responder.id().clone()).unwrap();
                     let cancellation = responder.cancellation();
                     cx.spawn(async move {
                         let response = cancellation
@@ -399,7 +399,7 @@ async fn agent_cancellation_propagates_hop_by_hop_to_client() -> Result<(), Erro
     // its own connection.
     let parked_id = next_with_timeout(&mut parked_id_rx).await;
     let observed = next_with_timeout(&mut client_cancel_rx).await;
-    assert_eq!(serde_json::to_value(observed).unwrap(), parked_id);
+    assert_eq!(observed, parked_id);
     assert_no_event(&mut client_cancel_rx);
 
     conductor_handle.abort();
@@ -461,7 +461,7 @@ async fn prompt_cancellation_cascades_through_real_proxy_chain() -> Result<(), E
                     return responder.respond(PromptResponse::new(StopReason::EndTurn));
                 }
 
-                prompt_id_tx.unbounded_send(responder.id()).unwrap();
+                prompt_id_tx.unbounded_send(responder.id().clone()).unwrap();
                 let cancellation = responder.cancellation();
                 let connection = cx.clone();
                 cx.spawn(async move {
@@ -534,7 +534,9 @@ async fn prompt_cancellation_cascades_through_real_proxy_chain() -> Result<(), E
                 async move |_request: RequestPermissionRequest,
                             responder: Responder<RequestPermissionResponse>,
                             cx: ConnectionTo<Agent>| {
-                    permission_id_tx.unbounded_send(responder.id()).unwrap();
+                    permission_id_tx
+                        .unbounded_send(responder.id().clone())
+                        .unwrap();
                     let cancellation = responder.cancellation();
                     cx.spawn(async move {
                         let response = cancellation
@@ -588,7 +590,7 @@ async fn prompt_cancellation_cascades_through_real_proxy_chain() -> Result<(), E
                         session.session_id.clone(),
                         vec!["park".into()],
                     ));
-                    let client_prompt_id = prompt.id();
+                    let client_prompt_id = prompt.id().clone();
                     prompt.cancel()?;
 
                     let error = prompt
@@ -627,14 +629,14 @@ async fn prompt_cancellation_cascades_through_real_proxy_chain() -> Result<(), E
         "each hop must re-issue the request under its own ID"
     );
     let observed = next_with_timeout(&mut agent_cancel_rx).await;
-    assert_eq!(serde_json::to_value(observed).unwrap(), prompt_id);
+    assert_eq!(observed, prompt_id);
     assert_no_event(&mut agent_cancel_rx);
 
     // The client saw exactly one `$/cancel_request` (for the permission
     // request), with the ID of that request on the client's own connection.
     let permission_id = next_with_timeout(&mut permission_id_rx).await;
     let observed = next_with_timeout(&mut client_cancel_rx).await;
-    assert_eq!(serde_json::to_value(observed).unwrap(), permission_id);
+    assert_eq!(observed, permission_id);
     assert_no_event(&mut client_cancel_rx);
 
     // The barrier prompt's session update was transformed by the arrow proxy.
@@ -666,7 +668,7 @@ async fn session_new_cancellation_propagates_through_proxy() -> Result<(), Error
                         responder: Responder<NewSessionResponse>,
                         cx: ConnectionTo<Client>| {
                 if request.cwd.ends_with("park-session") {
-                    parked_id_tx.unbounded_send(responder.id()).unwrap();
+                    parked_id_tx.unbounded_send(responder.id().clone()).unwrap();
                     let cancellation = responder.cancellation();
                     cx.spawn(async move {
                         let response = cancellation
@@ -722,7 +724,7 @@ async fn session_new_cancellation_propagates_through_proxy() -> Result<(), Error
 
                     let request: SentRequest<NewSessionResponse> =
                         cx.send_request(NewSessionRequest::new("/park-session"));
-                    let client_request_id = request.id();
+                    let client_request_id = request.id().clone();
                     request.cancel()?;
 
                     let error = request
@@ -758,7 +760,7 @@ async fn session_new_cancellation_propagates_through_proxy() -> Result<(), Error
         "each hop must re-issue the request under its own ID"
     );
     let observed = next_with_timeout(&mut agent_cancel_rx).await;
-    assert_eq!(serde_json::to_value(observed).unwrap(), parked_id);
+    assert_eq!(observed, parked_id);
     assert_no_event(&mut agent_cancel_rx);
 
     conductor_handle.abort();
@@ -785,7 +787,7 @@ async fn proxy_session_helper_cancellation_propagates_to_agent() -> Result<(), E
                         responder: Responder<NewSessionResponse>,
                         cx: ConnectionTo<Client>| {
                 if request.cwd.ends_with("park-session") {
-                    parked_id_tx.unbounded_send(responder.id()).unwrap();
+                    parked_id_tx.unbounded_send(responder.id().clone()).unwrap();
                     let cancellation = responder.cancellation();
                     cx.spawn(async move {
                         let response = cancellation
@@ -850,7 +852,7 @@ async fn proxy_session_helper_cancellation_propagates_to_agent() -> Result<(), E
 
                     let request: SentRequest<NewSessionResponse> =
                         cx.send_request(NewSessionRequest::new("/park-session"));
-                    let client_request_id = request.id();
+                    let client_request_id = request.id().clone();
                     request.cancel()?;
 
                     let error = request
@@ -882,7 +884,7 @@ async fn proxy_session_helper_cancellation_propagates_to_agent() -> Result<(), E
         "each hop must re-issue the request under its own ID"
     );
     let observed = next_with_timeout(&mut agent_cancel_rx).await;
-    assert_eq!(serde_json::to_value(observed).unwrap(), parked_id);
+    assert_eq!(observed, parked_id);
     assert_no_event(&mut agent_cancel_rx);
 
     conductor_handle.abort();
@@ -926,7 +928,7 @@ async fn proxy_session_helper_cleans_up_mcp_handlers_after_cancelled_session() -
                             .lock()
                             .expect("cancelled MCP ID mutex poisoned") =
                             Some(advertised_mcp_acp_id);
-                        parked_id_tx.unbounded_send(responder.id()).unwrap();
+                        parked_id_tx.unbounded_send(responder.id().clone()).unwrap();
                         let cancellation = responder.cancellation();
                         cx.spawn(async move {
                             let response = cancellation
@@ -1046,7 +1048,7 @@ async fn proxy_session_helper_cleans_up_mcp_handlers_after_cancelled_session() -
 
                     let request: SentRequest<NewSessionResponse> =
                         cx.send_request(NewSessionRequest::new("/park-session"));
-                    let client_request_id = request.id();
+                    let client_request_id = request.id().clone();
                     request.cancel()?;
 
                     let error = request
@@ -1080,7 +1082,7 @@ async fn proxy_session_helper_cleans_up_mcp_handlers_after_cancelled_session() -
         "each hop must re-issue the request under its own ID"
     );
     let observed = next_with_timeout(&mut agent_cancel_rx).await;
-    assert_eq!(serde_json::to_value(observed).unwrap(), parked_id);
+    assert_eq!(observed, parked_id);
     assert_no_event(&mut agent_cancel_rx);
 
     assert_eq!(
@@ -1110,7 +1112,7 @@ async fn initialize_cancellation_propagates_through_proxy() -> Result<(), Error>
                         responder: Responder<InitializeResponse>,
                         cx: ConnectionTo<Client>| {
                 if !parked_first.swap(true, Ordering::SeqCst) {
-                    parked_id_tx.unbounded_send(responder.id()).unwrap();
+                    parked_id_tx.unbounded_send(responder.id().clone()).unwrap();
                     let cancellation = responder.cancellation();
                     cx.spawn(async move {
                         let response = cancellation
@@ -1164,7 +1166,7 @@ async fn initialize_cancellation_propagates_through_proxy() -> Result<(), Error>
                 async |cx| {
                     let request: SentRequest<InitializeResponse> =
                         cx.send_request(InitializeRequest::new(ProtocolVersion::V1));
-                    let client_request_id = request.id();
+                    let client_request_id = request.id().clone();
                     request.cancel()?;
 
                     let error = request
@@ -1198,7 +1200,7 @@ async fn initialize_cancellation_propagates_through_proxy() -> Result<(), Error>
         "each hop must re-issue the request under its own ID"
     );
     let observed = next_with_timeout(&mut agent_cancel_rx).await;
-    assert_eq!(serde_json::to_value(observed).unwrap(), parked_id);
+    assert_eq!(observed, parked_id);
     assert_no_event(&mut agent_cancel_rx);
 
     conductor_handle.abort();

--- a/src/agent-client-protocol-conductor/tests/request_cancellation.rs
+++ b/src/agent-client-protocol-conductor/tests/request_cancellation.rs
@@ -62,7 +62,9 @@ impl<Counterpart: Role> McpServerConnect<Counterpart> for TrackingMcpServer {
     }
 
     fn connect(&self, cx: McpConnectionTo<Counterpart>) -> DynConnectTo<role::mcp::Client> {
-        self.connect_tx.unbounded_send(cx.acp_id()).unwrap();
+        self.connect_tx
+            .unbounded_send(cx.acp_id().to_owned())
+            .unwrap();
         DynConnectTo::new(EmptyMcpServerComponent)
     }
 }

--- a/src/agent-client-protocol-conductor/tests/test_session_id_in_mcp_tools.rs
+++ b/src/agent-client-protocol-conductor/tests/test_session_id_in_mcp_tools.rs
@@ -38,7 +38,7 @@ fn create_echo_proxy() -> DynConnectTo<Conductor> {
             "Returns the current session_id",
             async |_input: EchoInput, context| {
                 Ok(EchoOutput {
-                    acp_id: context.acp_id(),
+                    acp_id: context.acp_id().to_owned(),
                 })
             },
             agent_client_protocol::tool_fn_mut!(),

--- a/src/agent-client-protocol-cookbook/src/lib.rs
+++ b/src/agent-client-protocol-cookbook/src/lib.rs
@@ -219,7 +219,7 @@ pub mod building_an_agent {
     //! # Minimal Example
     //!
     //! ```
-    //! use agent_client_protocol::{Agent, Client, ConnectTo, Dispatch, ConnectionTo};
+    //! use agent_client_protocol::{Agent, ConnectTo};
     //! use agent_client_protocol::schema::v1::{
     //!     InitializeRequest, InitializeResponse, AgentCapabilities,
     //!     NewSessionRequest, NewSessionResponse, SessionId,
@@ -248,11 +248,8 @@ pub mod building_an_agent {
     //!             // Return final response
     //!             responder.respond(PromptResponse::new(StopReason::EndTurn))
     //!         }, agent_client_protocol::on_receive_request!())
-    //!         // Reject unknown requests. Notifications are ignored because
-    //!         // they cannot receive responses.
-    //!         .on_receive_dispatch(async |message: Dispatch, _connection: ConnectionTo<Client>| {
-    //!             message.respond_with_error(agent_client_protocol::Error::method_not_found())
-    //!         }, agent_client_protocol::on_receive_dispatch!())
+    //!         // Unknown requests receive Method not found automatically;
+    //!         // unhandled notifications are ignored.
     //!         .connect_to(transport)
     //!         .await
     //! }

--- a/src/agent-client-protocol-polyfill/src/mcp_over_acp/mod.rs
+++ b/src/agent-client-protocol-polyfill/src/mcp_over_acp/mod.rs
@@ -144,7 +144,7 @@ impl ConnectTo<Conductor> for McpOverAcpPolyfill {
         Proxy
             .builder()
             .name("mcp-over-acp-polyfill")
-            .with_responder(BridgeResponder {
+            .with_runner(BridgeResponder {
                 bridge_tx: bridge_tx.clone(),
                 bridge_rx,
                 bridge_connections: HashMap::new(),

--- a/src/agent-client-protocol/CHANGELOG.md
+++ b/src/agent-client-protocol/CHANGELOG.md
@@ -25,6 +25,9 @@
 - **Breaking:** Return borrowed identifiers, connection handles, modes, and metadata from
   `McpConnectionTo` and `ActiveSession`; remove `acp_url` and rename `connection_to` to
   `connection`. See the [2.0 migration guide](../../md/migration_v2.0.md).
+- **Breaking:** Narrow low-level helpers by borrowing `DynConnectTo` type names, hiding transport
+  fields and session/stream internals, and removing `util::both`. See the
+  [2.0 migration guide](../../md/migration_v2.0.md).
 - **Breaking:** Replace the MCP wire-schema configuration accepted by `AcpAgent` with the SDK-local
   `AcpAgentConfig`; use `config()` and `into_config()`, and represent JSON environment variables as
   an object.

--- a/src/agent-client-protocol/CHANGELOG.md
+++ b/src/agent-client-protocol/CHANGELOG.md
@@ -22,6 +22,9 @@
 - **Breaking:** Rename `MatchDispatch::if_message` to `if_dispatch` and
   `MatchDispatchFrom::if_message_from` to `if_dispatch_from`. See the
   [2.0 migration guide](../../md/migration_v2.0.md).
+- **Breaking:** Return borrowed identifiers, connection handles, modes, and metadata from
+  `McpConnectionTo` and `ActiveSession`; remove `acp_url` and rename `connection_to` to
+  `connection`. See the [2.0 migration guide](../../md/migration_v2.0.md).
 - **Breaking:** Replace the MCP wire-schema configuration accepted by `AcpAgent` with the SDK-local
   `AcpAgentConfig`; use `config()` and `into_config()`, and represent JSON environment variables as
   an object.

--- a/src/agent-client-protocol/CHANGELOG.md
+++ b/src/agent-client-protocol/CHANGELOG.md
@@ -19,6 +19,9 @@
 - **Breaking:** Rename `Builder::with_responder` to `with_runner` to describe background
   connection tasks separately from JSON-RPC response handles. See the
   [2.0 migration guide](../../md/migration_v2.0.md).
+- **Breaking:** Rename `MatchDispatch::if_message` to `if_dispatch` and
+  `MatchDispatchFrom::if_message_from` to `if_dispatch_from`. See the
+  [2.0 migration guide](../../md/migration_v2.0.md).
 - **Breaking:** Replace the MCP wire-schema configuration accepted by `AcpAgent` with the SDK-local
   `AcpAgentConfig`; use `config()` and `into_config()`, and represent JSON environment variables as
   an object.

--- a/src/agent-client-protocol/CHANGELOG.md
+++ b/src/agent-client-protocol/CHANGELOG.md
@@ -10,6 +10,9 @@
 - **Breaking:** Rename `ResponseRouter` response methods to use routing terminology and return
   borrowed `RequestId` values from response and request handles. See the
   [2.0 migration guide](../../md/migration_v2.0.md).
+- **Breaking:** Replace cloneable dynamic-handler registrations with `DynamicHandlerGuard` and
+  use `detach()` to keep handlers registered without leaking a connection handle. See the
+  [2.0 migration guide](../../md/migration_v2.0.md).
 - **Breaking:** Replace the MCP wire-schema configuration accepted by `AcpAgent` with the SDK-local
   `AcpAgentConfig`; use `config()` and `into_config()`, and represent JSON environment variables as
   an object.

--- a/src/agent-client-protocol/CHANGELOG.md
+++ b/src/agent-client-protocol/CHANGELOG.md
@@ -16,6 +16,9 @@
 - **Breaking:** Replace cloneable dynamic-handler registrations with `DynamicHandlerGuard` and
   use `detach()` to keep handlers registered without leaking a connection handle. See the
   [2.0 migration guide](../../md/migration_v2.0.md).
+- **Breaking:** Rename `Builder::with_responder` to `with_runner` to describe background
+  connection tasks separately from JSON-RPC response handles. See the
+  [2.0 migration guide](../../md/migration_v2.0.md).
 - **Breaking:** Replace the MCP wire-schema configuration accepted by `AcpAgent` with the SDK-local
   `AcpAgentConfig`; use `config()` and `into_config()`, and represent JSON environment variables as
   an object.

--- a/src/agent-client-protocol/CHANGELOG.md
+++ b/src/agent-client-protocol/CHANGELOG.md
@@ -10,6 +10,9 @@
 - **Breaking:** Rename `ResponseRouter` response methods to use routing terminology and return
   borrowed `RequestId` values from response and request handles. See the
   [2.0 migration guide](../../md/migration_v2.0.md).
+- **Breaking:** Remove ambiguous JSON-RPC error-response and dispatch-conversion helpers, and
+  require `Dispatch` notification types to implement `JsonRpcNotification`. See the
+  [2.0 migration guide](../../md/migration_v2.0.md).
 - **Breaking:** Replace cloneable dynamic-handler registrations with `DynamicHandlerGuard` and
   use `detach()` to keep handlers registered without leaking a connection handle. See the
   [2.0 migration guide](../../md/migration_v2.0.md).

--- a/src/agent-client-protocol/CHANGELOG.md
+++ b/src/agent-client-protocol/CHANGELOG.md
@@ -7,6 +7,9 @@
 - **Breaking:** Make `Channel` the batch-aware `TransportFrame` boundary and remove the hidden
   `FramedChannel` compatibility path. See the
   [2.0 migration guide](../../md/migration_v2.0.md).
+- **Breaking:** Rename `ResponseRouter` response methods to use routing terminology and return
+  borrowed `RequestId` values from response and request handles. See the
+  [2.0 migration guide](../../md/migration_v2.0.md).
 - **Breaking:** Replace the MCP wire-schema configuration accepted by `AcpAgent` with the SDK-local
   `AcpAgentConfig`; use `config()` and `into_config()`, and represent JSON environment variables as
   an object.

--- a/src/agent-client-protocol/examples/simple_agent.rs
+++ b/src/agent-client-protocol/examples/simple_agent.rs
@@ -1,5 +1,5 @@
 use agent_client_protocol::schema::v1::{AgentCapabilities, InitializeRequest, InitializeResponse};
-use agent_client_protocol::{Agent, Client, ConnectionTo, Dispatch, Result, Stdio};
+use agent_client_protocol::{Agent, Result, Stdio};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -15,16 +15,6 @@ async fn main() -> Result<()> {
                 )
             },
             agent_client_protocol::on_receive_request!(),
-        )
-        .on_receive_dispatch(
-            async move |message: Dispatch, _cx: ConnectionTo<Client>| {
-                // Reject unhandled requests. Notifications are ignored because
-                // JSON-RPC notifications cannot receive responses.
-                message.respond_with_error(agent_client_protocol::util::internal_error(
-                    "unhandled message",
-                ))
-            },
-            agent_client_protocol::on_receive_dispatch!(),
         )
         .connect_to(Stdio::new())
         .await

--- a/src/agent-client-protocol/src/component.rs
+++ b/src/agent-client-protocol/src/component.rs
@@ -166,7 +166,7 @@ pub trait ConnectTo<R: Role>: Send + 'static {
 /// [`ConnectTo`] instead, which is automatically converted to `ErasedConnectTo`
 /// via a blanket implementation.
 trait ErasedConnectTo<R: Role>: Send {
-    fn type_name(&self) -> String;
+    fn type_name(&self) -> &'static str;
 
     fn connect_to_erased(
         self: Box<Self>,
@@ -179,8 +179,8 @@ trait ErasedConnectTo<R: Role>: Send {
 
 /// Blanket implementation: any `Serve<R>` can be type-erased.
 impl<C: ConnectTo<R>, R: Role> ErasedConnectTo<R> for C {
-    fn type_name(&self) -> String {
-        std::any::type_name::<C>().to_string()
+    fn type_name(&self) -> &'static str {
+        std::any::type_name::<C>()
     }
 
     fn connect_to_erased(
@@ -239,7 +239,7 @@ impl<R: Role> DynConnectTo<R> {
 
     /// Returns the type name of the wrapped component.
     #[must_use]
-    pub fn type_name(&self) -> String {
+    pub fn type_name(&self) -> &'static str {
         self.inner.type_name()
     }
 }
@@ -258,8 +258,27 @@ impl<R: Role> ConnectTo<R> for DynConnectTo<R> {
 
 impl<R: Role> Debug for DynConnectTo<R> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DynServe")
+        f.debug_struct("DynConnectTo")
             .field("type_name", &self.type_name())
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::role::UntypedRole;
+
+    #[test]
+    fn dyn_connect_to_reports_static_type_name_and_correct_debug_label() {
+        let (channel, _other) = Channel::duplex();
+        let component = DynConnectTo::<UntypedRole>::new(channel);
+
+        let type_name: &'static str = component.type_name();
+        assert_eq!(type_name, std::any::type_name::<Channel>());
+        assert_eq!(
+            format!("{component:?}"),
+            format!("DynConnectTo {{ type_name: {type_name:?} }}")
+        );
     }
 }

--- a/src/agent-client-protocol/src/jsonrpc.rs
+++ b/src/agent-client-protocol/src/jsonrpc.rs
@@ -585,7 +585,7 @@ fn params_from_transport(params: Option<RawJsonRpcParams>) -> serde_json::Value 
 /// For an agent handler, `R = Agent` (I handle messages as an agent).
 /// For a client handler, `R = Client` (I handle messages as a client).
 pub trait HandleDispatchFrom<Counterpart: Role>: Send {
-    /// Attempt to claim an incoming message (request or notification).
+    /// Attempt to claim an incoming dispatch (request, notification, or response).
     ///
     /// # Important: do not block
     ///
@@ -602,7 +602,8 @@ pub trait HandleDispatchFrom<Counterpart: Role>: Send {
     ///
     /// * `Ok(Handled::Yes)` if the message was claimed. It will not be propagated further.
     /// * `Ok(Handled::No(message))` if not; the (possibly changed) message will be passed to the remaining handlers.
-    /// * `Err` if an internal error occurs (this will bring down the server).
+    /// * `Err` if processing fails. Requests receive an Error Response; notification
+    ///   and response errors are logged without a wire reply.
     fn handle_dispatch_from(
         &mut self,
         message: Dispatch,
@@ -716,7 +717,8 @@ where
 ///
 /// ## Mixed Message Types
 ///
-/// For enums containing both requests AND notifications, use [`on_receive_dispatch`](Self::on_receive_dispatch):
+/// To handle requests, notifications, and responses in one callback, use
+/// [`on_receive_dispatch`](Self::on_receive_dispatch):
 ///
 /// ```no_run
 /// # use agent_client_protocol_test::*;
@@ -750,7 +752,7 @@ where
 ///
 /// * [`on_receive_request`](Self::on_receive_request) - Handle JSON-RPC requests (messages expecting responses)
 /// * [`on_receive_notification`](Self::on_receive_notification) - Handle JSON-RPC notifications (fire-and-forget)
-/// * [`on_receive_dispatch`](Self::on_receive_dispatch) - Handle enums containing both requests and notifications
+/// * [`on_receive_dispatch`](Self::on_receive_dispatch) - Handle requests, notifications, and responses in one callback
 /// * [`with_handler`](Self::with_handler) - Low-level primitive for maximum flexibility
 ///
 /// ## Handler Ordering
@@ -760,7 +762,6 @@ where
 ///
 /// ```no_run
 /// # use agent_client_protocol_test::*;
-/// # use agent_client_protocol::{Dispatch, UntypedMessage};
 /// # use agent_client_protocol::schema::v1::{InitializeRequest, InitializeResponse, PromptRequest, PromptResponse};
 /// # async fn example() -> Result<(), agent_client_protocol::Error> {
 /// # let connection = mock_connection();
@@ -773,11 +774,8 @@ where
 ///         // This runs first for PromptRequest
 ///         responder.respond(PromptResponse::make())
 ///     }, agent_client_protocol::on_receive_request!())
-///     .on_receive_dispatch(async |msg: Dispatch, _cx| {
-///         // Reject unhandled requests. Notifications are ignored because they
-///         // cannot receive responses.
-///         msg.respond_with_error(agent_client_protocol::util::internal_error("unknown method"))
-///     }, agent_client_protocol::on_receive_dispatch!())
+///     // Unknown requests receive Method not found automatically; unhandled
+///     // notifications are ignored.
 /// # .connect_to(agent_client_protocol_test::MockTransport).await?;
 /// # Ok(())
 /// # }
@@ -1174,11 +1172,10 @@ impl<
         }
     }
 
-    /// Register a handler for messages that can be either requests OR notifications.
+    /// Register a handler for requests, notifications, and responses.
     ///
-    /// Use this when you want to handle an enum type that contains both request and
-    /// notification variants. Your handler receives a [`Dispatch<Req, Notif>`] which
-    /// is an enum with two variants:
+    /// Use this when you want to handle all JSON-RPC message kinds in one callback.
+    /// Your handler receives a [`Dispatch<Req, Notif>`] with three variants:
     ///
     /// - `Dispatch::Request(request, responder)` - A request with its response context
     /// - `Dispatch::Notification(notification)` - A notification
@@ -1563,7 +1560,9 @@ impl<
     /// and dispatching them to your registered handlers. The connection will run until:
     /// - The transport closes (e.g., EOF on byte streams)
     /// - An error occurs
-    /// - One of your handlers returns an error
+    ///
+    /// Handler errors are normally contained: requests receive an Error Response,
+    /// while notification and response errors are logged without a wire reply.
     ///
     /// On clean EOF, messages already accepted by the outgoing queue—including
     /// handler responses and close-callback notifications—are drained through
@@ -3856,14 +3855,16 @@ pub trait JsonRpcRequest: JsonRpcMessage {
     type Response: JsonRpcResponse;
 }
 
-/// An enum capturing an in-flight request or notification.
-/// In the case of a request, also includes the context used to respond to the request.
+/// An incoming request, notification, or response being dispatched through handlers.
+/// Requests include the context used to answer them; responses include the context
+/// used to route them to the local requester.
 ///
 /// Type parameters allow specifying the concrete request and notification types.
 /// By default, both are `UntypedMessage` for dynamic dispatch.
 /// The request context's response type matches the request's response type.
 #[derive(Debug)]
-pub enum Dispatch<Req: JsonRpcRequest = UntypedMessage, Notif: JsonRpcMessage = UntypedMessage> {
+pub enum Dispatch<Req: JsonRpcRequest = UntypedMessage, Notif: JsonRpcNotification = UntypedMessage>
+{
     /// Incoming request and the context where the response should be sent.
     Request(Req, Responder<Req::Response>),
 
@@ -3881,7 +3882,7 @@ pub enum Dispatch<Req: JsonRpcRequest = UntypedMessage, Notif: JsonRpcMessage = 
     ),
 }
 
-impl<Req: JsonRpcRequest, Notif: JsonRpcMessage> Dispatch<Req, Notif> {
+impl<Req: JsonRpcRequest, Notif: JsonRpcNotification> Dispatch<Req, Notif> {
     /// Map the request and notification types to new types.
     ///
     /// Note: Response variants are passed through unchanged since they don't
@@ -3893,7 +3894,7 @@ impl<Req: JsonRpcRequest, Notif: JsonRpcMessage> Dispatch<Req, Notif> {
     ) -> Dispatch<Req1, Notif1>
     where
         Req1: JsonRpcRequest<Response = Req::Response>,
-        Notif1: JsonRpcMessage,
+        Notif1: JsonRpcNotification,
     {
         match self {
             Dispatch::Request(request, responder) => {
@@ -3905,49 +3906,6 @@ impl<Req: JsonRpcRequest, Notif: JsonRpcMessage> Dispatch<Req, Notif> {
                 Dispatch::Notification(new_notification)
             }
             Dispatch::Response(result, router) => Dispatch::Response(result, router),
-        }
-    }
-
-    /// Respond to the message with an error.
-    ///
-    /// If this message is a request, this error becomes the reply to the request.
-    ///
-    /// If this message is a notification, the error is logged and ignored because
-    /// JSON-RPC notifications cannot be answered.
-    ///
-    /// If this message is a response, the error is forwarded to the waiting handler.
-    pub fn respond_with_error(self, error: crate::Error) -> Result<(), crate::Error> {
-        match self {
-            Dispatch::Request(_, responder) => responder.respond_with_error(error),
-            Dispatch::Notification(_) => {
-                tracing::warn!(
-                    ?error,
-                    "Ignoring attempted error response to a JSON-RPC notification"
-                );
-                Ok(())
-            }
-            Dispatch::Response(_, router) => router.route_with_error(error),
-        }
-    }
-
-    /// Convert to a `Responder` that expects a JSON value
-    /// and which checks (dynamically) that the JSON value it receives
-    /// can be converted to `T`.
-    ///
-    /// Note: Response variants cannot be erased since their payload is already
-    /// parsed. This returns an error for Response variants.
-    pub fn erase_to_json(self) -> Result<Dispatch, crate::Error> {
-        match self {
-            Dispatch::Request(response, responder) => Ok(Dispatch::Request(
-                response.to_untyped_message()?,
-                responder.erase_to_json(),
-            )),
-            Dispatch::Notification(notification) => {
-                Ok(Dispatch::Notification(notification.to_untyped_message()?))
-            }
-            Dispatch::Response(_, _) => Err(crate::util::internal_error(
-                "cannot erase Response variant to JSON",
-            )),
         }
     }
 

--- a/src/agent-client-protocol/src/jsonrpc.rs
+++ b/src/agent-client-protocol/src/jsonrpc.rs
@@ -5054,10 +5054,8 @@ impl<T: JsonRpcResponse> SentRequest<T> {
 /// [`ConnectTo`]: crate::ConnectTo
 #[derive(Debug)]
 pub struct Lines<OutgoingSink, IncomingStream> {
-    /// Outgoing line sink (where we write serialized JSON-RPC messages)
-    pub outgoing: OutgoingSink,
-    /// Incoming line stream (where we read and parse JSON-RPC messages)
-    pub incoming: IncomingStream,
+    outgoing: OutgoingSink,
+    incoming: IncomingStream,
 }
 
 impl<OutgoingSink, IncomingStream> Lines<OutgoingSink, IncomingStream>
@@ -5196,10 +5194,8 @@ where
 /// [`ConnectTo`]: crate::ConnectTo
 #[derive(Debug)]
 pub struct ByteStreams<OB, IB> {
-    /// Outgoing byte stream (where we write serialized messages)
-    pub outgoing: OB,
-    /// Incoming byte stream (where we read and parse messages)
-    pub incoming: IB,
+    outgoing: OB,
+    incoming: IB,
 }
 
 impl<OB, IB> ByteStreams<OB, IB>

--- a/src/agent-client-protocol/src/jsonrpc.rs
+++ b/src/agent-client-protocol/src/jsonrpc.rs
@@ -724,7 +724,7 @@ where
 /// # use agent_client_protocol::schema::v1::{InitializeRequest, InitializeResponse, SessionNotification};
 /// # async fn example() -> Result<(), agent_client_protocol::Error> {
 /// # let connection = mock_connection();
-/// // on_receive_dispatch receives Dispatch which can be either a request or notification
+/// // on_receive_dispatch receives requests, notifications, and responses
 /// connection.on_receive_dispatch(async |msg: Dispatch<InitializeRequest, SessionNotification>, _cx| {
 ///     match msg {
 ///         Dispatch::Request(req, responder) => {
@@ -735,7 +735,7 @@ where
 ///         }
 ///         Dispatch::Response(result, router) => {
 ///             // Forward response to its destination
-///             router.respond_with_result(result)
+///             router.route_with_result(result)
 ///         }
 ///     }
 /// }, agent_client_protocol::on_receive_dispatch!())
@@ -1203,7 +1203,7 @@ impl<
     ///         }
     ///         Dispatch::Response(result, router) => {
     ///             // Forward response to its destination
-    ///             router.respond_with_result(result)
+    ///             router.route_with_result(result)
     ///         }
     ///     }
     /// }, agent_client_protocol::on_receive_dispatch!())
@@ -3036,7 +3036,7 @@ impl<Counterpart: Role> ConnectionTo<Counterpart> {
             }
             Dispatch::Response(result, router) => {
                 // Responses are forwarded directly to their destination
-                router.respond_with_result(result)
+                router.route_with_result(result)
             }
         }
     }
@@ -3481,10 +3481,10 @@ impl<T: JsonRpcResponse> Responder<T> {
         &self.method
     }
 
-    /// ID of the incoming request/response as a JSON value
+    /// ID of the incoming request.
     #[must_use]
-    pub fn id(&self) -> serde_json::Value {
-        crate::util::id_to_json(&self.id)
+    pub fn id(&self) -> &RequestId {
+        &self.id
     }
 
     /// Returns the cancellation marker for this request.
@@ -3584,7 +3584,7 @@ impl<T: JsonRpcResponse> Responder<T> {
 ///
 /// # Drop Behavior
 ///
-/// Dropping a `ResponseRouter` without responding (for example, from a
+/// Dropping a `ResponseRouter` without routing the response (for example, from a
 /// dispatch handler that claims a [`Dispatch::Response`]) discards the
 /// response: the local awaiter observes the response as never received. The
 /// request still counts as settled: routing a response this far disarms the
@@ -3619,7 +3619,7 @@ impl<T: JsonRpcResponse> std::fmt::Debug for ResponseRouter<T> {
 impl ResponseRouter<serde_json::Value> {
     /// Create a new response context for routing a response to a local awaiter.
     ///
-    /// When `respond_with_result` is called, the response is sent through the oneshot
+    /// When [`route_with_result`](Self::route_with_result) is called, the response is sent through the oneshot
     /// channel to the code that originally sent the request. If that receiver was
     /// dropped, the response is discarded because there is no local awaiter left.
     pub(crate) fn new(
@@ -3677,10 +3677,10 @@ impl<T: JsonRpcResponse> ResponseRouter<T> {
         &self.method
     }
 
-    /// ID of the original request as a JSON value
+    /// ID of the original request.
     #[must_use]
-    pub fn id(&self) -> serde_json::Value {
-        crate::util::id_to_json(&self.id)
+    pub fn id(&self) -> &RequestId {
+        &self.id
     }
 
     /// The peer to which the original request was sent.
@@ -3718,29 +3718,26 @@ impl<T: JsonRpcResponse> ResponseRouter<T> {
         }
     }
 
-    /// Complete the response by sending the result to the waiting task.
-    pub fn respond_with_result(
-        self,
-        response: Result<T, crate::Error>,
-    ) -> Result<(), crate::Error> {
+    /// Route the response result to the waiting task.
+    pub fn route_with_result(self, response: Result<T, crate::Error>) -> Result<(), crate::Error> {
         tracing::debug!(id = ?self.id, "response routed to awaiter");
         (self.send_fn)(response)
     }
 
-    /// Complete the response by sending a value to the waiting task.
-    pub fn respond(self, response: T) -> Result<(), crate::Error> {
-        self.respond_with_result(Ok(response))
+    /// Route a successful response value to the waiting task.
+    pub fn route(self, response: T) -> Result<(), crate::Error> {
+        self.route_with_result(Ok(response))
     }
 
-    /// Complete the response by sending an internal error to the waiting task.
-    pub fn respond_with_internal_error(self, message: impl ToString) -> Result<(), crate::Error> {
-        self.respond_with_error(crate::util::internal_error(message))
+    /// Route an internal error to the waiting task.
+    pub fn route_with_internal_error(self, message: impl ToString) -> Result<(), crate::Error> {
+        self.route_with_error(crate::util::internal_error(message))
     }
 
-    /// Complete the response by sending an error to the waiting task.
-    pub fn respond_with_error(self, error: crate::Error) -> Result<(), crate::Error> {
+    /// Route an error response to the waiting task.
+    pub fn route_with_error(self, error: crate::Error) -> Result<(), crate::Error> {
         tracing::debug!(id = ?self.id, ?error, "error routed to awaiter");
-        self.respond_with_result(Err(error))
+        self.route_with_result(Err(error))
     }
 }
 
@@ -3915,7 +3912,7 @@ impl<Req: JsonRpcRequest, Notif: JsonRpcMessage> Dispatch<Req, Notif> {
                 );
                 Ok(())
             }
-            Dispatch::Response(_, responder) => responder.respond_with_error(error),
+            Dispatch::Response(_, router) => router.route_with_error(error),
         }
     }
 
@@ -3973,7 +3970,7 @@ impl<Req: JsonRpcRequest, Notif: JsonRpcMessage> Dispatch<Req, Notif> {
     }
 
     /// Returns the request ID if this is a request or response, None if notification.
-    pub fn id(&self) -> Option<serde_json::Value> {
+    pub fn id(&self) -> Option<&RequestId> {
         match self {
             Dispatch::Request(_, cx) => Some(cx.id()),
             Dispatch::Notification(_) => None,
@@ -4625,8 +4622,8 @@ impl<T> SentRequest<T> {
 impl<T: JsonRpcResponse> SentRequest<T> {
     /// The id of the outgoing request.
     #[must_use]
-    pub fn id(&self) -> serde_json::Value {
-        crate::util::id_to_json(&self.id)
+    pub fn id(&self) -> &RequestId {
+        &self.id
     }
 
     /// The method of the request this is in response to.

--- a/src/agent-client-protocol/src/jsonrpc.rs
+++ b/src/agent-client-protocol/src/jsonrpc.rs
@@ -3312,7 +3312,7 @@ impl<Counterpart: Role> ConnectionTo<Counterpart> {
     pub fn add_dynamic_handler(
         &self,
         handler: impl HandleDispatchFrom<Counterpart> + 'static,
-    ) -> Result<DynamicHandlerRegistration<Counterpart>, crate::Error> {
+    ) -> Result<DynamicHandlerGuard<Counterpart>, crate::Error> {
         let uuid = Uuid::new_v4();
         self.dynamic_handler_tx
             .unbounded_send(DynamicHandlerMessage::AddDynamicHandler(
@@ -3321,7 +3321,7 @@ impl<Counterpart: Role> ConnectionTo<Counterpart> {
             ))
             .map_err(crate::util::internal_error)?;
 
-        Ok(DynamicHandlerRegistration::new(uuid, self.clone()))
+        Ok(DynamicHandlerGuard::new(uuid, self.clone()))
     }
 
     fn remove_dynamic_handler(&self, uuid: Uuid) {
@@ -3333,26 +3333,40 @@ impl<Counterpart: Role> ConnectionTo<Counterpart> {
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct DynamicHandlerRegistration<R: Role> {
-    uuid: Uuid,
+/// A guard that keeps a dynamic message handler registered.
+///
+/// Dropping the guard unregisters the handler. Use [`detach`](Self::detach) to
+/// keep the handler registered for the remaining lifetime of the connection.
+#[must_use = "dropping this guard unregisters the dynamic handler"]
+#[derive(Debug)]
+pub struct DynamicHandlerGuard<R: Role> {
+    uuid: Option<Uuid>,
     cx: ConnectionTo<R>,
 }
 
-impl<R: Role> DynamicHandlerRegistration<R> {
+impl<R: Role> DynamicHandlerGuard<R> {
     fn new(uuid: Uuid, cx: ConnectionTo<R>) -> Self {
-        Self { uuid, cx }
+        Self {
+            uuid: Some(uuid),
+            cx,
+        }
     }
 
-    /// Prevents the dynamic handler from being removed when dropped.
-    pub fn run_indefinitely(self) {
-        std::mem::forget(self);
+    /// Keep the dynamic handler registered after this guard is dropped.
+    ///
+    /// The handler remains registered until the connection itself shuts down.
+    /// Unlike leaking the guard, detaching does not retain an extra
+    /// [`ConnectionTo`] handle.
+    pub fn detach(mut self) {
+        self.uuid = None;
     }
 }
 
-impl<R: Role> Drop for DynamicHandlerRegistration<R> {
+impl<R: Role> Drop for DynamicHandlerGuard<R> {
     fn drop(&mut self) {
-        self.cx.remove_dynamic_handler(self.uuid);
+        if let Some(uuid) = self.uuid {
+            self.cx.remove_dynamic_handler(uuid);
+        }
     }
 }
 
@@ -5419,6 +5433,76 @@ impl<R: Role> ConnectTo<R> for Channel {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn connection_with_dynamic_handler_receiver() -> (
+        ConnectionTo<crate::role::UntypedRole>,
+        mpsc::UnboundedReceiver<DynamicHandlerMessage<crate::role::UntypedRole>>,
+    ) {
+        let (message_tx, _message_rx) = mpsc::unbounded();
+        let (task_tx, _task_rx) = mpsc::unbounded();
+        let (dynamic_handler_tx, dynamic_handler_rx) = mpsc::unbounded();
+        let transport_completion: SharedTransportCompletion =
+            future::ready(Ok::<(), crate::Error>(())).boxed().shared();
+        let pending_replies = PendingReplies::default();
+
+        (
+            ConnectionTo::new(
+                crate::role::UntypedRole,
+                message_tx,
+                task_tx,
+                dynamic_handler_tx,
+                transport_completion,
+                pending_replies.registrar(),
+            ),
+            dynamic_handler_rx,
+        )
+    }
+
+    fn next_dynamic_handler_message(
+        receiver: &mut mpsc::UnboundedReceiver<DynamicHandlerMessage<crate::role::UntypedRole>>,
+    ) -> Option<DynamicHandlerMessage<crate::role::UntypedRole>> {
+        futures::FutureExt::now_or_never(futures::StreamExt::next(receiver))
+            .expect("dynamic-handler receiver should be ready")
+    }
+
+    #[test]
+    fn dropping_dynamic_handler_guard_unregisters_handler() {
+        let (connection, mut receiver) = connection_with_dynamic_handler_receiver();
+        let guard = connection.add_dynamic_handler(NullHandler).unwrap();
+
+        let added_uuid = match next_dynamic_handler_message(&mut receiver) {
+            Some(DynamicHandlerMessage::AddDynamicHandler(uuid, _)) => uuid,
+            other => panic!("expected handler registration, got {other:?}"),
+        };
+
+        drop(guard);
+
+        match next_dynamic_handler_message(&mut receiver) {
+            Some(DynamicHandlerMessage::RemoveDynamicHandler(uuid)) => {
+                assert_eq!(uuid, added_uuid);
+            }
+            other => panic!("expected handler removal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn detaching_dynamic_handler_guard_does_not_leak_connection() {
+        let (connection, mut receiver) = connection_with_dynamic_handler_receiver();
+        let guard = connection.add_dynamic_handler(NullHandler).unwrap();
+
+        assert!(matches!(
+            next_dynamic_handler_message(&mut receiver),
+            Some(DynamicHandlerMessage::AddDynamicHandler(_, _))
+        ));
+
+        drop(connection);
+        guard.detach();
+
+        assert!(
+            next_dynamic_handler_message(&mut receiver).is_none(),
+            "detach should retain the handler without retaining a connection sender"
+        );
+    }
 
     #[tokio::test]
     async fn write_line_flushes_buffered_writers() {

--- a/src/agent-client-protocol/src/jsonrpc.rs
+++ b/src/agent-client-protocol/src/jsonrpc.rs
@@ -943,8 +943,8 @@ where
     /// Handler for incoming messages.
     handler: Handler,
 
-    /// Responder for background tasks.
-    responder: Runner,
+    /// Runner for background connection tasks.
+    runner: Runner,
 
     /// Protocol version mode for the public API and wire compatibility layer.
     protocol_mode: ProtocolMode,
@@ -974,7 +974,7 @@ impl<Host: Role> Builder<Host, NullHandler, NullRun, NullClose> {
             host: role,
             name: None,
             handler: NullHandler,
-            responder: NullRun,
+            runner: NullRun,
             protocol_mode: default_protocol_mode::<Host>(),
             on_close: NullClose,
         }
@@ -991,7 +991,7 @@ where
             host: role,
             name: None,
             handler,
-            responder: NullRun,
+            runner: NullRun,
             protocol_mode: default_protocol_mode::<Host>(),
             on_close: NullClose,
         }
@@ -1054,7 +1054,7 @@ impl<
         let Builder {
             name: other_name,
             handler: other_handler,
-            responder: other_responder,
+            runner: other_runner,
             protocol_mode: other_protocol_mode,
             on_close: other_on_close,
             host: _,
@@ -1066,7 +1066,7 @@ impl<
                 self.handler,
                 NamedHandler::new(other_name, other_handler),
             ),
-            responder: ChainRun::new(self.responder, other_responder),
+            runner: ChainRun::new(self.runner, other_runner),
             protocol_mode: self.protocol_mode.merge(other_protocol_mode),
             on_close: ChainedClose::new(self.on_close, other_on_close),
         }
@@ -1084,16 +1084,16 @@ impl<
             host: self.host,
             name: self.name,
             handler: ChainedHandler::new(self.handler, handler),
-            responder: self.responder,
+            runner: self.runner,
             protocol_mode: self.protocol_mode,
             on_close: self.on_close,
         }
     }
 
     /// Add a new [`RunWithConnectionTo`] to the chain.
-    pub fn with_responder<Run1>(
+    pub fn with_runner<Run1>(
         self,
-        responder: Run1,
+        runner: Run1,
     ) -> Builder<Host, Handler, impl RunWithConnectionTo<Host::Counterpart>, Close>
     where
         Run1: RunWithConnectionTo<Host::Counterpart>,
@@ -1102,7 +1102,7 @@ impl<
             host: self.host,
             name: self.name,
             handler: self.handler,
-            responder: ChainRun::new(self.responder, responder),
+            runner: ChainRun::new(self.runner, runner),
             protocol_mode: self.protocol_mode,
             on_close: self.on_close,
         }
@@ -1119,7 +1119,7 @@ impl<
         Fut: Future<Output = Result<(), crate::Error>> + Send,
     {
         let location = Location::caller();
-        self.with_responder(SpawnedRun::new(location, task))
+        self.with_runner(SpawnedRun::new(location, task))
     }
 
     /// Run a callback when the incoming transport reaches clean EOF.
@@ -1166,7 +1166,7 @@ impl<
             host: self.host,
             name: self.name,
             handler: self.handler,
-            responder: self.responder,
+            runner: self.runner,
             protocol_mode: self.protocol_mode,
             on_close: ChainedClose::new(self.on_close, CloseCallback::new(callback)),
         }
@@ -1550,8 +1550,8 @@ impl<
     where
         Host::Counterpart: HasPeer<Agent> + HasPeer<Client>,
     {
-        let (handler, responder) = mcp_server.into_handler_and_responder();
-        self.with_handler(handler).with_responder(responder)
+        let (handler, runner) = mcp_server.into_handler_and_runner();
+        self.with_handler(handler).with_runner(runner)
     }
 
     /// Run in server mode with the provided transport.
@@ -1689,7 +1689,7 @@ impl<
         let Self {
             name,
             handler,
-            responder,
+            runner,
             host: me,
             protocol_mode,
             on_close,
@@ -1763,7 +1763,7 @@ impl<
                                 protocol_compat,
                             ),
                             task_actor::task_actor(new_task_rx, &connection),
-                            responder.run_with_connection_to(connection.clone()),
+                            runner.run_with_connection_to(connection.clone()),
                         )?;
                         Ok(())
                     };

--- a/src/agent-client-protocol/src/jsonrpc/handlers.rs
+++ b/src/agent-client-protocol/src/jsonrpc/handlers.rs
@@ -298,7 +298,7 @@ where
     }
 }
 
-/// Handler that handles both requests and notifications of specific types.
+/// Handler for typed requests, notifications, and matching responses.
 pub struct MessageHandler<
     Counterpart: Role,
     Peer: Role,

--- a/src/agent-client-protocol/src/jsonrpc/incoming_actor.rs
+++ b/src/agent-client-protocol/src/jsonrpc/incoming_actor.rs
@@ -419,7 +419,7 @@ async fn dispatch_dispatch<Counterpart: Role>(
 
     let mut retry_any = false;
 
-    let id = dispatch.id();
+    let id = dispatch.id().cloned();
     let method = dispatch.method().to_string();
     let reply_target = dispatch.request_reply_target();
 
@@ -540,7 +540,7 @@ async fn dispatch_dispatch<Counterpart: Role>(
             }
             Dispatch::Response(result, router) => {
                 tracing::trace!(?method, "Forwarding response");
-                router.respond_with_result(result)
+                router.route_with_result(result)
             }
         }
     }

--- a/src/agent-client-protocol/src/jsonrpc/incoming_actor.rs
+++ b/src/agent-client-protocol/src/jsonrpc/incoming_actor.rs
@@ -533,10 +533,9 @@ async fn dispatch_dispatch<Counterpart: Role>(
                 tracing::debug!(?method, "Ignoring unhandled notification");
                 Ok(())
             }
-            Dispatch::Request(..) => {
+            Dispatch::Request(_, responder) => {
                 tracing::info!(?method, "Rejecting request with error, no handler");
-                let method = dispatch.method().to_string();
-                dispatch.respond_with_error(crate::Error::method_not_found().data(method))
+                responder.respond_with_error(crate::Error::method_not_found().data(method))
             }
             Dispatch::Response(result, router) => {
                 tracing::trace!(?method, "Forwarding response");

--- a/src/agent-client-protocol/src/lib.rs
+++ b/src/agent-client-protocol/src/lib.rs
@@ -95,11 +95,12 @@ pub mod util;
 pub use capabilities::*;
 
 pub use jsonrpc::{
-    Builder, ByteStreams, Channel, ConnectionTo, Dispatch, HandleConnectionClose,
-    HandleDispatchFrom, Handled, INCOMING_TRANSPORT_CLOSED_REASON, IntoHandled, JsonRpcMessage,
-    JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, Lines, NullClose, NullHandler,
-    RawJsonRpcMessage, RawJsonRpcParams, Responder, ResponseRouter, SentRequest, TransportBatch,
-    TransportBatchEntry, TransportFrame, UntypedMessage, is_incoming_transport_closed,
+    Builder, ByteStreams, Channel, ConnectionTo, Dispatch, DynamicHandlerGuard,
+    HandleConnectionClose, HandleDispatchFrom, Handled, INCOMING_TRANSPORT_CLOSED_REASON,
+    IntoHandled, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, Lines,
+    NullClose, NullHandler, RawJsonRpcMessage, RawJsonRpcParams, Responder, ResponseRouter,
+    SentRequest, TransportBatch, TransportBatchEntry, TransportFrame, UntypedMessage,
+    is_incoming_transport_closed,
     run::{ChainRun, NullRun, RunWithConnectionTo},
 };
 pub use jsonrpc::{RequestCancellation, is_cancel_request_notification};

--- a/src/agent-client-protocol/src/mcp_server/context.rs
+++ b/src/agent-client-protocol/src/mcp_server/context.rs
@@ -9,20 +9,14 @@ pub struct McpConnectionTo<Counterpart: Role> {
 
 impl<Counterpart: Role> McpConnectionTo<Counterpart> {
     /// The ACP identifier for this MCP server (e.g., `"acp:UUID"`).
-    pub fn acp_id(&self) -> String {
-        self.acp_id.clone()
+    pub fn acp_id(&self) -> &str {
+        &self.acp_id
     }
 
-    /// The `acp:UUID` that was given.
-    #[deprecated(since = "0.12.0", note = "renamed to `acp_id()`")]
-    pub fn acp_url(&self) -> String {
-        self.acp_id()
-    }
-
-    /// The host connection context.
+    /// Borrow the host connection context.
     ///
     /// If this MCP server is hosted inside of an ACP context, this will be the ACP connection context.
-    pub fn connection_to(&self) -> ConnectionTo<Counterpart> {
-        self.connection.clone()
+    pub fn connection(&self) -> &ConnectionTo<Counterpart> {
+        &self.connection
     }
 }

--- a/src/agent-client-protocol/src/mcp_server/server.rs
+++ b/src/agent-client-protocol/src/mcp_server/server.rs
@@ -9,7 +9,7 @@ use crate::{
     Agent, Client, ConnectTo, ConnectionTo, Dispatch, DynConnectTo, HandleDispatchFrom, Handled,
     Role,
     jsonrpc::{
-        DynamicHandlerRegistration,
+        DynamicHandlerGuard,
         run::{NullRun, RunWithConnectionTo},
     },
     mcp_server::{McpConnectionTo, McpServerConnect, active_session::McpActiveSession},
@@ -142,16 +142,16 @@ where
     ///
     /// # Return value
     ///
-    /// Returns a [`DynamicHandlerRegistration`] for the handler that intercepts messages
+    /// Returns a [`DynamicHandlerGuard`] for the handler that intercepts messages
     /// related to this MCP server. Once the value is dropped, the MCP server messages
     /// will no longer be received, so you need to keep this value alive as long as the session
-    /// is in use. You can also invoke [`DynamicHandlerRegistration::run_indefinitely`]
-    /// if you want to keep the handler running indefinitely.
+    /// is in use. You can also invoke [`DynamicHandlerGuard::detach`] if you
+    /// want to keep the handler registered for the life of the connection.
     pub fn into_dynamic_handler(
         self,
         request: &mut NewSessionRequest,
         cx: &ConnectionTo<Counterpart>,
-    ) -> Result<DynamicHandlerRegistration<Counterpart>, crate::Error>
+    ) -> Result<DynamicHandlerGuard<Counterpart>, crate::Error>
     where
         Counterpart: HasPeer<Agent>,
     {

--- a/src/agent-client-protocol/src/mcp_server/server.rs
+++ b/src/agent-client-protocol/src/mcp_server/server.rs
@@ -45,13 +45,13 @@ pub struct McpServer<Counterpart: Role, Run = NullRun> {
     /// The "connect" instance
     connect: Arc<dyn McpServerConnect<Counterpart>>,
 
-    /// The "responder" is a task that should be run alongside the message handler.
+    /// The runner is a task that should be run alongside the message handler.
     /// Some futures direct messages back through channels to this future which actually
     /// handles responding to the client.
     ///
     /// Some connector implementations use this to run support tasks alongside
     /// the message handler.
-    responder: Run,
+    runner: Run,
 }
 
 impl<Counterpart: Role + std::fmt::Debug, Run: std::fmt::Debug> std::fmt::Debug
@@ -61,7 +61,7 @@ impl<Counterpart: Role + std::fmt::Debug, Run: std::fmt::Debug> std::fmt::Debug
         f.debug_struct("McpServer")
             .field("phantom", &self.phantom)
             .field("acp_id", &self.acp_id)
-            .field("responder", &self.responder)
+            .field("runner", &self.runner)
             .finish_non_exhaustive()
     }
 }
@@ -76,17 +76,17 @@ where
     ///
     /// See `agent-client-protocol-rmcp` to construct MCP servers from Rust code
     /// with `rmcp`.
-    pub fn new(c: impl McpServerConnect<Counterpart>, responder: Run) -> Self {
+    pub fn new(c: impl McpServerConnect<Counterpart>, runner: Run) -> Self {
         McpServer {
             phantom: PhantomData,
             acp_id: format!("acp:{}", Uuid::new_v4()),
             connect: Arc::new(c),
-            responder,
+            runner,
         }
     }
 
     /// Split this MCP server into the message handler and a future that must be run while the handler is active.
-    pub(crate) fn into_handler_and_responder(self) -> (McpNewSessionHandler<Counterpart>, Run)
+    pub(crate) fn into_handler_and_runner(self) -> (McpNewSessionHandler<Counterpart>, Run)
     where
         Counterpart: HasPeer<Agent>,
     {
@@ -94,9 +94,9 @@ where
             phantom: _,
             acp_id,
             connect,
-            responder,
+            runner,
         } = self;
-        (McpNewSessionHandler::new(acp_id, connect), responder)
+        (McpNewSessionHandler::new(acp_id, connect), runner)
     }
 }
 
@@ -198,7 +198,7 @@ where
         let Self {
             acp_id,
             connect,
-            responder,
+            runner,
             phantom: _,
         } = self;
 
@@ -206,7 +206,7 @@ where
 
         role::mcp::Server
             .builder()
-            .with_responder(responder)
+            .with_runner(runner)
             .on_receive_dispatch(
                 async |message_from_client: Dispatch, _cx| {
                     tx.unbounded_send(message_from_client)

--- a/src/agent-client-protocol/src/role/acp.rs
+++ b/src/agent-client-protocol/src/role/acp.rs
@@ -1096,7 +1096,7 @@ impl Role for Conductor {
                     async move |result| {
                         if let Ok(NewSessionResponse { session_id, .. }) = &result {
                             cx.add_dynamic_handler(ProxySessionMessages::new(session_id.clone()))?
-                                .run_indefinitely();
+                                .detach();
                         }
                         responder.respond_with_result(result)
                     }

--- a/src/agent-client-protocol/src/role/acp.rs
+++ b/src/agent-client-protocol/src/role/acp.rs
@@ -281,7 +281,7 @@ impl Role for Agent {
         connection: ConnectionTo<Agent>,
     ) -> Result<Handled<Dispatch>, crate::Error> {
         MatchDispatchFrom::new(message, &connection)
-            .if_message_from(Agent, async |message: Dispatch| {
+            .if_dispatch_from(Agent, async |message: Dispatch| {
                 // Subtle: messages that have a session-id field
                 // should be captured by a dynamic message handler
                 // for that session -- but there is a race condition
@@ -1104,12 +1104,12 @@ impl Role for Conductor {
             })
             .await
             // Incoming message from the client -- forward to the agent
-            .if_message_from(Client, async |message: Dispatch| {
+            .if_dispatch_from(Client, async |message: Dispatch| {
                 cx.send_proxied_message_to(Agent, message)
             })
             .await
             // Incoming message from the agent -- forward to the client
-            .if_message_from(Agent, async |message: Dispatch| {
+            .if_dispatch_from(Agent, async |message: Dispatch| {
                 cx.send_proxied_message_to(Client, message)
             })
             .await
@@ -1161,7 +1161,7 @@ where
         connection: ConnectionTo<Counterpart>,
     ) -> Result<Handled<Dispatch>, crate::Error> {
         MatchDispatchFrom::new(message, &connection)
-            .if_message_from(Agent, async |message| {
+            .if_dispatch_from(Agent, async |message| {
                 // If this is for our session-id, proxy it to the client.
                 if let Some(session_id) = message.get_session_id()?
                     && session_id == self.session_id

--- a/src/agent-client-protocol/src/session.rs
+++ b/src/agent-client-protocol/src/session.rs
@@ -5,7 +5,7 @@ use futures::channel::{mpsc, oneshot};
 use crate::{
     Agent, Client, ConnectionTo, Dispatch, HandleDispatchFrom, Handled, Responder, Role,
     jsonrpc::{
-        DynamicHandlerRegistration,
+        DynamicHandlerGuard,
         run::{ChainRun, NullRun, RunWithConnectionTo},
     },
     mcp_server::McpServer,
@@ -78,7 +78,7 @@ where
     pub fn attach_session<'responder>(
         &self,
         response: NewSessionResponse,
-        mcp_handler_registrations: Vec<DynamicHandlerRegistration<Counterpart>>,
+        mcp_handler_registrations: Vec<DynamicHandlerGuard<Counterpart>>,
     ) -> Result<ActiveSession<'responder, Counterpart>, crate::Error> {
         let NewSessionResponse {
             session_id,
@@ -123,7 +123,7 @@ pub struct SessionBuilder<
 {
     connection: ConnectionTo<Counterpart>,
     request: NewSessionRequest,
-    dynamic_handler_registrations: Vec<DynamicHandlerRegistration<Counterpart>>,
+    dynamic_handler_registrations: Vec<DynamicHandlerGuard<Counterpart>>,
     run: Run,
     block_state: PhantomData<BlockState>,
 }
@@ -316,13 +316,13 @@ where
                 // Install a dynamic handler to proxy messages from this session
                 connection
                     .add_dynamic_handler(ProxySessionMessages::new(session_id.clone()))?
-                    .run_indefinitely();
+                    .detach();
 
                 // Spawn off the run and dynamic handlers to run indefinitely
                 connection.spawn(run.run_with_connection_to(connection.clone()))?;
                 dynamic_handler_registrations
                     .into_iter()
-                    .for_each(super::jsonrpc::DynamicHandlerRegistration::run_indefinitely);
+                    .for_each(DynamicHandlerGuard::detach);
 
                 op(session_id).await
             }
@@ -499,12 +499,12 @@ where
     /// Registration for the handler that routes session messages to `update_rx`.
     /// This is separate from MCP handlers so it can be dropped independently
     /// when switching to proxy mode.
-    session_handler_registration: DynamicHandlerRegistration<Link>,
+    session_handler_registration: DynamicHandlerGuard<Link>,
 
     /// Registrations for MCP server handlers.
     /// These will be dropped once the active-session struct is dropped
     /// which will cause them to be deregistered.
-    mcp_handler_registrations: Vec<DynamicHandlerRegistration<Link>>,
+    mcp_handler_registrations: Vec<DynamicHandlerGuard<Link>>,
 
     /// Phantom lifetime representing the responder lifetime.
     _responder: PhantomData<&'responder ()>,
@@ -698,11 +698,11 @@ where
         // can take over. Any new messages will go directly through the proxy.
         connection
             .add_dynamic_handler(ProxySessionMessages::new(session_id))?
-            .run_indefinitely();
+            .detach();
 
         // Keep MCP server handlers alive for the lifetime of the proxy
         for registration in mcp_handler_registrations {
-            registration.run_indefinitely();
+            registration.detach();
         }
 
         Ok(())

--- a/src/agent-client-protocol/src/session.rs
+++ b/src/agent-client-protocol/src/session.rs
@@ -157,7 +157,7 @@ where
     where
         McpRun: RunWithConnectionTo<Counterpart>,
     {
-        let (handler, mcp_run) = mcp_server.into_handler_and_responder();
+        let (handler, mcp_run) = mcp_server.into_handler_and_runner();
         self.dynamic_handler_registrations
             .push(handler.into_dynamic_handler(&mut self.request, &self.connection)?);
         Ok(SessionBuilder {

--- a/src/agent-client-protocol/src/session.rs
+++ b/src/agent-client-protocol/src/session.rs
@@ -536,13 +536,13 @@ where
     }
 
     /// Access modes available in this session.
-    pub fn modes(&self) -> &Option<SessionModeState> {
-        &self.modes
+    pub fn modes(&self) -> Option<&SessionModeState> {
+        self.modes.as_ref()
     }
 
     /// Access meta data from session response.
-    pub fn meta(&self) -> &Option<serde_json::Map<String, serde_json::Value>> {
-        &self.meta
+    pub fn meta(&self) -> Option<&serde_json::Map<String, serde_json::Value>> {
+        self.meta.as_ref()
     }
 
     /// Build a `NewSessionResponse` from the session information.
@@ -556,8 +556,8 @@ where
     }
 
     /// Access the underlying connection context used to communicate with the agent.
-    pub fn connection(&self) -> ConnectionTo<Link> {
-        self.connection.clone()
+    pub fn connection(&self) -> &ConnectionTo<Link> {
+        &self.connection
     }
 
     /// Send a prompt to the agent. You can then read messages sent in response.

--- a/src/agent-client-protocol/src/session.rs
+++ b/src/agent-client-protocol/src/session.rs
@@ -75,7 +75,7 @@ where
     /// The vector `dynamic_handler_registrations` contains any dynamic
     /// handle registrations associated with this session (e.g., from MCP servers).
     /// You can simply pass `Default::default()` if not applicable.
-    pub fn attach_session<'responder>(
+    pub(crate) fn attach_session<'responder>(
         &self,
         response: NewSessionResponse,
         mcp_handler_registrations: Vec<DynamicHandlerGuard<Counterpart>>,

--- a/src/agent-client-protocol/src/session.rs
+++ b/src/agent-client-protocol/src/session.rs
@@ -739,7 +739,7 @@ where
             "ActiveSessionHandler::handle_dispatch"
         );
         MatchDispatchFrom::new(message, &cx)
-            .if_message_from(Agent, async |message| {
+            .if_dispatch_from(Agent, async |message| {
                 if let Some(session_id) = message.get_session_id()? {
                     tracing::trace!(
                         message_session_id = ?session_id,

--- a/src/agent-client-protocol/src/util.rs
+++ b/src/agent-client-protocol/src/util.rs
@@ -67,11 +67,6 @@ pub fn parse_error(message: impl ToString) -> crate::Error {
     crate::Error::parse_error().data(message.to_string())
 }
 
-/// Convert a JSON-RPC id to a serde_json::Value.
-pub(crate) fn id_to_json(id: &crate::schema::v1::RequestId) -> serde_json::Value {
-    serde_json::to_value(id).expect("RequestId serializes infallibly")
-}
-
 pub(crate) fn instrumented_with_connection_name<F>(
     name: String,
     task: F,

--- a/src/agent-client-protocol/src/util.rs
+++ b/src/agent-client-protocol/src/util.rs
@@ -87,16 +87,6 @@ pub(crate) async fn instrument_with_connection_name<R>(
     }
 }
 
-/// Run two fallible futures concurrently, returning when both complete successfully
-/// or when either fails.
-pub async fn both<E>(
-    a: impl Future<Output = Result<(), E>>,
-    b: impl Future<Output = Result<(), E>>,
-) -> Result<(), E> {
-    let ((), ()) = futures::future::try_join(a, b).await?;
-    Ok(())
-}
-
 /// Run `background` until `foreground` completes.
 ///
 /// Returns the result of `foreground`. If `background` errors before
@@ -132,7 +122,7 @@ pub fn run_until<T, E>(
 ///
 /// This is useful for patterns where you receive work items from a channel
 /// and want to process them concurrently while respecting backpressure.
-pub async fn process_stream_concurrently<T, F>(
+pub(crate) async fn process_stream_concurrently<T, F>(
     stream: impl Stream<Item = T>,
     process_fn: F,
     process_fn_hack: impl for<'a> Fn(&'a F, T) -> BoxFuture<'a, Result<(), crate::Error>>,

--- a/src/agent-client-protocol/src/util/typed.rs
+++ b/src/agent-client-protocol/src/util/typed.rs
@@ -217,7 +217,7 @@ impl MatchDispatch {
     ///
     /// This attempts to parse the message as either request type `R` or notification type `N`,
     /// providing a typed `Dispatch` to the handler if successful.
-    pub async fn if_message<R: JsonRpcRequest, N: JsonRpcNotification, H>(
+    pub async fn if_dispatch<R: JsonRpcRequest, N: JsonRpcNotification, H>(
         mut self,
         op: impl AsyncFnOnce(Dispatch<R, N>) -> Result<H, crate::Error>,
     ) -> Self
@@ -606,14 +606,14 @@ impl<Counterpart: Role> MatchDispatchFrom<Counterpart> {
 
     /// Try to handle the message as a typed `Dispatch<Req, N>` from a specific peer.
     ///
-    /// This is similar to [`MatchDispatch::if_message`], but first applies peer-specific
+    /// This is similar to [`MatchDispatch::if_dispatch`], but first applies peer-specific
     /// message transformation (e.g., unwrapping `SuccessorMessage` envelopes).
     ///
     /// # Parameters
     ///
     /// * `peer` - The peer the message is expected to come from
     /// * `op` - The handler to call if the message matches
-    pub async fn if_message_from<Peer: Role, Req: JsonRpcRequest, N: JsonRpcNotification, H>(
+    pub async fn if_dispatch_from<Peer: Role, Req: JsonRpcRequest, N: JsonRpcNotification, H>(
         mut self,
         peer: Peer,
         op: impl AsyncFnOnce(Dispatch<Req, N>) -> Result<H, crate::Error>,
@@ -630,7 +630,7 @@ impl<Counterpart: Role> MatchDispatchFrom<Counterpart> {
                 self.connection.clone(),
                 async |dispatch, _connection| {
                     // Delegate to MatchDispatch for parsing
-                    MatchDispatch::new(dispatch).if_message(op).await.done()
+                    MatchDispatch::new(dispatch).if_dispatch(op).await.done()
                 },
             )
             .await;

--- a/src/agent-client-protocol/tests/jsonrpc_error_handling.rs
+++ b/src/agent-client-protocol/tests/jsonrpc_error_handling.rs
@@ -848,7 +848,7 @@ async fn test_notification_errors_are_ignored_and_connection_stays_alive() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn dispatch_error_for_notification_is_ignored_and_connection_stays_alive() {
+async fn dispatch_handler_can_ignore_notification_and_connection_stays_alive() {
     use tokio::io::{AsyncWriteExt, BufReader};
     use tokio::task::LocalSet;
 
@@ -873,8 +873,12 @@ async fn dispatch_error_for_notification_is_ignored_and_connection_stays_alive()
                     agent_client_protocol::on_receive_request!(),
                 )
                 .on_receive_dispatch(
-                    async |message: Dispatch, _connection: ConnectionTo<UntypedRole>| {
-                        message.respond_with_error(agent_client_protocol::Error::internal_error())
+                    async |message: Dispatch, _connection: ConnectionTo<UntypedRole>| match message
+                    {
+                        Dispatch::Request(_, responder) => responder
+                            .respond_with_error(agent_client_protocol::Error::method_not_found()),
+                        Dispatch::Notification(_) => Ok(()),
+                        Dispatch::Response(result, router) => router.route_with_result(result),
                     },
                     agent_client_protocol::on_receive_dispatch!(),
                 );
@@ -888,7 +892,7 @@ async fn dispatch_error_for_notification_is_ignored_and_connection_stays_alive()
             client_writer
                 .write_all(
                     br#"{"jsonrpc":"2.0","method":"unknown/notification","params":{}}
-{"jsonrpc":"2.0","id":11,"method":"simple_method","params":{"message":"after dispatch error"}}
+{"jsonrpc":"2.0","id":11,"method":"simple_method","params":{"message":"after ignored notification"}}
 "#,
                 )
                 .await
@@ -898,7 +902,10 @@ async fn dispatch_error_for_notification_is_ignored_and_connection_stays_alive()
             let mut client_reader = BufReader::new(client_reader);
             let response = read_jsonrpc_response_line(&mut client_reader).await;
             assert_eq!(response["id"], 11);
-            assert_eq!(response["result"]["result"], "echo: after dispatch error");
+            assert_eq!(
+                response["result"]["result"],
+                "echo: after ignored notification"
+            );
         })
         .await;
 }

--- a/src/agent-client-protocol/tests/jsonrpc_request_cancellation.rs
+++ b/src/agent-client-protocol/tests/jsonrpc_request_cancellation.rs
@@ -2105,7 +2105,7 @@ async fn retried_protocol_level_notification_reaches_later_dynamic_handler() {
                                     .add_dynamic_handler(CancelCollector {
                                         tx: collector_tx.clone(),
                                     })?
-                                    .run_indefinitely();
+                                    .detach();
                             }
                             responder.respond(SimpleResponse {
                                 result: format!("echo: {}", request.message),

--- a/src/agent-client-protocol/tests/jsonrpc_request_cancellation.rs
+++ b/src/agent-client-protocol/tests/jsonrpc_request_cancellation.rs
@@ -494,7 +494,7 @@ async fn cancelling_request_sent_to_successor_peer_sends_wrapped_cancel() {
                             message: "wrapped cancel".into(),
                         },
                     );
-                    let expected_id = request.id();
+                    let expected_id = request.id().clone();
                     request.cancel()?;
                     let error = request
                         .block_task()
@@ -510,7 +510,7 @@ async fn cancelling_request_sent_to_successor_peer_sends_wrapped_cancel() {
             // The cancellation arrived wrapped, for the wrapped request's
             // outer JSON-RPC id, and never in unwrapped form.
             let received = next_with_timeout(&mut wrapped_cancel_rx).await;
-            assert_eq!(serde_json::to_value(received).unwrap(), expected_id);
+            assert_eq!(received, expected_id);
             assert_no_event(&mut wrapped_cancel_rx);
             assert_no_event(&mut plain_cancel_rx);
         })
@@ -615,7 +615,7 @@ async fn sent_request_can_send_cancellation_for_its_id() {
                     let request: SentRequest<SimpleResponse> = cx.send_request(SimpleRequest {
                         message: "slow".into(),
                     });
-                    let expected_id = request.id();
+                    let expected_id = request.id().clone();
                     request.cancel()?;
                     let received = next_with_timeout(&mut cancel_rx).await;
 
@@ -638,7 +638,7 @@ async fn sent_request_can_send_cancellation_for_its_id() {
                 .await
                 .unwrap();
 
-            assert_eq!(serde_json::to_value(received).unwrap(), expected_id);
+            assert_eq!(received, expected_id);
             assert_no_event(&mut cancel_rx);
         })
         .await;
@@ -688,7 +688,7 @@ async fn dropped_sent_request_sends_cancellation_for_its_id() {
                     let request: SentRequest<SimpleResponse> = cx.send_request(SimpleRequest {
                         message: "abandoned".into(),
                     });
-                    let expected_id = request.id();
+                    let expected_id = request.id().clone();
                     drop(request);
                     let received = next_with_timeout(&mut cancel_rx).await;
                     Ok((expected_id, received))
@@ -696,7 +696,7 @@ async fn dropped_sent_request_sends_cancellation_for_its_id() {
                 .await
                 .unwrap();
 
-            assert_eq!(serde_json::to_value(received).unwrap(), expected_id);
+            assert_eq!(received, expected_id);
             assert_no_event(&mut cancel_rx);
         })
         .await;
@@ -847,7 +847,7 @@ async fn late_response_after_dropped_sent_request_does_not_close_connection() {
                     let request: SentRequest<SimpleResponse> = cx.send_request(SimpleRequest {
                         message: "late".into(),
                     });
-                    let expected_id = request.id();
+                    let expected_id = request.id().clone();
                     drop(request);
 
                     let received = next_with_timeout(&mut cancel_rx).await;
@@ -868,7 +868,7 @@ async fn late_response_after_dropped_sent_request_does_not_close_connection() {
                 .unwrap();
 
             assert_eq!(response.result, "echo: after late");
-            assert_eq!(serde_json::to_value(received).unwrap(), expected_id);
+            assert_eq!(received, expected_id);
         })
         .await;
 }
@@ -999,7 +999,7 @@ async fn response_claimed_by_dispatch_handler_disarms_auto_cancellation() {
 
             // The JSON-RPC id whose response the dispatch handler below
             // claims (and discards) without ever invoking the router.
-            let claimed_id: Arc<Mutex<Option<serde_json::Value>>> = Arc::new(Mutex::new(None));
+            let claimed_id: Arc<Mutex<Option<RequestId>>> = Arc::new(Mutex::new(None));
 
             let client_transport =
                 agent_client_protocol::ByteStreams::new(client_writer, client_reader);
@@ -1010,7 +1010,7 @@ async fn response_claimed_by_dispatch_handler_disarms_auto_cancellation() {
                         let claimed_id = claimed_id.clone();
                         async move |dispatch: Dispatch, _connection: ConnectionTo<UntypedRole>| {
                             if let Dispatch::Response(_, router) = &dispatch
-                                && claimed_id.lock().unwrap().as_ref() == Some(&router.id())
+                                && claimed_id.lock().unwrap().as_ref() == Some(router.id())
                             {
                                 // Claim the response; the router is dropped
                                 // without responding.
@@ -1028,7 +1028,7 @@ async fn response_claimed_by_dispatch_handler_disarms_auto_cancellation() {
                     let request: SentRequest<SimpleResponse> = cx.send_request(SimpleRequest {
                         message: "claimed".into(),
                     });
-                    *claimed_id.lock().unwrap() = Some(request.id());
+                    *claimed_id.lock().unwrap() = Some(request.id().clone());
 
                     // The server answers requests in order, so once this
                     // round trip completes, the response to `claimed` has
@@ -1105,7 +1105,7 @@ async fn response_retained_by_dispatch_handler_disarms_auto_cancellation() {
                 }
             });
 
-            let claimed_id: Arc<Mutex<Option<serde_json::Value>>> = Arc::new(Mutex::new(None));
+            let claimed_id: Arc<Mutex<Option<RequestId>>> = Arc::new(Mutex::new(None));
             let retained_response: Arc<Mutex<Option<Dispatch>>> = Arc::new(Mutex::new(None));
 
             let client_transport =
@@ -1119,7 +1119,7 @@ async fn response_retained_by_dispatch_handler_disarms_auto_cancellation() {
                         async move |dispatch: Dispatch, _connection: ConnectionTo<UntypedRole>| {
                             let should_claim = match &dispatch {
                                 Dispatch::Response(_, router) => {
-                                    claimed_id.lock().unwrap().as_ref() == Some(&router.id())
+                                    claimed_id.lock().unwrap().as_ref() == Some(router.id())
                                 }
                                 Dispatch::Request(_, _) | Dispatch::Notification(_) => false,
                             };
@@ -1141,7 +1141,7 @@ async fn response_retained_by_dispatch_handler_disarms_auto_cancellation() {
                     let request: SentRequest<SimpleResponse> = cx.send_request(SimpleRequest {
                         message: "retained".into(),
                     });
-                    *claimed_id.lock().unwrap() = Some(request.id());
+                    *claimed_id.lock().unwrap() = Some(request.id().clone());
 
                     // This proves the earlier response was routed into the
                     // handler and is still retained rather than dropped.
@@ -1440,7 +1440,7 @@ async fn send_proxied_message_does_not_tunnel_cancel_notifications() {
                                     responder: Responder<SimpleResponse>,
                                     _connection: ConnectionTo<UntypedRole>| {
                             if request.message == "park" {
-                                parked_id_tx.unbounded_send(responder.id()).unwrap();
+                                parked_id_tx.unbounded_send(responder.id().clone()).unwrap();
                                 *pending_responder.lock().unwrap() = Some(responder);
                                 return Ok(());
                             }
@@ -1517,7 +1517,7 @@ async fn send_proxied_message_does_not_tunnel_cancel_notifications() {
                         connection.send_request(SimpleRequest {
                             message: "park".into(),
                         });
-                    let client_request_id = request.id();
+                    let client_request_id = request.id().clone();
                     request.cancel()?;
 
                     let error = request
@@ -1550,7 +1550,7 @@ async fn send_proxied_message_does_not_tunnel_cancel_notifications() {
                 "the proxy must re-issue the request under its own ID"
             );
             let observed = next_with_timeout(&mut backend_cancel_rx).await;
-            assert_eq!(serde_json::to_value(observed).unwrap(), parked_id);
+            assert_eq!(observed, parked_id);
             assert_no_event(&mut backend_cancel_rx);
         })
         .await;
@@ -1682,7 +1682,7 @@ async fn send_proxied_message_does_not_tunnel_wrapped_cancel_notifications() {
 /// Returns the proxy-side connection to the backend.
 async fn spawn_parking_backend(
     honor_cancellations: bool,
-    parked_id_tx: mpsc::UnboundedSender<serde_json::Value>,
+    parked_id_tx: mpsc::UnboundedSender<RequestId>,
     backend_cancel_tx: mpsc::UnboundedSender<RequestId>,
 ) -> ConnectionTo<UntypedRole> {
     let pending_responder: Arc<Mutex<Option<Responder<SimpleResponse>>>> =
@@ -1714,7 +1714,7 @@ async fn spawn_parking_backend(
                             _connection: ConnectionTo<UntypedRole>| {
                     match request.message.as_str() {
                         "park" => {
-                            parked_id_tx.unbounded_send(responder.id()).unwrap();
+                            parked_id_tx.unbounded_send(responder.id().clone()).unwrap();
                             *pending_responder.lock().unwrap() = Some(responder);
                             Ok(())
                         }
@@ -1820,7 +1820,7 @@ async fn custom_forwarding_propagates_cancellation_when_opted_in() {
                         connection.send_request(SimpleRequest {
                             message: "park".into(),
                         });
-                    let client_request_id = request.id();
+                    let client_request_id = request.id().clone();
                     request.cancel()?;
 
                     let error = request
@@ -1846,7 +1846,7 @@ async fn custom_forwarding_propagates_cancellation_when_opted_in() {
             let parked_id = next_with_timeout(&mut parked_id_rx).await;
             assert_ne!(parked_id, client_request_id);
             let observed = next_with_timeout(&mut backend_cancel_rx).await;
-            assert_eq!(serde_json::to_value(observed).unwrap(), parked_id);
+            assert_eq!(observed, parked_id);
             assert_no_event(&mut backend_cancel_rx);
         })
         .await;

--- a/src/agent-client-protocol/tests/match_dispatch.rs
+++ b/src/agent-client-protocol/tests/match_dispatch.rs
@@ -146,7 +146,7 @@ async fn match_dispatch_from_preserves_retry_across_chained_matches()
                     })
                 })
                 .await
-                .if_message_from(UntypedRole, async |message: Dispatch| {
+                .if_dispatch_from(UntypedRole, async |message: Dispatch| {
                     Ok(Handled::No {
                         message,
                         retry: false,


### PR DESCRIPTION
- **refactor(acp)!: clarify response routing and request IDs**
- **fix(acp)!: make dynamic handler lifetimes explicit**
- **refactor(acp)!: make notification dispatch explicit**
- **refactor(acp)!: rename background responders to runners**
- **refactor(acp)!: rename message matchers to dispatch matchers**
- **refactor(acp)!: borrow MCP and session accessors**
- **refactor(acp)!: narrow low-level helper APIs**
