### PR TITLE
fix!: harden the 2.0 transport and API boundary

### DIFF
--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -30,8 +30,12 @@ version_group = "acp"
 name = "agent-client-protocol-polyfill"
 version_group = "acp"
 
-# rmcp is a public dependency, so this crate's major version tracks rmcp's
-# major releases independently of the rest of the workspace.
+# This crate publicly exposes types from both rmcp and agent-client-protocol.
+# A major-version change in either public dependency therefore requires a
+# major release here. Keep it outside the `acp` version group because its
+# version need not equal the core version, but verify dependency-only release
+# proposals manually: core 1.x -> 2.x requires rmcp 2.x -> 3.x even if
+# release-plz initially classifies the manifest update as a patch.
 [[package]]
 name = "agent-client-protocol-rmcp"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,11 +7,12 @@ The crates are found in `src/*`. Each crate's `README.md` and `CHANGELOG.md` des
 ## Crate Layout
 
 - `agent-client-protocol` – Core protocol SDK (roles, connections, handlers, schema)
-- `agent-client-protocol-tokio` – Tokio utilities (process spawning, stdio transports)
+- `agent-client-protocol-http` – HTTP/SSE and WebSocket transports
 - `agent-client-protocol-rmcp` – Integration with the `rmcp` crate
 - `agent-client-protocol-cookbook` – Usage patterns rendered as rustdoc
 - `agent-client-protocol-derive` – Proc macros
 - `agent-client-protocol-conductor` – Conductor binary and library for proxy chains
+- `agent-client-protocol-polyfill` – Compatibility proxy implementations
 - `agent-client-protocol-test` – Shared test utilities and fixtures
 - `agent-client-protocol-trace-viewer` – Interactive sequence diagram viewer
 - `yopo` – "You Only Prompt Once" example client
@@ -80,7 +81,6 @@ Common scopes for this repository (typically the crate name without the `agent-c
 
 - `acp` – Core protocol changes
 - `conductor` – Conductor-specific changes
-- `tokio` – Tokio utility changes
 - `rmcp` – rmcp integration changes
 - `cookbook` – Cookbook patterns and docs
 - `trace-viewer` – Trace viewer changes

--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@ This repository is the official **Rust SDK** for ACP. It provides crates for bui
 **Core SDK**
 
 - [`agent-client-protocol`](./src/agent-client-protocol/) – Roles (Client, Agent, Proxy, Conductor), connection builders, handlers, and protocol types.
-- [`agent-client-protocol-tokio`](./src/agent-client-protocol-tokio/) – Tokio utilities for spawning agent processes and wiring stdio transports.
+- [`agent-client-protocol-http`](./src/agent-client-protocol-http/) – HTTP/SSE and WebSocket transports.
 - [`agent-client-protocol-rmcp`](./src/agent-client-protocol-rmcp/) – Integration with the [`rmcp`](https://docs.rs/rmcp) MCP SDK.
 - [`agent-client-protocol-derive`](./src/agent-client-protocol-derive/) – Derive macros used by the core crate.
 
 **Proxy orchestration**
 
 - [`agent-client-protocol-conductor`](./src/agent-client-protocol-conductor/) – Binary and library that manages chains of proxy components.
+- [`agent-client-protocol-polyfill`](./src/agent-client-protocol-polyfill/) – Compatibility proxies, including bridging legacy `acp:` MCP declarations for agents that cannot consume them directly.
 - [`agent-client-protocol-trace-viewer`](./src/agent-client-protocol-trace-viewer/) – Interactive sequence-diagram viewer for conductor trace files.
 
 **Patterns, examples, and testing**
@@ -37,12 +38,12 @@ This repository is the official **Rust SDK** for ACP. It provides crates for bui
 
 ## Integrations
 
-- [Schema](./schema/schema.json)
+- [Protocol schema and documentation](https://agentclientprotocol.com/)
 - [Agents](https://agentclientprotocol.com/overview/agents)
 - [Clients](https://agentclientprotocol.com/overview/clients)
 - Official Libraries
   - **Kotlin**: [`acp-kotlin`](https://github.com/agentclientprotocol/kotlin-sdk) – supports JVM, other targets are in progress
-  - **Rust**: [`agent-client-protocol`](https://crates.io/crates/agent-client-protocol) - See [examples/agent.rs](https://github.com/agentclientprotocol/rust-sdk/blob/main/src/agent-client-protocol/examples/agent.rs) and [examples/client.rs](https://github.com/agentclientprotocol/rust-sdk/blob/main/src/agent-client-protocol/examples/client.rs)
+  - **Rust**: [`agent-client-protocol`](https://crates.io/crates/agent-client-protocol) - See the [agent](./src/agent-client-protocol/examples/simple_agent.rs) and [client](./src/agent-client-protocol/examples/yolo_one_shot_client.rs) examples
   - **TypeScript**: [`@agentclientprotocol/sdk`](https://www.npmjs.com/package/@agentclientprotocol/sdk) - See [examples/](https://github.com/agentclientprotocol/typescript-sdk/tree/main/src/examples)
 - [Community Libraries](https://agentclientprotocol.com/libraries/community)
 

--- a/md/SUMMARY.md
+++ b/md/SUMMARY.md
@@ -11,6 +11,7 @@
 
 # Transports
 
+- [Transport Architecture](./transport-architecture.md)
 - [HTTP / WebSocket Transport](./http-transport.md)
 
 # Conductor (agent-client-protocol-conductor)
@@ -27,8 +28,7 @@
 
 - [Migrating to v2.0](./migration_v2.0.md)
 - [Migrating to v0.11](./migration_v0.11.x.md)
-- [P/ACP Specification](./proxying-acp.md)
 
 # Archive
 
-- [Transport Architecture](./transport-architecture.md)
+- [Original P/ACP Design Proposal](./proxying-acp.md)

--- a/md/conductor.md
+++ b/md/conductor.md
@@ -1,379 +1,136 @@
 # Conductor Design
 
-The **Conductor** (binary name: `agent-client-protocol-conductor`) orchestrates P/ACP proxy chains. It coordinates the flow of ACP messages through a chain of proxy components.
+The `agent-client-protocol-conductor` crate runs a chain of ACP proxy
+components. It presents one ACP endpoint upstream while owning the connections
+to every proxy and, in agent mode, the final agent.
 
-For API usage, see the [agent-client-protocol-conductor rustdoc](https://docs.rs/agent-client-protocol-conductor).
+For API details, see the
+[`agent-client-protocol-conductor` rustdoc](https://docs.rs/agent-client-protocol-conductor).
 
-## Overview
-
-The conductor orchestrates proxy chains by sitting **between every component**. It spawns component processes and routes all messages, presenting itself as a normal ACP agent to the editor.
+## Chain Model
 
 ```mermaid
-flowchart TB
-    Editor[Editor]
-    C[Conductor]
-    P1[Component 1]
-    P2[Component 2]
+flowchart LR
+    Client[ACP client]
+    Conductor[Conductor]
+    Proxy1[Proxy 1]
+    Proxy2[Proxy 2]
+    Agent[Agent]
 
-    Editor <-->|ACP via stdio| C
-    C <-->|stdio| P1
-    C <-->|stdio| P2
+    Client <--> Conductor
+    Conductor <--> Proxy1
+    Conductor <--> Proxy2
+    Conductor <--> Agent
 ```
 
-**Key insight**: Components never talk directly to each other. The conductor routes ALL messages using the `_proxy/successor/*` protocol.
+Components do not open direct connections to one another. The conductor owns
+each transport and maps the logical chain onto those connections:
 
-**From the editor's perspective**: Conductor is a normal ACP agent communicating over stdio.
+- Upstream traffic is delivered to the first proxy as ordinary ACP messages.
+- A proxy uses `_proxy/successor` to send a request or notification to the next
+  component.
+- Traffic from a successor is presented to its predecessor through the same
+  typed proxy abstraction.
+- JSON-RPC responses remain paired with the request context that caused them.
 
-**From each component's perspective**:
+The final agent receives ordinary ACP and does not need to implement the proxy
+extension. See the [Proxy Extension Protocol Reference](./protocol.md) for the
+wire method shapes.
 
-- Receives normal ACP messages from the conductor
-- Sends `_proxy/successor/request` to conductor to forward messages TO successor
-- Receives `_proxy/successor/request` from conductor for messages FROM successor
+## Lazy Initialization
 
-See [Protocol Reference](./protocol.md) for detailed message formats.
+Proxy and agent components are instantiated when the first `initialize`
+request arrives. For each non-final component, the conductor sends
+`_proxy/initialize`; the last component in agent mode receives ordinary
+`initialize`. Each proxy can initialize its successor before completing its own
+response, so capabilities flow back toward the client through the chain.
 
-## Responsibilities
+Lazy construction allows an `InstantiateProxiesAndAgent` or
+`InstantiateProxies` implementation to inspect and, when appropriate, adjust
+the initialize request before choosing components.
 
-The conductor has four core responsibilities:
+## Agent and Proxy Modes
 
-### 1. Process Management
+In **agent mode**, the conductor owns zero or more proxies followed by a final
+agent and acts as an agent toward its upstream client.
 
-- Spawns component processes based on command-line arguments
-- Manages component lifecycle (startup, shutdown, error handling)
-- For MVP: If any component crashes, shut down the entire chain
+In **proxy mode**, the conductor owns only a proxy sub-chain. The final managed
+proxy's successor is the conductor's own downstream successor, allowing a
+sub-chain to participate as one proxy inside a larger composition.
 
-**Command-line interface:**
+## Routing and Ordering
+
+A central routing loop serializes forwarding decisions for incoming requests
+and notifications. Responses are associated with their original requests by
+the core JSON-RPC contexts and may use a direct response path; the conductor
+does not maintain a second global request-ID table.
+
+Every physical and in-process bridge carries `TransportFrame`, so tracing and
+delegating components preserve JSON-RPC batch boundaries. This matters because
+flattening a batch would change one response array into several response
+objects. The complete framing rules are documented in [Transport
+Architecture](./transport-architecture.md#json-rpc-batch-behavior).
+
+## Command-Line Usage
+
+Global options precede the subcommand. Each component argument is one
+shell-parsed command string, so quote commands that include arguments:
 
 ```bash
-# Agent mode - manages proxy chain
-conductor agent sparkle-acp claude-code-acp
-
-# MCP mode - bridges stdio to TCP for MCP-over-ACP
-conductor mcp 54321
+agent-client-protocol-conductor agent \
+  "proxy-one --flag" \
+  "proxy-two" \
+  "base-agent --acp"
 ```
 
-**Agent mode** creates a chain: `Editor → Conductor → sparkle-acp → claude-code-acp`
+The last command in `agent` mode is the agent; earlier commands are proxies.
+Proxy mode accepts only proxy commands:
 
-**MCP mode** bridges MCP JSON-RPC (stdio) to raw JSON-RPC (TCP connection to main conductor)
-
-### 2. Message Routing
-
-The conductor routes ALL messages between components. No component talks directly to another.
-
-**Message ordering**: The conductor preserves message send order by routing all forwarding decisions through a central event loop, preventing responses from overtaking notifications.
-
-**Message flow types:**
-
-1. **Editor → First Component**: Conductor forwards normal ACP messages
-2. **Component → Successor**: Component sends `_proxy/successor/request` to conductor, which unwraps and forwards to next component
-3. **Successor → Component**: Conductor wraps messages in `_proxy/successor/request` when sending FROM successor
-4. **Responses**: Flow back via standard JSON-RPC response IDs
-
-See [Protocol Reference](./protocol.md) for detailed request/response flow diagrams.
-
-### 3. Capability Management
-
-The conductor manages proxy capability handshakes during initialization:
-
-**Normal Mode (conductor as root):**
-
-- Offers `proxy: true` to all components EXCEPT the last
-- Verifies each proxy component accepts the capability
-- Last component (agent) receives standard ACP initialization
-
-**Proxy Mode (conductor as proxy):**
-
-- When conductor itself receives `proxy: true` during initialization
-- Offers `proxy: true` to ALL components (including the last)
-- Enables tree-structured proxy chains
-
-See [Proxy Mode](#proxy-mode) below for hierarchical chain details.
-
-### 4. MCP Bridge Adaptation
-
-When components provide MCP servers with ACP transport (`"url": "acp:$UUID"`):
-
-**If agent has `mcpCapabilities.acp` capability:**
-
-- Pass through MCP server declarations unchanged
-- Agent handles `_mcp/*` messages natively
-
-**If agent lacks `mcpCapabilities.acp` capability:**
-
-- Bind TCP port for each ACP-transport MCP server
-- Transform MCP server spec to use `conductor mcp $port`
-- Spawn `conductor mcp $port` bridge processes
-- Route MCP tool calls:
-  - Agent → stdio → bridge → TCP → conductor → `_mcp/*` messages backward up chain
-  - Component responses flow back: component → conductor → TCP → bridge → stdio → agent
-
-See [MCP Bridge](./mcp-bridge.md) for full implementation details.
-
-## Proxy Mode
-
-The conductor can itself operate as a proxy component within a larger chain, enabling **tree-structured proxy architectures**.
-
-### How Proxy Mode Works
-
-When the conductor receives an `initialize` request **with** the `proxy` capability:
-
-1. **Detection**: Conductor detects it's being used as a proxy component
-2. **All components become proxies**: Offers `proxy: true` to ALL managed components (including the last)
-3. **Successor forwarding**: When the final component sends `_proxy/successor/request`, conductor forwards to **its own successor**
-
-### Example: Hierarchical Chain
-
-```
-client → proxy1 → conductor (proxy mode) → final-agent
-                      ↓ manages
-                  p1 → p2 → p3
+```bash
+agent-client-protocol-conductor proxy "proxy-one" "proxy-two"
 ```
 
-**Message flow when p3 forwards to successor:**
+Tracing options are global:
 
-1. p3 sends `_proxy/successor/request` to conductor
-2. Conductor recognizes it's in proxy mode
-3. Conductor sends `_proxy/successor/request` to proxy1 (its predecessor)
-4. proxy1 routes to final-agent
-
-### Use Cases
-
-**Modular sub-chains**: Group related proxies into a conductor-managed sub-chain that can be inserted anywhere
-
-**Conditional routing**: A proxy can route to conductor-based sub-chains based on request type
-
-**Isolated environments**: Each conductor manages its own component lifecycle while participating in larger chains
-
-### Implementation Notes
-
-- Proxy mode is detected during initialization by checking for `proxy: true` in incoming `initialize` request
-- In normal mode: last component is agent (no proxy capability)
-- In proxy mode: all components are proxies (all receive proxy capability)
-- The conductor's own successor is determined by whoever initialized it
-
-## Initialization Flow
-
-```mermaid
-sequenceDiagram
-    participant Editor
-    participant Conductor
-    participant Sparkle as Component1<br/>(Sparkle)
-    participant Agent as Component2<br/>(Agent)
-
-    Note over Conductor: Spawns both components at startup<br/>from CLI args
-
-    Editor->>Conductor: acp/initialize [I0]
-    Conductor->>Sparkle: acp/initialize (offers proxy capability) [I0]
-
-    Note over Sparkle: Sees proxy capability offer,<br/>knows it has a successor
-
-    Sparkle->>Conductor: _proxy/successor/request(acp/initialize) [I1]
-
-    Note over Conductor: Unwraps request,<br/>knows Agent is last in chain
-
-    Conductor->>Agent: acp/initialize (NO proxy capability - agent is last) [I1]
-    Agent-->>Conductor: initialize response (capabilities) [I1]
-    Conductor-->>Sparkle: _proxy/successor response [I1]
-
-    Note over Sparkle: Sees Agent's capabilities,<br/>prepares response
-
-    Sparkle-->>Conductor: initialize response (accepts proxy capability) [I0]
-
-    Note over Conductor: Verifies Sparkle accepted proxy.<br/>If not, would fail with error.
-
-    Conductor-->>Editor: initialize response [I0]
+```bash
+agent-client-protocol-conductor --trace ./trace.jsons agent "proxy-one" "base-agent"
+agent-client-protocol-conductor --serve agent "proxy-one" "base-agent"
+agent-client-protocol-conductor --trace ./trace.jsons --serve agent "proxy-one" "base-agent"
 ```
 
-Key points:
+There is no conductor `mcp` subcommand. MCP compatibility bridging lives in
+`agent-client-protocol-polyfill` and must be inserted explicitly when needed.
 
-1. **Conductor spawns ALL components at startup** based on command-line args
-2. **Sequential initialization**: Conductor → Component1 → Component2 → ... → Agent
-3. **Proxy capability handshake**:
-   - Conductor **offers** `proxy: true` to non-last components (in InitializeRequest `_meta`)
-   - Components **must accept** by responding with `proxy: true` (in InitializeResponse `_meta`)
-   - Last component (agent) is NOT offered proxy capability
-   - Conductor **verifies** acceptance and fails initialization if missing
-4. **Components use `_proxy/successor/request`** to initialize their successors
-5. **Capabilities flow back up the chain**: Each component sees successor's capabilities before responding
-6. **Message IDs**: Preserved from editor (I0), new IDs for proxy messages (I1, I2, ...)
+## Programmatic Usage
 
-## Implementation Architecture
+```rust,ignore
+use agent_client_protocol_conductor::{ConductorImpl, ProxiesAndAgent};
 
-The conductor uses an actor-based architecture with message passing via channels.
+let components = ProxiesAndAgent::new(agent)
+    .proxy(first_proxy)
+    .proxy(second_proxy);
 
-### Core Components
+ConductorImpl::new_agent("conductor", components)
+    .run(upstream_transport)
+    .await?;
+```
 
-- **Main connection**: Handles editor stdio and spawns the event loop
-- **Component connections**: Each component has a bidirectional JSON-RPC connection
-- **Message router**: Central actor that receives `ConductorMessage` enums and routes appropriately
-- **MCP bridge actors**: Manage MCP-over-ACP connections
+`ConductorImpl::new_proxy` accepts an `InstantiateProxies` implementation for
+the nested-proxy case. Both modes can use dynamic instantiator closures when
+the chain depends on initialization data.
 
-### Message Ordering Invariant
+## MCP Compatibility
 
-**Critical invariant**: All messages (requests, responses, notifications) between any two endpoints must maintain their send order.
+MCP-over-ACP adaptation is intentionally not built into `ConductorImpl`. Add
+`McpOverAcpPolyfill::http()` or `McpOverAcpPolyfill::stdio(...)` as a proxy in
+the chain when an agent cannot consume the legacy `McpServer::Http` `acp:`
+declaration directly. Keeping the polyfill explicit prevents instrumentation
+or orchestration from silently changing session MCP declarations. See
+[MCP Bridge](./mcp-bridge.md).
 
-The conductor ensures this invariant by routing **all** message forwarding through its central message queue (`ConductorMessage` channel). This prevents faster message types (responses) from overtaking slower ones (notifications).
+## Tracing
 
-#### Why This Matters
-
-Without ordering preservation, a race condition can occur:
-
-1. Agent sends `session/update` notification
-2. Agent responds to `session/prompt` request
-3. Response takes a fast path (reply_actor with oneshot channels)
-4. Notification takes slower path (handler pipeline)
-5. **Response arrives before notification** → client loses notification data
-
-#### Implementation
-
-The conductor uses extension traits to route all forwarding through the central queue:
-
-- `JrConnectionCxExt::send_proxied_message_via` - Routes both requests and notifications
-- `JrRequestCxExt::respond_via` - Routes responses through the queue
-- `JrResponseExt::forward_response_via` - Ensures response forwarding maintains order
-
-All message forwarding in both directions (client-to-agent and agent-to-client) flows through the conductor's central event loop, which processes `ConductorMessage` enums sequentially. This serialization ensures messages arrive in the same order they were sent.
-
-### Message Routing Implementation
-
-The conductor uses a recursive spawning pattern:
-
-1. **Recursive chain building**: Each component spawns the next, establishing connections
-2. **Actor-based routing**: All messages flow through a central conductor actor via channels
-3. **Response routing**: Uses JSON-RPC response IDs and request contexts to route back
-4. **No explicit ID tracking**: Context passing eliminates need for manual ID management
-
-**Key routing decisions:**
-
-- **Normal mode**: Last component gets normal ACP (no proxy capability)
-- **Proxy mode**: All components get proxy capability, final component can forward to conductor's successor
-- **Bidirectional `_proxy/successor/*`**: Used for both TO successor (unwrap and forward) and FROM successor (wrap and deliver)
-
-### Concurrency Model
-
-Built on Tokio async runtime:
-
-- **Async I/O**: All stdio operations are non-blocking
-- **Message passing**: Components communicate via mpsc channels
-- **Spawned tasks**: Each connection handler runs as separate task
-- **Error propagation**: Tasks send errors back to main actor via channels
-
-See source code in `src/agent-client-protocol-conductor/src/conductor.rs` for implementation details.
-
-## Error Handling
-
-### Component Crashes
-
-If any component process exits or crashes:
-
-1. Log error to stderr
-2. Shut down entire Conductor process
-3. Exit with non-zero status
-
-The editor will see the ACP connection close and can handle appropriately.
-
-### Invalid Messages
-
-If Conductor receives malformed JSON-RPC:
-
-- Log to stderr
-- Continue processing (don't crash the chain)
-- May result in downstream errors
-
-### Initialization Failures
-
-If component fails to initialize:
-
-1. Log error
-2. Return error response to editor
-3. Shut down
-
-## Implementation Phases
-
-### Phase 1: Basic Routing (MVP)
-
-- [x] Design documented
-- [x] Parse command-line arguments (component list)
-- [x] Spawn components recursively (alternative to "spawn all at startup")
-- [x] Set up stdio pipes for all components
-- [x] Message routing logic:
-  - [x] Editor → Component1 forwarding
-  - [x] `_proxy/successor/request` unwrapping and forwarding
-  - [x] Response routing via context passing (alternative to explicit ID tracking)
-  - [x] Component → Editor message routing
-- [x] Actor-based message passing architecture with `ConductorMessage` enum
-- [x] Error reporting from spawned tasks to conductor
-- [ ] **PUNCH LIST - Remaining MVP items:**
-  - [ ] Fix typo: `ComnponentToItsClientMessage` → `ComponentToItsClientMessage`
-  - [ ] Proxy capability handshake during initialization:
-    - [ ] Offer `proxy: true` in `_meta` to non-last components during `acp/initialize`
-    - [ ] Do NOT offer `proxy` to last component (agent)
-    - [ ] Verify component accepts by checking for `proxy: true` in InitializeResponse `_meta`
-    - [ ] Fail initialization with error "component X is not a proxy" if handshake fails
-  - [ ] Add documentation/comments explaining recursive chain building
-  - [ ] Add logging (message routing, component startup, errors)
-  - [ ] Write tests (proxy capability handshake, basic routing, initialization, error handling)
-  - [ ] Component crash detection and chain shutdown
-
-### Phase 2: Robust Error Handling
-
-- [x] Basic error reporting from async tasks
-- [ ] Graceful component shutdown
-- [ ] Retry logic for transient failures
-- [ ] Health checks
-- [ ] Timeout handling for hung requests
-
-### Phase 3: Observability
-
-- [ ] Structured logging/tracing
-- [ ] Performance metrics
-- [ ] Debug mode with message inspection
-
-### Phase 4: Advanced Features
-
-- [ ] Dynamic component loading
-- [ ] Hot reload of components
-- [ ] Multiple parallel chains
-
-## Testing Strategy
-
-### Unit Tests
-
-- Message parsing and forwarding logic
-- Capability modification
-- Error handling paths
-
-### Integration Tests
-
-- Full chain initialization
-- Message flow through real components
-- Component crash scenarios
-- Malformed message handling
-
-### End-to-End Tests
-
-- Real editor + Conductor + test components
-- Sparkle + Claude Code integration
-- Performance benchmarks
-
-## Open Questions
-
-1. **Component discovery**: How do we find component binaries? PATH? Configuration file?
-2. **Configuration**: Should Conductor support a config file for default chains?
-3. **Logging**: Structured logging format?
-4. **Metrics**: Should Conductor expose metrics (message counts, latency)?
-5. **Security**: Do we need to validate/sandbox component processes?
-
-## Key Source Files
-
-| File                                                              | Purpose                       |
-| ----------------------------------------------------------------- | ----------------------------- |
-| `src/agent-client-protocol-conductor/src/conductor.rs`            | Main conductor implementation |
-| `src/agent-client-protocol-conductor/src/conductor/mcp_bridge.rs` | MCP bridge actor              |
-| `src/agent-client-protocol-conductor/src/main.rs`                 | CLI entry point               |
-
-## Related Documentation
-
-- [P/ACP Specification](./proxying-acp.md) - Full protocol specification
-- [MCP Bridge](./mcp-bridge.md) - MCP-over-ACP implementation details
-- [Protocol Reference](./protocol.md) - Wire protocol details
+The conductor can record an idealized logical sequence of ACP and MCP messages.
+Its snooping bridges retain complete transport frames, so enabling tracing does
+not change batch behavior. See [Trace Viewer](./trace-viewer.md) for the event
+format and current CLI/API examples.

--- a/md/design.md
+++ b/md/design.md
@@ -1,6 +1,6 @@
 # Core Library Design
 
-This document describes the design of the `agent-client-protocol` crate and its companion crates (`agent-client-protocol-tokio`, `agent-client-protocol-rmcp`).
+This document describes the design of the `agent-client-protocol` crate and its companion transport and integration crates.
 
 For API usage, see the [rustdoc](https://docs.rs/agent-client-protocol) and [cookbook](https://docs.rs/agent-client-protocol-cookbook).
 
@@ -14,14 +14,12 @@ The core SDK. Provides:
 - **Connection builders** (`builder()`, `connect_to()`, `connect_with()`)
 - **Message handling** (`on_receive_request`, `on_receive_notification`, `on_receive_dispatch`)
 - **Protocol types** (`agent_client_protocol::schema::*`) - all ACP message types
+- **Transports and process launching** (`Channel`, `Lines`, `ByteStreams`, `Stdio`, `AcpAgent`)
 - **MCP server attachment** - runtime-agnostic interfaces for wiring MCP servers into ACP sessions
 
-### agent-client-protocol-tokio
+### agent-client-protocol-http
 
-Tokio-specific utilities:
-
-- **Process spawning** - spawn agent/proxy processes and connect via stdio
-- **Transport helpers** - convert tokio streams to ACP transports
+Optional HTTP/SSE and WebSocket clients and servers built on the core transport-frame boundary.
 
 ### agent-client-protocol-rmcp
 
@@ -89,7 +87,7 @@ sequenceDiagram
     participant Handlers
     participant UserCode
 
-    Transport->>DispatchLoop: incoming JSON-RPC message
+    Transport->>DispatchLoop: incoming TransportFrame
     DispatchLoop->>Handlers: try handlers in order
 
     alt Handler matches
@@ -165,9 +163,11 @@ This keeps request correctness separate from async cancellation policy. Applicat
 | -------------------------------------------- | ------------------------------------- |
 | `src/agent-client-protocol/src/role.rs`      | Role trait and type definitions       |
 | `src/agent-client-protocol/src/role/acp.rs`  | Client, Agent, Proxy, Conductor roles |
-| `src/agent-client-protocol/src/component.rs` | ConnectTo and Builder traits          |
-| `src/agent-client-protocol/src/handler.rs`   | Connection builder implementation     |
-| `src/agent-client-protocol/src/typed.rs`     | Dispatch type and handler matching    |
+| `src/agent-client-protocol/src/component.rs` | `ConnectTo` component abstraction     |
+| `src/agent-client-protocol/src/jsonrpc.rs`  | Connection builder and frame types    |
+| `src/agent-client-protocol/src/jsonrpc/handlers.rs` | Handler chain implementation  |
+| `src/agent-client-protocol/src/jsonrpc/transport_actor.rs` | Line framing and JSON parsing |
+| `src/agent-client-protocol/src/util/typed.rs` | Dispatch typing and matching helpers |
 | `src/agent-client-protocol/src/mcp_server/`  | Runtime-agnostic MCP server attachment |
 | `src/agent-client-protocol/src/concepts/`    | Rustdoc concept explanations          |
 

--- a/md/http-transport.md
+++ b/md/http-transport.md
@@ -10,6 +10,36 @@
 
 `POST /acp` request bodies are limited to 16 MiB.
 
+## JSON-RPC Batches
+
+`HttpClient` starts every connection with an individual `initialize` and
+requires an individual initialize response. For compatibility with other
+clients, the server also accepts an initial batch when its first call-shaped
+entry is an `initialize` request. Valid and malformed response-only entries may
+precede it and are ignored; an invalid or call-shaped predecessor rejects the
+batch as an initial frame. The server forwards the complete frame and returns
+the complete grouped response in the POST response body; a successful
+initialize also adds `Acp-Connection-Id`. Lifecycle-sensitive calls should
+normally remain individual. If the agent emits a notification or callback
+before the initialize response is ready, including from a batched sibling, the
+server buffers that frame for the connection's SSE stream until initialization
+completes.
+
+After initialization, both transport shapes preserve batches:
+
+- On an established HTTP connection, one complete batch occupies one POST
+  body. The server returns `202 Accepted`; any grouped JSON-RPC reply is
+  delivered through SSE as one array.
+- WebSocket sends one complete batch in one text frame and writes its grouped
+  reply in one text frame.
+- A grouped HTTP reply is sent to a session stream only when all correlated
+  entries have the same session route. If routes differ, it is sent on the
+  connection-level stream so the array remains intact.
+
+Entry validation, notification-only behavior, empty arrays, and malformed
+response filtering follow the shared [transport batch
+contract](./transport-architecture.md#json-rpc-batch-behavior).
+
 ## HTTP + SSE Streams
 
 After `initialize`, clients should open a connection-level SSE stream:

--- a/md/introduction.md
+++ b/md/introduction.md
@@ -18,15 +18,15 @@ The `agent-client-protocol` crate includes a [`concepts`](https://docs.rs/agent-
 
 ### Repository Structure
 
-```
+```text
 src/
 ├── agent-client-protocol/              # Core protocol SDK
-├── agent-client-protocol-tokio/        # Tokio utilities (process spawning)
 ├── agent-client-protocol-http/         # HTTP/SSE/WebSocket transport
 ├── agent-client-protocol-rmcp/         # Integration with rmcp crate
 ├── agent-client-protocol-cookbook/     # Usage patterns (rendered as rustdoc)
 ├── agent-client-protocol-derive/       # Proc macros
 ├── agent-client-protocol-conductor/    # Conductor binary and library
+├── agent-client-protocol-polyfill/     # Compatibility proxy implementations
 ├── agent-client-protocol-test/         # Test utilities and fixtures
 ├── agent-client-protocol-trace-viewer/ # Trace visualization tool
 └── yopo/                               # "You Only Prompt Once" example client
@@ -36,18 +36,19 @@ src/
 
 ```mermaid
 graph TD
-    acp[agent-client-protocol<br/>Core SDK]
-    tokio[agent-client-protocol-tokio<br/>Process spawning]
+    acp[agent-client-protocol<br/>Core SDK, stdio, process spawning]
     http[agent-client-protocol-http<br/>HTTP/SSE/WebSocket transport]
     rmcp[agent-client-protocol-rmcp<br/>rmcp integration]
     conductor[agent-client-protocol-conductor<br/>Proxy orchestration]
+    polyfill[agent-client-protocol-polyfill<br/>Compatibility proxies]
+    trace[agent-client-protocol-trace-viewer<br/>Trace visualization]
     cookbook[agent-client-protocol-cookbook<br/>Usage patterns]
 
-    tokio --> acp
     http --> acp
     rmcp --> acp
     conductor --> acp
-    conductor --> tokio
+    conductor --> trace
+    polyfill --> acp
     cookbook --> acp
     cookbook --> rmcp
     cookbook --> conductor
@@ -55,8 +56,10 @@ graph TD
 
 ### Key Design Documents
 
-- [Core Library Design](./design.md) - How `agent-client-protocol`, `agent-client-protocol-tokio`, and `agent-client-protocol-rmcp` are organized
+- [Core Library Design](./design.md) - How the core crate and its transport and integration crates are organized
+- [Transport Architecture](./transport-architecture.md) - The frame-aware boundary shared by transports and in-process components
 - [Conductor Design](./conductor.md) - How the conductor orchestrates proxy chains
 - [Protocol Reference](./protocol.md) - Wire protocol details and extension methods
-- [P/ACP Specification](./proxying-acp.md) - The full proxy protocol specification
+- [Original P/ACP Design Proposal](./proxying-acp.md) - Historical design context; not the current wire reference
+- [Migrating to v2.0](./migration_v2.0.md) - Upgrade guide from 1.x to 2.0
 - [Migrating to v0.11](./migration_v0.11.x.md) - Upgrade guide from 0.10.x to 0.11

--- a/md/mcp-bridge.md
+++ b/md/mcp-bridge.md
@@ -1,380 +1,107 @@
-# MCP Bridge: Proxying MCP over ACP
+# MCP-over-ACP Compatibility Bridge
 
-The **MCP Bridge** enables agents without native MCP-over-ACP support to work with proxy components that provide MCP servers using ACP transport (`acp:$UUID`).
+`agent-client-protocol-polyfill::mcp_over_acp::McpOverAcpPolyfill` is an
+explicit proxy for agents that cannot consume the SDK's legacy ACP-routed MCP
+server declarations directly. MCP adaptation is no longer built into the
+conductor.
 
-## Problem Statement
+## Native and Legacy Transports
 
-Proxy components may want to expose MCP servers to agents using ACP as the transport layer. This allows:
+Two similarly named mechanisms coexist and must not be mixed:
 
-- Dynamic MCP server registration during session creation
-- Proxies to correlate MCP tool calls with specific ACP sessions
-- Unified protocol handling (everything flows through ACP messages)
+- The draft **native** transport is enabled by `unstable_mcp_over_acp`. It uses
+  `McpServer::Acp` plus `mcp/connect`, `mcp/message`, and `mcp/disconnect`.
+- The polyfill's **legacy compatibility** path recognizes
+  `McpServer::Http` entries whose URL begins with `acp:`. It routes them with
+  `_mcp/connect`, `_mcp/message`, and `_mcp/disconnect`.
 
-However, many agents only support traditional MCP transports (stdio, SSE). The conductor bridges this gap by:
+The polyfill currently implements the second path. New implementations that
+control both peers should prefer the draft native schema types; use the
+polyfill only where compatibility requires it.
 
-1. Accepting `acp:$UUID` URLs in `session/new` requests
-2. Transforming them into stdio-based MCP servers the agent can connect to
-3. Routing MCP messages between the agent (stdio) and proxies (ACP `_mcp/*` messages)
+## Placement
 
-## High-Level Architecture
+Insert the polyfill as a proxy before the final agent:
 
-```mermaid
-flowchart LR
-    Proxy[Proxy Component]
-    Conductor[Conductor]
-    Agent[Agent Process]
-    Bridge[MCP Bridge Process]
+```rust,ignore
+use agent_client_protocol_conductor::{ConductorImpl, ProxiesAndAgent};
+use agent_client_protocol_polyfill::mcp_over_acp::McpOverAcpPolyfill;
 
-    Proxy -->|session/new with acp: URL| Conductor
-    Conductor -->|session/new with stdio| Agent
-    Agent <-->|stdio| Bridge
-    Bridge <-->|TCP| Conductor
-    Conductor <-->|_mcp/* messages| Proxy
+let components = ProxiesAndAgent::new(agent)
+    .proxy(application_proxy)
+    .proxy(McpOverAcpPolyfill::http());
+
+ConductorImpl::new_agent("conductor", components)
+    .run(upstream_transport)
+    .await?;
 ```
 
-**Key decision**: Use stdio + TCP bridge instead of direct stdio to agent, because:
+The application proxy can then supply a legacy declaration such as an HTTP MCP
+server whose URL is `acp:server-1`. The identifier is opaque and must route back
+to the component that provides the MCP server.
 
-- Preserves agent isolation (agent only sees stdio)
-- Enables connection multiplexing (multiple bridges to one conductor)
-- Simplifies lifecycle management (bridge exits when agent closes stdio)
+During initialization, the polyfill forwards the request to its successor and
+sets `agentCapabilities.mcpCapabilities.acp` in the response seen upstream. In
+this chain position that capability means the polyfill can handle the routed
+transport; it does not imply that the final agent implements it natively.
 
-## Session Initialization Flow
+## Transformation
 
-The conductor transforms MCP servers during session creation and correlates them with session IDs.
+For each `McpServer::Http` entry with an `acp:` URL in `session/new`, the
+polyfill:
 
-```mermaid
-sequenceDiagram
-    participant Proxy
-    participant Conductor
-    participant Listener as MCP Bridge<br/>Listener Actor
-    participant Agent
+1. Rejects non-empty HTTP headers, which have no defined meaning for this
+   compatibility transport.
+2. Reuses an existing listener for the same ACP identifier or binds a new
+   localhost TCP listener.
+3. Replaces the server declaration with a transport the final agent can open.
+4. When that transport connects, sends `_mcp/connect` toward the component that
+   declared the identifier.
+5. Relays MCP requests and notifications through `_mcp/message`, keyed by the
+   returned connection identifier, and sends `_mcp/disconnect` when the bridge
+   closes.
 
-    Note over Proxy: Wants to provide MCP server<br/>with session-specific context
+The exact underscore-prefixed envelopes are documented in the [Proxy Extension
+Protocol Reference](./protocol.md#legacy-mcp-polyfill-methods).
 
-    Proxy->>Conductor: session/new {<br/>  mcp_servers: [{<br/>    name: "research-tools",<br/>    url: "acp:uuid-123"<br/>  }]<br/>}
+## HTTP Mode
 
-    Note over Conductor: Detects acp: transport<br/>Agent lacks mcpCapabilities.acp
+`McpOverAcpPolyfill::http()` is the default compatibility shape. It replaces
+the `acp:` declaration with an HTTP MCP URL on `localhost`. The embedded server
+accepts MCP POST requests and an SSE GET stream at `/`, retaining JSON-RPC batch
+frames and correlating each POST with its response.
 
-    Conductor->>Conductor: Bind TCP listener on port 54321
-
-    Conductor->>Listener: Spawn MCP Bridge Listener<br/>(acp_url: "acp:uuid-123")
-
-    Note over Listener: Listening on TCP port 54321<br/>Waiting for session_id
-
-    Conductor->>Agent: session/new {<br/>  mcp_servers: [{<br/>    name: "research-tools",<br/>    command: "conductor",<br/>    args: ["mcp", "54321"]<br/>  }]<br/>}
-
-    Agent-->>Conductor: session/new response {<br/>  session_id: "sess-abc"<br/>}
-
-    Note over Conductor: Extract session_id from response
-
-    Conductor->>Listener: Send session_id: "sess-abc"<br/>(via oneshot channel)
-
-    Note over Listener: Now has session_id<br/>Ready to accept connections
-
-    Conductor-->>Proxy: session/new response {<br/>  session_id: "sess-abc"<br/>}
-
-    Note over Agent: Later: spawns MCP bridge process
-
-    Agent->>Bridge: spawn process:<br/>conductor mcp 54321
-
-    Bridge->>Listener: TCP connect to localhost:54321
-
-    Note over Listener: Connection arrives<br/>Session ID already known
-
-    Listener->>Conductor: McpConnectionReceived {<br/>  acp_url: "acp:uuid-123",<br/>  session_id: "sess-abc"<br/>}
-
-    Conductor->>Proxy: _mcp/connect {<br/>  acp_url: "acp:uuid-123",<br/>  session_id: "sess-abc"<br/>}
-
-    Proxy-->>Conductor: _mcp/connect response {<br/>  connection_id: "conn-xyz"<br/>}
-
-    Note over Proxy: Can correlate connection<br/>with session context
-
-    Conductor-->>Listener: connection_id: "conn-xyz"
-
-    Note over Listener,Bridge: Bridge now active<br/>Routes MCP <-> ACP messages
+```rust,ignore
+let bridge = McpOverAcpPolyfill::http();
 ```
 
-### Key Decisions
+The listener is bound only on loopback and uses an ephemeral port. It does not
+implement resumable SSE event IDs.
 
-**Why spawn TCP listener before getting session_id (during request, not response)?**
+## Stdio Mode
 
-- Agent may spawn bridge process immediately after receiving `session/new` response
-- If listener doesn't exist yet, bridge connection fails with "connection refused"
-- Spawning during request ensures TCP port is ready before agent receives response
-- Session_id delivered asynchronously via oneshot channel once response arrives
+`McpOverAcpPolyfill::stdio(command)` replaces the declaration with an MCP stdio
+server. It appends `mcp PORT` to the supplied command and expects that process
+to copy newline-delimited JSON-RPC between stdio and the designated localhost
+TCP port.
 
-**Why send session_id to listener before forwarding response?**
-
-- Ensures session_id is available before agent spawns bridge process
-- Eliminates race condition where TCP connection arrives before session_id known
-- Listener blocks on receiving session_id, guaranteeing it's available when needed
-
-**Why include session_id in `_mcp/connect`?**
-
-- Proxies need to correlate MCP connections with ACP sessions
-- Example: Research proxy remembers session context (current task, preferences)
-- Without session_id, proxy has no way to associate connection with session state
-
-**Why use oneshot channel for session_id delivery?**
-
-- Listener spawned during request handling (before response available)
-- Response comes asynchronously from agent
-- Oneshot channel delivers session_id exactly once when response arrives
-- Clean separation: listener setup (during request) vs session_id delivery (during response)
-
-## Connection Lifecycle
-
-Once the MCP connection is established, the bridge routes messages bidirectionally:
-
-```mermaid
-sequenceDiagram
-    participant Agent
-    participant Bridge as MCP Bridge<br/>Process
-    participant Listener as Bridge Listener<br/>Actor
-    participant Conductor
-    participant Proxy
-
-    Note over Agent,Proxy: Connection established (connection_id: "conn-xyz")
-
-    Agent->>Bridge: MCP tools/list request<br/>(stdio JSON-RPC)
-
-    Bridge->>Listener: JSON-RPC over TCP
-
-    Listener->>Conductor: Raw JSON-RPC message
-
-    Conductor->>Proxy: _mcp/request {<br/>  connection_id: "conn-xyz",<br/>  method: "tools/list",<br/>  params: {...}<br/>}
-
-    Note over Proxy: Has connection_id -> session_id mapping<br/>Can use session context
-
-    Proxy-->>Conductor: _mcp/request response {<br/>  tools: [...]<br/>}
-
-    Conductor-->>Listener: JSON-RPC response
-
-    Listener-->>Bridge: JSON-RPC over TCP
-
-    Bridge-->>Agent: MCP response<br/>(stdio JSON-RPC)
-
-    Note over Agent: Agent disconnects
-
-    Agent->>Bridge: Close stdio
-
-    Bridge->>Listener: Close TCP connection
-
-    Listener->>Conductor: McpConnectionDisconnected {<br/>  connection_id: "conn-xyz"<br/>}
-
-    Conductor->>Proxy: _mcp/disconnect {<br/>  connection_id: "conn-xyz"<br/>}
-
-    Note over Proxy: Clean up session state
+```rust,ignore
+let bridge = McpOverAcpPolyfill::stdio(vec![
+    "legacy-mcp-bridge".to_owned(),
+]);
 ```
 
-### Key Decisions
-
-**Why route through conductor instead of direct bridge-to-proxy?**
-
-- Maintains consistent message ordering through central conductor queue
-- Preserves conductor as sole message router
-- Simplifies error handling and lifecycle management
-
-**Why use connection_id instead of session_id in `_mcp/*` messages?**
-
-- One session can have multiple MCP connections (multiple servers)
-- Connection_id uniquely identifies the bridge instance
-- Proxies maintain `connection_id -> session_id` mapping internally
-
-**Why send disconnect notification?**
-
-- Allows proxies to clean up session-specific state
-- Enables resource cleanup (close files, release locks, etc.)
-- Provides explicit lifecycle boundary
-
-## Race Condition Handling
-
-The session_id delivery mechanism prevents a race condition:
-
-```mermaid
-sequenceDiagram
-    participant Conductor
-    participant Listener as MCP Bridge Listener
-    participant Agent
-    participant Bridge as MCP Bridge Process
-
-    Note over Conductor: Without oneshot channel coordination
-
-    Conductor->>Listener: Spawn (no session_id yet)
-
-    Conductor->>Agent: session/new request
-
-    Note over Agent: Fast agent responds immediately
-
-    Agent->>Bridge: Spawn bridge process
-
-    Bridge->>Listener: TCP connect
-
-    Note over Listener: ❌ No session_id available yet!<br/>Can't send McpConnectionReceived
-
-    Agent-->>Conductor: session/new response {<br/>  session_id: "sess-abc"<br/>}
-
-    Note over Conductor: Too late - connection already waiting
-
-    rect rgb(200, 50, 50)
-        Note over Listener,Bridge: Race condition:<br/>Connection arrived before session_id
-    end
-```
-
-**Solution**: Listener blocks on oneshot channel:
-
-```mermaid
-sequenceDiagram
-    participant Conductor
-    participant Listener as MCP Bridge Listener
-    participant Agent
-    participant Bridge as MCP Bridge Process
-
-    Conductor->>Listener: Spawn with oneshot receiver
-
-    Note over Listener: Listening on TCP<br/>Waiting for session_id via oneshot
-
-    Conductor->>Agent: session/new request
-
-    Agent->>Bridge: Spawn bridge process
-
-    Bridge->>Listener: TCP connect
-
-    Note over Listener: Connection accepted<br/>⏸️ BLOCKS waiting for session_id
-
-    Agent-->>Conductor: session/new response {<br/>  session_id: "sess-abc"<br/>}
-
-    Conductor->>Listener: Send "sess-abc" via oneshot
-
-    Note over Listener: ✅ Session ID received<br/>Unblocks with connection + session_id
-
-    Listener->>Conductor: McpConnectionReceived {<br/>  acp_url: "acp:uuid-123",<br/>  session_id: "sess-abc"<br/>}
-
-    rect rgb(50, 200, 50)
-        Note over Listener,Bridge: No race condition:<br/>session_id always available
-    end
-```
-
-**Key decision**: Block connection acceptance on session_id availability
-
-- Listener accepts TCP connection immediately (agent won't wait)
-- But blocks sending `McpConnectionReceived` until session_id arrives
-- Guarantees session_id is always available when creating `_mcp/connect` request
-- Simple implementation: `oneshot_rx.await?` before sending message
-
-## Multiple MCP Servers
-
-A single session can register multiple MCP servers:
-
-```mermaid
-flowchart TB
-    Proxy[Proxy]
-    Conductor[Conductor]
-    Agent[Agent]
-
-    Listener1[Listener: acp:uuid-1<br/>Port 54321]
-    Listener2[Listener: acp:uuid-2<br/>Port 54322]
-
-    Bridge1[Bridge: conductor mcp 54321]
-    Bridge2[Bridge: conductor mcp 54322]
-
-    Proxy -->|session/new with 2 servers| Conductor
-    Conductor -->|session_id: sess-abc| Listener1
-    Conductor -->|session_id: sess-abc| Listener2
-    Conductor -->|session/new response| Proxy
-
-    Agent <-->|stdio| Bridge1
-    Agent <-->|stdio| Bridge2
-
-    Bridge1 <-->|TCP| Listener1
-    Bridge2 <-->|TCP| Listener2
-
-    Listener1 -->|_mcp/* messages<br/>conn-1| Conductor
-    Listener2 -->|_mcp/* messages<br/>conn-2| Conductor
-
-    Conductor <-->|Both connections| Proxy
-
-    style Listener1 fill:#e1f5ff
-    style Listener2 fill:#e1f5ff
-```
-
-**Key decisions**:
-
-- Each `acp:` URL gets its own TCP port and listener
-- All listeners for a session receive the same session_id
-- Each connection gets unique connection_id
-- Proxy maintains map: `connection_id -> (session_id, acp_url)`
-
-## Implementation Components
-
-### McpBridgeListeners
-
-- **Purpose**: Manages TCP listeners for all `acp:` URLs
-- **Lifecycle**: Created with conductor, lives for entire conductor lifetime
-- **Responsibilities**:
-  - Detect `acp:` URLs during `session/new`
-  - Spawn TCP listeners on ephemeral ports
-  - Transform MCP server specs to stdio transport
-  - Deliver session_id to listeners via oneshot channels
-
-### McpBridgeListener Actor
-
-- **Purpose**: Accepts TCP connections for a specific `acp:` URL
-- **Lifecycle**: Spawned during `session/new`, lives until conductor exits
-- **Responsibilities**:
-  - Listen on TCP port
-  - Block on oneshot channel to receive session_id
-  - Accept connections and send `McpConnectionReceived` with session_id
-  - Spawn connection actors
-
-### McpBridgeConnectionActor
-
-- **Purpose**: Routes messages for a single MCP connection
-- **Lifecycle**: Spawned when agent connects, exits when agent disconnects
-- **Responsibilities**:
-  - Read JSON-RPC from TCP, forward to conductor
-  - Receive messages from conductor, write to TCP
-  - Send `McpConnectionDisconnected` on close
-
-### MCP Bridge Process (`conductor mcp $PORT`)
-
-- **Purpose**: Bridges agent's stdio to conductor's TCP
-- **Lifecycle**: Spawned by agent, exits when stdio closes
-- **Responsibilities**:
-  - Connect to TCP port on startup
-  - Bidirectional stdio ↔ TCP forwarding
-  - No protocol awareness (just bytes)
-
-## Error Handling
-
-### Agent Disconnects During Session Creation
-
-If agent closes connection before sending `session/new` response:
-
-- Oneshot channel sender drops
-- Listener receives `Err` from oneshot
-- Listener exits gracefully
-- TCP port cleaned up
-
-### Bridge Process Crashes
-
-If bridge process exits unexpectedly:
-
-- TCP connection closes
-- Listener detects disconnect
-- Sends `McpConnectionDisconnected`
-- Proxy cleans up state
-
-### Multiple Connections to Same Listener
-
-Decision: Allow multiple connections per listener (for future flexibility)
-
-- Each connection gets unique connection_id
-- All connections share same session_id
-- Proxy can correlate all connections to session
-
-## Related Documentation
-
-- [Conductor Design](./conductor.md) - Conductor architecture
-- [Protocol Reference](./protocol.md) - ACP message formats
-- [Cookbook rustdoc](https://docs.rs/agent-client-protocol-cookbook) - Patterns for implementing MCP-aware proxies
+The current `agent-client-protocol-conductor` binary has no `mcp` subcommand,
+so it is not itself a valid stdio bridge command. Use this mode only with a
+compatible bridge executable; otherwise use HTTP mode.
+
+## Lifecycle and Failure Behavior
+
+Each accepted bridge connection receives a unique connection ID from
+`_mcp/connect`. The polyfill keeps a connection map until the local MCP
+transport closes, then removes the entry and sends `_mcp/disconnect`.
+Connection or relay failures propagate through the proxy connection rather than
+being encoded as notification responses.
+
+The polyfill does not infer or store ACP session IDs. Association is carried by
+the MCP server identifier and the resulting MCP connection ID.

--- a/md/migration_v0.11.x.md
+++ b/md/migration_v0.11.x.md
@@ -2,6 +2,10 @@
 
 This guide explains how to move existing code to the programming model planned for `agent-client-protocol` `0.11`.
 
+> **Historical note:** later releases merged subprocess and stdio support into
+> `agent-client-protocol`. The examples below use the current import path where
+> that does not obscure the 0.11 migration itself.
+
 Throughout this guide:
 
 - **old API** = `agent-client-protocol` `0.10.x`
@@ -42,7 +46,7 @@ The main construction changes are:
 
 If you already have stdin/stdout or socket-like byte streams, wrap them with `ByteStreams::new(outgoing, incoming)`.
 
-If you are spawning subprocess agents, prefer `agent-client-protocol-tokio` over hand-rolled process wiring.
+If you are spawning subprocess agents, prefer the core crate's `AcpAgent` over hand-rolled process wiring.
 
 If you already have a reason to stay at the raw request/response level, you can still send `PromptRequest` directly with `cx.send_request(...)`; the session helpers are just the default migration path for most client code.
 
@@ -283,14 +287,14 @@ Most migrations to the `0.11` API can remove:
 
 When you need concurrency from a handler in `0.11`, use `cx.spawn(...)`.
 
-## 9. Prefer `agent-client-protocol-tokio` for subprocess agents
+## 9. Prefer `AcpAgent` for subprocess agents
 
 If your old client code spawned an agent with `tokio::process::Command`, the new stack has a higher-level helper for that. `AcpAgent` implements `ConnectTo<Client>` and takes care of spawning the process and wiring up its stdio:
 
 ```rust
 use agent_client_protocol as acp;
 use acp::schema::{InitializeRequest, ProtocolVersion};
-use agent_client_protocol_tokio::AcpAgent;
+use agent_client_protocol::AcpAgent;
 use std::str::FromStr;
 
 #[tokio::main]

--- a/md/migration_v2.0.md
+++ b/md/migration_v2.0.md
@@ -61,13 +61,37 @@ channel.tx.unbounded_send(TransportFrame::Single(message)).unwrap();
 ```
 
 `TransportFrame` distinguishes a valid single message, a non-empty `TransportBatch`, and an
-explicit malformed wire value. Transport I/O failures are returned by the future from
+explicit malformed wire value. Each batch contains public `TransportBatchEntry` values so a
+relay can retain invalid siblings without turning a protocol error into a transport failure.
+All three public frame types implement `Clone`, and `TransportBatch::into_entries()` provides an
+owned, source-order iterator.
+
+Transport I/O failures are returned by the future from
 `ConnectTo::into_channel_and_future`; they are never channel items. Components should preserve a
 received frame intact when relaying it so batch response grouping remains correct.
 
-The separate, hidden `FramedChannel` and `into_framed_channel_and_future` compatibility path no
-longer exist. Implement only `ConnectTo::connect_to`, optionally overriding
-`into_channel_and_future` for a direct channel adapter.
+`TransportFrame::parse_json` returns a frame directly for every input. It retains malformed
+response-shaped values so raw framed intermediaries can preserve them; protocol actors suppress
+replies to response-only shapes. Standalone malformed input keeps its exact source text. Batch
+entries retain parsed JSON values and source order, but reserialization may normalize whitespace.
+
+The standard line, byte-stream, stdio, HTTP, and WebSocket transports now accept incoming
+JSON-RPC batches in both protocol v1 and v2 mode. Entries are handled independently, replies are
+grouped into one response array, notification-only batches produce no reply, and an empty array
+produces one standalone `Invalid Request` response. Malformed entries that are response-shaped but
+not call-shaped are ignored because JSON-RPC responses must not themselves receive responses. The
+SDK does not initiate batches of requests or notifications. See
+[Transport Architecture](./transport-architecture.md#json-rpc-batch-behavior) for the full framing
+contract.
+
+Dropping a `Responder` for one request in a batch now produces an `Internal Error` fallback after
+dispatch completes, allowing completed sibling responses to flush. A handler error overrides the
+fallback with that error. The longstanding behavior for an individual request is unchanged:
+dropping its responder does not automatically send a response.
+
+Existing `ConnectTo` implementations that override `into_channel_and_future` must now return the
+frame-aware `Channel`. Most components need to implement only `ConnectTo::connect_to`; a direct
+channel adapter may still override `into_channel_and_future` to avoid an intermediate copy.
 
 ## Response routing uses routing terminology
 
@@ -82,6 +106,10 @@ Its methods have therefore been renamed:
 | `respond_with_internal_error` | `route_with_internal_error` |
 
 `Responder` still uses `respond*`, because it sends the response to an incoming request.
+
+If a catch-all response handler returns `Err`, that error is now routed to the local
+`SentRequest` awaiter. It is never serialized as a response to the peer's response. This replaces
+the misleading generic failure that previously appeared when the real interceptor error was lost.
 
 ## Request IDs remain typed
 
@@ -117,6 +145,15 @@ respond to an individual JSON-RPC request. The builder method now reflects that 
 | 1.x | 2.0 |
 | --- | --- |
 | `Builder::with_responder` | `Builder::with_runner` |
+
+The conductor crate applies the same terminology to its public background task:
+
+| 1.x | 2.0 |
+| --- | --- |
+| `agent_client_protocol_conductor::ConductorResponder` | `agent_client_protocol_conductor::ConductorRunner` |
+
+This is a type rename only; custom code that names the conductor task should update its imports
+and type references.
 
 ## Matchers use dispatch terminology
 
@@ -171,6 +208,35 @@ already-returned `NewSessionResponse` is no longer supported, so move request cu
 
 Construct `Lines` and `ByteStreams` with `Lines::new(outgoing, incoming)` and
 `ByteStreams::new(outgoing, incoming)`; their stream fields are no longer public.
+
+## Draft v2 schema updates
+
+The optional `unstable_protocol_v2` surface now tracks
+`agent-client-protocol-schema` 1.5. Because this API is explicitly unstable, its source changes
+are included in the SDK 2.0 migration rather than treated as stable-v1 wire changes.
+
+- Many values that were plain `String` or `PathBuf` fields are semantic newtypes, including
+  `AbsolutePath`, `MediaType`, session/message/tool/terminal IDs, and list cursors. Construct them
+  with `.into()` or their `new` methods, and use `AsRef<Path>` or `as_ref()` when borrowing their
+  contents.
+- `v2::DiffPatch.diff` is now `text`. `DiffPatch::new(text)` remains the preferred constructor.
+- Terminal state is represented by `Terminal`, `TerminalUpdate`, `TerminalOutput`,
+  `TerminalOutputChunk`, and `TerminalExitStatus`. `SessionUpdate` also has terminal update and
+  output-chunk variants, so exhaustive matches must handle the new variants.
+- Conversion helpers are now generic and fallible. Replace `v2_to_v1(value)` and
+  `v1_to_v2(value)` with `try_v2_to_v1::<_, Target>(value)` and
+  `try_v1_to_v2::<_, Target>(value)`. Use `try_v2_to_v1_many::<_, Target>(value)` when one v2
+  update may become several v1 updates.
+- The bespoke `IntoV1`, `IntoV1Many`, and `IntoV2` conversion traits have been removed. Use the
+  standard `TryFrom`/`TryInto` traits for fallible conversions, `From`/`Into` for infallible
+  conversions, or the helper functions above.
+- `v2::SessionCapabilities::into_v1()` is now `try_into_v1_parts()`.
+
+## `SentRequest::map` accepts arbitrary output
+
+`SentRequest::map` can now consume a typed response into any output type; the mapped value no
+longer needs to implement `JsonRpcResponse`. The mapper may also be a one-shot closure. This is
+additive, so existing mapping code does not need to change.
 
 ## `AcpAgent` has its own process configuration
 

--- a/md/protocol-v2.md
+++ b/md/protocol-v2.md
@@ -12,24 +12,12 @@ is a versioning experiment, not just an unstable method family.
 
 ## JSON-RPC batches
 
-The standard `Lines`, `ByteStreams`, and `Stdio` transports accept incoming
-JSON-RPC batch arrays. They process each entry independently, preserve valid
-entries when a sibling is invalid, and collect all response-bearing entries
-into one response array after the batch completes. An empty array receives one
-`Invalid Request` response object, while a notification-only batch receives no
-response. Incoming response arrays are routed entry by entry using their request
-IDs; malformed response-like siblings are ignored rather than answered.
-
-This support lives in the shared transport layer and therefore also works in
-v1 mode as a compatibility extension. The SDK does not initiate batches of
-requests or notifications. It only writes a batch array when responding to a
-batch call received from the peer; requests received individually continue to
-receive individual response objects.
-
-ACP peers should still send lifecycle-sensitive calls individually. For
-compatibility, the agent protocol router accepts `initialize` as the first
-entry of an incoming batch and preserves that batch when handing the connection
-to the selected v1 or v2 implementation.
+Batch framing is a shared JSON-RPC transport feature, not a v2-only protocol
+feature. Both v1 and v2 accept incoming batches, preserve them through relays,
+and group replies into one response array. The SDK does not originate batches
+of requests or notifications. See [Transport Architecture: JSON-RPC Batch
+Behavior](./transport-architecture.md#json-rpc-batch-behavior) for the complete
+rules.
 
 By default, `Client.builder()` and `Agent.builder()` continue to expose the
 stable v1 API and advertise protocol v1. To use the v2 API for a connection,
@@ -49,7 +37,7 @@ Client
     .connect_with(agent_transport, async |cx| {
         let initialize = cx
             .send_request(v2::InitializeRequest::new(
-                ProtocolVersion::V1,
+                ProtocolVersion::V2,
                 implementation(),
             ))
             .block_task()
@@ -102,7 +90,7 @@ The SDK handles the `initialize` negotiation at the JSON-RPC boundary:
 That means v1 and v2 implementations still need separate handlers.
 `Agent.v2()` and `Client.v2()` are v2-only. While protocol v2 stabilizes, the
 `unstable_protocol_v2` crate feature also exposes `Agent.protocol_router()` and
-`Client.protocol_router()` for composing version-specific implementations.
+`Client.protocol_connector()` for composing version-specific implementations.
 
 Agents can add protocol implementations independently, which makes it easy for
 applications built with v2 support to control v2 rollout with a runtime feature
@@ -153,39 +141,45 @@ The protocol router reads the initial `initialize` request, selects the
 highest configured protocol version that is compatible with the requested
 version, and then hands the connection to that implementation. If only v2 is
 configured, v1 clients are rejected without changing the fluent API. The router
-does not convert messages between v1 and v2 after routing.
+does not convert messages between v1 and v2 after routing. For compatibility,
+the initial frame may be a batch whose first call-shaped entry is `initialize`;
+the router preserves the complete frame when handing it to the selected
+implementation. Response-only frames before initialization are ignored.
 
-Clients use the same fluent shape:
+Clients use a connector because fallback may require opening a new transport.
+Both client implementations and the agent transport are factories:
 
-```rust
-use agent_client_protocol::{Client, ConnectTo};
+```rust,ignore
+use agent_client_protocol::Client;
 
-# fn v1_client() -> impl agent_client_protocol::ConnectTo<agent_client_protocol::Agent> {
-#     Client.builder()
-# }
-# fn v2_client() -> impl agent_client_protocol::ConnectTo<agent_client_protocol::Agent> {
-#     Client.v2()
-# }
-# async fn run(agent_transport: impl agent_client_protocol::ConnectTo<agent_client_protocol::Client>) -> agent_client_protocol::Result<()> {
-# let enable_protocol_v2 = true;
-let client = Client.protocol_router().with_v1(v1_client());
+let connector = Client
+    .protocol_connector()
+    .with_v1(|| v1_client())
+    .with_v2(|| v2_client());
 
-let client = if enable_protocol_v2 {
-    client.with_v2(v2_client())
-} else {
-    client
-};
-
-client
-    .connect_to(agent_transport)
-    .await?;
-# Ok(())
-# }
+connector.connect_to(|| open_agent_transport()).await?;
 ```
 
-The client router starts the highest configured implementation. If v2
-initialization negotiates v1 and a v1 implementation is configured, it switches
-to the local v1 client implementation and forwards the original initialize
-response. It does not send a second initialize request on the same connection.
-If v2 initialization is rejected, that error is surfaced to the v2 client
-implementation.
+The connector starts the highest configured implementation. If a successful v2
+initialize response negotiates v1 and a v1 implementation is configured, the
+connector starts the v1 implementation and compares the initialize metadata and
+capabilities it would send with the normalized v2 request already seen by the
+agent:
+
+- If they match exactly, the connector reuses the current agent connection and
+  delivers the original response to the v1 implementation with its request ID.
+  It does not send a second initialize request.
+- If they differ, the connector closes that connection, calls both factories
+  again as needed, and performs a fresh v1 initialization on a new agent
+  connection.
+- If the agent rejects the v2 initialize request, the error is surfaced. A
+  rejected initialize is not treated as permission to retry with v1.
+
+## Draft schema changes in schema 1.5
+
+The `unstable_protocol_v2` API follows the moving draft schema. Schema 1.5 adds
+semantic newtypes for paths, media types, IDs, and cursors; renames
+`DiffPatch.diff` to `DiffPatch.text`; adds terminal state and output update
+types; and makes v1/v2 conversions fallible and generic. These are draft API
+changes rather than stable v1 wire changes. See [Migrating to
+v2.0](./migration_v2.0.md#draft-v2-schema-updates) for concrete source changes.

--- a/md/protocol.md
+++ b/md/protocol.md
@@ -1,355 +1,148 @@
-# Protocol Reference
+# Proxy Extension Protocol Reference
 
-This chapter documents the P/ACP protocol extensions to ACP. These extensions use ACP's [extensibility mechanism](https://agentclientprotocol.com/protocol/extensibility) through custom methods and `_meta` fields.
+This chapter documents the extension methods implemented by the Rust SDK's
+conductor and MCP-over-ACP polyfill. These methods are provisional SDK
+extensions. They are separate from stable ACP methods and from the draft native
+MCP-over-ACP methods described below.
 
-## Overview
+## Method Summary
 
-P/ACP defines two main protocol extensions:
+| Method | JSON-RPC shape | Purpose |
+| --- | --- | --- |
+| `_proxy/initialize` | request | Initialize a component as a proxy |
+| `_proxy/successor` | request or notification | Forward one inner ACP message to the next component |
+| `_mcp/connect` | request | Open a legacy polyfill MCP connection |
+| `_mcp/message` | request or notification | Carry one inner MCP message through the legacy polyfill |
+| `_mcp/disconnect` | notification | Close a legacy polyfill MCP connection |
 
-1. **`_proxy/successor/*`** - For proxy-to-successor communication
-2. **`_mcp/*`** - For MCP-over-ACP bridging
+There are no `_proxy/successor/request`, `_proxy/successor/notification`,
+`_mcp/request`, or `_mcp/notification` methods. The presence of an outer
+JSON-RPC `id` distinguishes requests from notifications.
 
-## The `_proxy/successor/*` Protocol
+## Proxy Initialization
 
-Proxies communicate with their downstream component (next proxy or agent) through the conductor using these extension methods.
+The conductor sends `_proxy/initialize` to a component that has a successor.
+Its parameters are the same fields as a normal v1 `InitializeRequest`. Receiving
+this method, rather than `initialize`, tells the component that it is running as
+a proxy and may forward messages with `_proxy/successor`.
 
-### `_proxy/successor/request`
+The response is a normal `InitializeResponse` result. The final agent receives
+the ordinary `initialize` method and does not need to understand the proxy
+extension.
 
-Send a request to the successor component.
+## Successor Forwarding
 
-**Request:**
+`_proxy/successor` wraps one inner ACP method and its parameters. The inner
+message is flattened into the outer parameters:
 
 ```json
 {
   "jsonrpc": "2.0",
-  "id": 1,
-  "method": "_proxy/successor/request",
+  "id": 12,
+  "method": "_proxy/successor",
   "params": {
-    // The actual ACP request to forward, flattened
-    "method": "prompt",
+    "method": "session/prompt",
     "params": {
-      "messages": [...]
+      "sessionId": "session-1",
+      "prompt": []
     }
   }
 }
 ```
 
-**Response:**
-The response is the successor's response to the forwarded request:
+The conductor unwraps the message and sends the inner request to the next
+component. The outer response carries the inner request's result or error. To
+forward an inner notification, omit the outer `id`; no response is produced.
+Optional extension metadata may be included as `_meta` alongside the flattened
+inner message.
 
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": {
-    // The successor's response
-  }
-}
-```
+## Legacy MCP Polyfill Methods
 
-**Usage:** When a proxy receives an ACP request from upstream and wants to forward it (possibly transformed) to the downstream component, it sends `_proxy/successor/request` to the conductor. The conductor routes it to the next component.
-
-### `_proxy/successor/notification`
-
-Send a notification to the successor component.
-
-**Notification:**
-
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "_proxy/successor/notification",
-  "params": {
-    // The actual ACP notification to forward, flattened
-    "method": "cancelled",
-    "params": {}
-  }
-}
-```
-
-**Usage:** When a proxy receives a notification from upstream and wants to forward it downstream.
-
-### Message Flow Examples
-
-**Example: Transforming a prompt**
-
-1. Editor sends `prompt` request to conductor
-2. Conductor forwards as normal ACP `prompt` to Proxy A
-3. Proxy A modifies the prompt and sends:
-   ```json
-   {
-     "method": "_proxy/successor/request",
-     "params": {
-       "method": "prompt",
-       "params": {
-         /* modified prompt */
-       }
-     }
-   }
-   ```
-4. Conductor routes to Proxy B as normal `prompt`
-5. Response flows back through the chain
-
-**Pass-through proxies**: A proxy that doesn't register any handlers passes all messages through unchanged - the conductor automatically routes unhandled messages.
-
-## Capability Handshake
-
-### The `Proxy` Capability
-
-The conductor uses a two-way capability handshake to verify components can act as proxies.
-
-**InitializeRequest from conductor to proxy:**
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "initialize",
-  "params": {
-    "protocolVersion": "0.7.0",
-    "capabilities": {},
-    "_meta": {
-      "proxy": true
-    }
-  }
-}
-```
-
-**InitializeResponse from proxy to conductor:**
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": {
-    "protocolVersion": "0.7.0",
-    "serverInfo": {},
-    "capabilities": {},
-    "_meta": {
-      "proxy": true
-    }
-  }
-}
-```
-
-**Why a two-way handshake?**
-
-The proxy capability is an _active protocol_ - it requires the component to handle `_proxy/successor/*` messages and route communications. If a component doesn't respond with the proxy capability, the conductor fails initialization with an error.
-
-**Agent initialization:**
-
-The last component (agent) is NOT offered the proxy capability:
-
-```json
-{
-  "method": "initialize",
-  "params": {
-    "protocolVersion": "0.7.0",
-    "capabilities": {},
-    "_meta": {} // No proxy capability
-  }
-}
-```
-
-Agents don't need P/ACP awareness.
-
-## The `_mcp/*` Protocol
-
-P/ACP enables components to provide MCP servers that communicate over ACP messages instead of stdio.
-
-### MCP Server Declaration
-
-Components declare MCP servers with ACP transport using a special URL scheme:
-
-```json
-{
-  "tools": {
-    "mcpServers": {
-      "sparkle": {
-        "transport": "http",
-        "url": "acp:550e8400-e29b-41d4-a716-446655440000",
-        "headers": {}
-      }
-    }
-  }
-}
-```
-
-The `acp:UUID` URL signals ACP transport. The component generates a unique UUID to identify which component handles calls to this MCP server.
+The underscore-prefixed `_mcp/*` family is used by
+`agent-client-protocol-polyfill` for its legacy `acp:` URL compatibility path.
+It is not the draft native ACP MCP transport.
 
 ### `_mcp/connect`
 
-Create a new MCP connection (equivalent to "running the command").
-
-**Request:**
+The polyfill opens a connection to the component identified by `acp_id`:
 
 ```json
 {
   "jsonrpc": "2.0",
-  "id": 1,
+  "id": 20,
   "method": "_mcp/connect",
-  "params": {
-    "acp_url": "acp:550e8400-e29b-41d4-a716-446655440000"
-  }
+  "params": { "acp_id": "acp:server-1" }
 }
 ```
 
-**Response:**
+The result contains a polyfill connection identifier:
 
 ```json
 {
   "jsonrpc": "2.0",
-  "id": 1,
-  "result": {
-    "connection_id": "conn-123"
-  }
+  "id": 20,
+  "result": { "connection_id": "connection-1" }
 }
 ```
 
-The `connection_id` is used in subsequent MCP messages to identify which connection.
+### `_mcp/message`
 
-### `_mcp/disconnect`
-
-Disconnect an MCP connection.
-
-**Notification:**
+`_mcp/message` flattens one inner MCP method into its parameters. This method is
+bidirectional because MCP clients and servers can both issue requests:
 
 ```json
 {
   "jsonrpc": "2.0",
-  "method": "_mcp/disconnect",
+  "id": 21,
+  "method": "_mcp/message",
   "params": {
-    "connection_id": "conn-123"
-  }
-}
-```
-
-### `_mcp/request`
-
-Send an MCP request over the ACP connection. This is bidirectional:
-
-- Agent→Component: MCP client calling MCP server (tool calls, resource reads, etc.)
-- Component→Agent: MCP server calling MCP client (sampling/createMessage, etc.)
-
-**Request:**
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 2,
-  "method": "_mcp/request",
-  "params": {
-    "connection_id": "conn-123",
-    // The actual MCP request, flattened
+    "connectionId": "connection-1",
     "method": "tools/call",
     "params": {
-      "name": "embody_sparkle",
+      "name": "example",
       "arguments": {}
     }
   }
 }
 ```
 
-**Response:**
+Use an outer request for an inner MCP request and an outer notification for an
+inner MCP notification. The outer response carries the inner MCP result or
+error.
+
+### `_mcp/disconnect`
+
+The disconnect notification ends the named polyfill connection:
 
 ```json
 {
   "jsonrpc": "2.0",
-  "id": 2,
-  "result": {
-    // The MCP response
-    "content": [{ "type": "text", "text": "Embodiment complete" }]
-  }
+  "method": "_mcp/disconnect",
+  "params": { "connection_id": "connection-1" }
 }
 ```
 
-### `_mcp/notification`
+The local extension types intentionally retain their existing serialized field
+names: `acp_id` and `connection_id` for connect/disconnect, but `connectionId`
+inside `_mcp/message`.
 
-Send an MCP notification over the ACP connection. Bidirectional like `_mcp/request`.
+## Draft Native MCP-over-ACP
 
-**Notification:**
+With the `unstable_mcp_over_acp` feature, the protocol schema also exposes the
+draft native transport. A server is declared as `McpServer::Acp`, serialized
+with `type: "acp"`, `name`, and `serverId`. Native messages use
+`mcp/connect`, `mcp/message`, and `mcp/disconnect` without a leading underscore
+and use the schema's camel-case fields.
 
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "_mcp/notification",
-  "params": {
-    "connection_id": "conn-123",
-    // The actual MCP notification, flattened
-    "method": "notifications/progress",
-    "params": {
-      "progressToken": "token-1",
-      "progress": 50,
-      "total": 100
-    }
-  }
-}
-```
-
-### Agent Capability: `mcpCapabilities.acp`
-
-Agents that natively support MCP-over-ACP declare this capability:
-
-```json
-{
-  "agentCapabilities": {
-    "mcpCapabilities": {
-      "acp": true
-    }
-  }
-}
-```
-
-**Conductor behavior:**
-
-- If the agent has `mcpCapabilities.acp: true`, conductor passes MCP server declarations through unchanged
-- If the agent lacks this capability, conductor performs **bridging adaptation**:
-  1. Binds a TCP port (e.g., `localhost:54321`)
-  2. Transforms MCP server to use `conductor mcp PORT` command with stdio transport
-  3. Spawns bridge process that converts between stdio (MCP) and ACP messages
-  4. Agent thinks it's talking to normal MCP server over stdio
-
-**Bridging transformation example:**
-
-Original (from component):
-
-```json
-{
-  "sparkle": {
-    "transport": "http",
-    "url": "acp:550e8400-e29b-41d4-a716-446655440000"
-  }
-}
-```
-
-Transformed (for agent without native support):
-
-```json
-{
-  "sparkle": {
-    "command": "conductor",
-    "args": ["mcp", "54321"],
-    "transport": "stdio"
-  }
-}
-```
-
-The `conductor mcp PORT` process bridges between stdio and the conductor's ACP message routing.
-
-## Message Direction Summary
-
-| Message                         | Direction       | Purpose                         |
-| ------------------------------- | --------------- | ------------------------------- |
-| `_proxy/successor/request`      | Proxy→Conductor | Forward request downstream      |
-| `_proxy/successor/notification` | Proxy→Conductor | Forward notification downstream |
-| `_mcp/connect`                  | Agent↔Component | Establish MCP connection        |
-| `_mcp/disconnect`               | Agent↔Component | Close MCP connection            |
-| `_mcp/request`                  | Agent↔Component | Bidirectional MCP requests      |
-| `_mcp/notification`             | Agent↔Component | Bidirectional MCP notifications |
+The native and legacy method families are not interchangeable. Prefer the
+native schema types for new implementations that explicitly opt into the draft
+feature. Use the [MCP Bridge](./mcp-bridge.md) only to adapt the legacy
+`McpServer::Http` `acp:` declaration for an agent that cannot consume that
+routed form directly.
 
 ## Related Documentation
 
-- [Conductor Design](./conductor.md) - How the conductor routes messages
-- [MCP Bridge](./mcp-bridge.md) - MCP-over-ACP implementation details
-- [P/ACP Specification](./proxying-acp.md) - Full protocol specification
-- [agent-client-protocol rustdoc](https://docs.rs/agent-client-protocol) - API for building proxies and agents
+- [Conductor Design](./conductor.md)
+- [MCP Bridge](./mcp-bridge.md)
+- [Original P/ACP Design Proposal](./proxying-acp.md) (historical)
+- [ACP extensibility](https://agentclientprotocol.com/protocol/extensibility)

--- a/md/proxying-acp.md
+++ b/md/proxying-acp.md
@@ -1,4 +1,9 @@
-# Composable Agents via P/ACP (Proxying ACP)
+# Original P/ACP Design Proposal (Historical)
+
+> This document records the original proxying design and is retained for
+> historical context. It contains method names and capability shapes that were
+> superseded during implementation. Do not use it as a wire-protocol
+> specification; see the current [Protocol Reference](./protocol.md) instead.
 
 # Elevator pitch
 

--- a/md/request-cancellation.md
+++ b/md/request-cancellation.md
@@ -99,5 +99,5 @@ next hop's request ID instead.
 
 ## Related Documentation
 
-- [Protocol Reference](./protocol.md) - The `_proxy/successor/*` envelope protocol
+- [Protocol Reference](./protocol.md) - The `_proxy/successor` envelope protocol
 - [agent-client-protocol rustdoc](https://docs.rs/agent-client-protocol) - SDK API for sending, observing, and forwarding cancellations (see `concepts::cancellation`)

--- a/md/trace-viewer.md
+++ b/md/trace-viewer.md
@@ -1,249 +1,129 @@
 # Trace Viewer
 
-`agent-client-protocol-trace-viewer` is a debugging tool that visualizes message flow between ACP components as an interactive sequence diagram.
+`agent-client-protocol-trace-viewer` renders conductor message traces as an
+interactive sequence diagram. Capture lives in
+`agent-client-protocol-conductor`; the viewer can read the resulting file while
+the conductor is running or after it exits.
 
-## Overview
+## Capture and View
 
-When debugging ACP proxy chains, understanding the flow of messages between components is critical. The trace viewer provides:
-
-- **Visual sequence diagrams** showing messages flowing between Client, Proxies, and Agent
-- **Request/response correlation** with rainbow colors linking each request to its response
-- **Timeline spans** showing when components are actively processing requests
-- **Delta times** on each component's timeline showing elapsed time between events
-- **Content preview** for `session/update` notifications showing message text inline
-- **Filter controls** to show/hide ACP, MCP, and response messages
-- **Adjustable layout** with a slider to control swimlane width
-
-## Architecture
-
-The system has two parts:
-
-1. **Event capture** (in `agent-client-protocol-conductor`) - appends structured JSON events to a `.jsons` file
-2. **Viewer** (in `agent-client-protocol-trace-viewer`) - serves an interactive HTML/JS visualization
-
-### Workflow
+Conductor options are global and therefore precede the subcommand:
 
 ```bash
-# Run conductor with tracing enabled
-agent-client-protocol-conductor agent --trace ./trace.jsons "proxy1" "proxy2" "agent"
+agent-client-protocol-conductor --trace ./trace.jsons agent \
+  "proxy-one" "base-agent"
 
-# View the trace (works during or after the run)
 agent-client-protocol-trace-viewer ./trace.jsons
-# Opens browser to http://localhost:PORT
 ```
+
+The standalone viewer chooses a loopback port and opens a browser. Use
+`--port PORT` to choose the port or `--no-open` to suppress browser launch.
+
+The conductor can also host the viewer directly:
+
+```bash
+# In-memory live trace
+agent-client-protocol-conductor --serve agent "proxy-one" "base-agent"
+
+# File-backed live trace
+agent-client-protocol-conductor --trace ./trace.jsons --serve agent \
+  "proxy-one" "base-agent"
+```
+
+Starting file capture truncates an existing trace file. Each event is flushed
+as one JSON object followed by a newline.
 
 ## Event Schema
 
-Events are stored as newline-delimited JSON (`.jsons` file). Each line is a self-contained event.
-
-### Common Fields
-
-All events share these fields:
+The `.jsons` file contains exactly three event variants: request, response, and
+notification. It does not capture stderr or general tracing log records.
 
 ```typescript
-interface BaseEvent {
-  // Monotonic timestamp (seconds since trace start, f64)
-  ts: number;
+type TraceEvent = RequestEvent | ResponseEvent | NotificationEvent;
 
-  // Event type discriminator
-  type: "request" | "response" | "notification" | "trace";
-}
-```
-
-### Request Event
-
-A JSON-RPC request from one component to another.
-
-```typescript
-interface RequestEvent extends BaseEvent {
+interface RequestEvent {
   type: "request";
-
-  // Protocol: "acp" for ACP messages, "mcp" for MCP-over-ACP messages
+  ts: number;
   protocol: "acp" | "mcp";
-
-  // Source component (e.g., "client", "proxy:0", "proxy:1", "agent")
   from: string;
-
-  // Destination component
   to: string;
-
-  // JSON-RPC request ID (for correlating with response)
-  id: number | string;
-
-  // JSON-RPC method name
+  id: unknown;
   method: string;
-
-  // ACP session ID, if known (null before session/new completes)
-  session: string | null;
-
-  // Full request params (may be large)
-  params: object;
+  session?: string;
+  params: unknown;
 }
-```
 
-### Response Event
-
-A JSON-RPC response to a prior request.
-
-```typescript
-interface ResponseEvent extends BaseEvent {
+interface ResponseEvent {
   type: "response";
-
-  // Source component (who sent the response)
+  ts: number;
   from: string;
-
-  // Destination component (who receives the response)
   to: string;
-
-  // JSON-RPC request ID this responds to
-  id: number | string;
-
-  // True if this is an error response
+  id: unknown;
   is_error: boolean;
-
-  // Response result or error object
-  payload: object;
+  payload: unknown;
 }
-```
 
-### Notification Event
-
-A JSON-RPC notification (no response expected).
-
-```typescript
-interface NotificationEvent extends BaseEvent {
+interface NotificationEvent {
   type: "notification";
-
-  // Protocol: "acp" for ACP messages, "mcp" for MCP-over-ACP messages
+  ts: number;
   protocol: "acp" | "mcp";
-
   from: string;
   to: string;
   method: string;
-  session: string | null;
-  params: object;
+  session?: string;
+  params: unknown;
 }
 ```
 
-### Trace Event
+`ts` is monotonic seconds since capture began. JSON-RPC IDs may be strings,
+integers, or `null`; consumers must not assume they are numbers. The
+optional `session` field is omitted when the tracer has no session context; it
+is not serialized as `null`.
 
-A tracing log line from a component (captured from stderr or tracing subscriber).
+Components currently use the conductor's debug names, such as `Client`,
+`Proxy(0)`, and `Agent`.
 
-```typescript
-interface TraceEvent extends BaseEvent {
-  type: "trace";
+## Idealized Message Flow
 
-  // Which component emitted this log
-  component: string;
+The trace shows logical component-to-component traffic rather than conductor
+plumbing:
 
-  // Log level
-  level: "trace" | "debug" | "info" | "warn" | "error";
+- `_proxy/successor` is unwrapped and logged as its inner ACP method.
+- `_mcp/message` is unwrapped and its inner method is marked with protocol
+  `mcp`.
+- Responses are correlated with the request details retained by the trace
+  writer.
 
-  // Log message
-  message: string;
-
-  // Optional structured fields from tracing spans
-  fields?: Record<string, unknown>;
-}
-```
-
-## Component Naming
-
-Components are identified by strings:
-
-- `"client"` - the upstream client (editor/IDE)
-- `"proxy:0"`, `"proxy:1"`, etc. - proxy components by index
-- `"agent"` - the final agent component
-
-The viewer displays these as swimlane columns in the sequence diagram.
+The snooping bridges carry complete `TransportFrame` values. Enabling tracing
+therefore preserves batch boundaries even though the viewer renders the
+individual logical messages.
 
 ## Viewer Features
 
-### Sequence Diagram
+The web UI provides ACP/MCP/response filters, request-response color pairing,
+active-request spans, elapsed-time labels, `session/update` text previews, a
+resizable JSON detail panel, and adjustable swimlane width. The file-backed
+server rereads the trace on each poll so new events appear during capture.
 
-The main view is a vertical timeline with component columns (swimlanes):
+## Programmatic Capture
 
-```
-       client     proxy:0         agent
-         │           │               │
-         │──init────>│    14ms       │
-         │   97ms    │──init────────>│
-         │           │      74ms     │<── orange (request/response pair)
-         │           │<╌╌╌╌╌╌╌╌╌╌╌╌╌╌│
-         │<╌╌╌╌╌╌╌╌╌╌│               │
-         │           │               │
-         │──prompt──>│               │
-         │           ║    15ms       │<── thickened timeline = processing
-         │           │──prompt──────>│
-         │           │      235ms    │
-         │           │<──tools/list──●    (MCP: circular arrowhead)
-         │           │╌╌╌╌╌╌╌╌╌╌╌╌╌╌>│
-         │           │               │
+```rust,ignore
+use agent_client_protocol_conductor::{ConductorImpl, ProxiesAndAgent};
+
+let conductor = ConductorImpl::new_agent(
+    "conductor",
+    ProxiesAndAgent::new(agent).proxy(proxy),
+)
+.trace_to_path("./trace.jsons")?;
+
+conductor.run(upstream_transport).await?;
 ```
 
-### Visual Design
+Use `trace_to` with a custom implementation of
+`agent_client_protocol_conductor::trace::WriteEvent` to send events somewhere
+other than a file. `with_trace_writer` accepts an already configured
+`TraceWriter`.
 
-- **Requests/notifications** - solid arrows with method name label, colored by request/response pair
-- **Responses** - dashed arrows in the same color as their originating request
-- **MCP vs ACP** - MCP messages use circular arrowheads; ACP uses triangular
-- **Timeline spans** - when a component receives a request, its timeline thickens (in the pair's color) until the response is sent
-- **Delta times** - elapsed time shown on each component's timeline between its events
-- **Content preview** - `session/update` notifications show truncated message content below the arrow
-- **Error responses** - highlighted in red
-
-### Interactions
-
-- **Click message** - expands full JSON payload in resizable bottom panel
-- **Filter checkboxes** - show/hide ACP messages, MCP messages, responses
-- **Width slider** - adjust swimlane column width (80-300px)
-
-### Color Coding
-
-Each request/response pair gets a unique color from a rainbow palette. This makes it easy to visually trace a request through the proxy chain to its response, even when many messages are interleaved.
-
-## Implementation Notes
-
-### Idealized View
-
-The trace shows the _logical_ message flow between components, hiding conductor implementation details. The conductor transforms internal messages before logging:
-
-| Internal Message                       | Logged As                                       |
-| -------------------------------------- | ----------------------------------------------- |
-| `_proxy/successor/foo` from proxy N    | `foo` from proxy N to proxy N+1 (protocol: acp) |
-| `_mcp/request` with inner method `bar` | `bar` from agent to proxy (protocol: mcp)       |
-| `_mcp/notify` with inner method `baz`  | `baz` from agent to proxy (protocol: mcp)       |
-
-This means the viewer shows what conceptually happened without exposing the routing machinery.
-
-### agent-client-protocol-conductor changes
-
-**CLI usage:**
-
-```bash
-agent-client-protocol-conductor agent --trace ./trace.jsons "proxy1" "proxy2" "agent"
-```
-
-**Programmatic usage:**
-
-```rust
-Conductor::new(name, components, mcp_bridge_mode)
-    .trace_to("./trace.jsons")
-    .run(transport)
-    .await
-```
-
-**Implementation:**
-
-- Capture happens in `handle_conductor_message` where all messages flow
-- Conductor transforms messages to idealized form before logging
-- Events appended as JSON lines (one `writeln!` per event)
-- File opened in append mode, flushed after each event
-
-### agent-client-protocol-trace-viewer crate
-
-- Single binary with embedded static assets (HTML/JS/CSS via `include_str!`)
-- Axum HTTP server with two endpoints:
-  - `GET /` - serves the viewer HTML (single-page app)
-  - `GET /events` - returns trace events as JSON array
-- Vanilla JS renders SVG sequence diagram (no build step, no npm)
-- Auto-opens browser on launch (disable with `--no-open`)
+The viewer crate also exposes `serve_file` and `serve_memory`. The memory-backed
+form returns a `TraceHandle` for pushing JSON events and a server future that
+the caller must drive.

--- a/md/transport-architecture.md
+++ b/md/transport-architecture.md
@@ -21,9 +21,10 @@ The architecture separates two distinct responsibilities:
    - Method dispatch to handlers
    - Error handling
 
-2. **Transport Layer**: Message movement
+2. **Transport and framing layer**: Message movement and JSON-RPC envelope validation
    - Reading/writing from I/O sources
    - Serialization/deserialization
+   - Preserving single-value and batch boundaries
    - Connection management
 
 This separation enables:
@@ -35,9 +36,10 @@ This separation enables:
 
 ### The `TransportFrame` Boundary
 
-The key insight is that `agent_client_protocol::RawJsonRpcMessage` provides a natural,
-transport-neutral boundary backed by the JSON-RPC envelope types from
-`agent-client-protocol-schema`:
+The public, transport-neutral boundary is `TransportFrame`. A frame contains
+one `RawJsonRpcMessage`, one structurally non-empty `TransportBatch`, or a
+malformed wire value that a relay must preserve. `RawJsonRpcMessage` is backed
+by the JSON-RPC envelope types from `agent-client-protocol-schema`:
 
 ```rust
 enum RawJsonRpcMessage {
@@ -47,16 +49,23 @@ enum RawJsonRpcMessage {
 }
 ```
 
-`RawJsonRpcMessage` sits inside the transport-neutral public frame type:
+At that boundary:
 
 - **Above**: Protocol layer works with application types (`OutgoingMessage`, `UntypedMessage`)
-- **Below**: Transport layer parses and serializes `RawJsonRpcMessage`
+- **Below**: Transport actors parse and serialize JSON-RPC frames
 - **Boundary**: `TransportFrame` carries one raw message, a structurally
   non-empty batch, or a malformed wire value retained for a relay
 - **In-process API**: `Channel::rx` and `Channel::tx` carry `TransportFrame`
   directly, so adapters cannot accidentally flatten a batch
 - **Failures**: I/O and connection failures are returned by the future driving
   a transport; they are not sent as channel entries
+
+`TransportFrame::parse_json` returns one frame for every input string, including
+malformed response-shaped input. Standalone malformed input retains its exact
+text. Batch entries retain their parsed JSON values, source order, and batch
+boundary, although serializing a relayed batch may normalize whitespace. The
+protocol actor, not the parser, decides whether malformed input requires a
+response.
 
 ## Actor Architecture
 
@@ -74,19 +83,19 @@ Output: mpsc::UnboundedSender<TransportFrame>
 Responsibilities:
 
 - Assign unique IDs to outgoing requests
-- Subscribe to reply_actor for response correlation
+- Register pending replies before sending requests
 - Convert application-level `OutgoingMessage` to protocol-level `RawJsonRpcMessage`
 
 #### Incoming Protocol Actor
 
 ```
 Input:  mpsc::UnboundedReceiver<TransportFrame>
-Output: Routes to reply_actor or registered handlers
+Output: Routes to pending request awaiters or registered handlers
 ```
 
 Responsibilities:
 
-- Route responses to reply_actor (matches by ID)
+- Route responses to pending request awaiters (matched by ID)
 - Route requests/notifications to registered handlers
 - Convert schema request/notification envelopes to `UntypedMessage` for handlers
 - Retain batch response slots while entries are dispatched
@@ -95,21 +104,22 @@ Responsibilities:
 - Emit nothing for a notification-only batch; answer an empty batch with one
   standalone `Invalid Request` response
 
-#### Reply Actor
+#### Pending Reply Registry
 
-Manages request/response correlation:
+The shared pending-reply registry manages request/response correlation:
 
 - Maintains map from request ID to response channel
 - When response arrives, delivers to waiting request
-- Unchanged from original design
 
 #### Task Actor
 
-Runs user-spawned concurrent tasks via `cx.spawn()`. Unchanged from original design.
+Runs user-spawned concurrent tasks via `cx.spawn()`.
 
 ### Transport Actors
 
-These actors are driven by physical transport components and have **zero knowledge** of protocol semantics:
+These actors are driven by physical transport components. They understand
+JSON-RPC framing and envelope validity, but they do not dispatch ACP methods or
+correlate responses with pending requests:
 
 #### Transport Outgoing Actor
 
@@ -140,8 +150,9 @@ For byte streams:
 - Parse a single message or a non-empty batch array
 - Retain the batch boundary while dispatching each `RawJsonRpcMessage` entry to
   the incoming protocol actor
-- Report malformed JSON once, and report invalid call-batch entries independently
-- Ignore malformed response-batch entries instead of answering a response
+- Retain malformed entries so relays can forward the complete frame
+- Leave call/response-shape classification and Error Response decisions to the
+  incoming protocol actor
 
 For in-process channels:
 
@@ -152,6 +163,44 @@ initiate requests and notifications as individual JSON-RPC messages; response
 arrays are correlated replies to batch calls received from the peer. Relays and
 instrumentation must forward frames intact so they do not change those wire
 semantics.
+
+## JSON-RPC Batch Behavior
+
+Batch support is shared by the stable v1 and draft v2 APIs because it belongs
+to the JSON-RPC transport layer:
+
+- `Lines`, `ByteStreams`, `Stdio`, and the HTTP/WebSocket adapters accept
+  incoming JSON-RPC arrays.
+- Entries are validated and dispatched independently and in source order. An
+  invalid call-shaped entry receives its own `Invalid Request` error without
+  preventing valid siblings from running.
+- Responses for response-bearing entries are collected and written as one
+  response array after dispatch completes. A notification-only batch receives
+  no response.
+- If a handler drops a batched request's `Responder`, the completed dispatch
+  supplies an `Internal Error` for that slot so completed siblings are not
+  stranded. Returning a handler error supplies that error instead. Dropping an
+  individual request's responder continues to send no automatic response.
+- An empty input array receives one standalone `Invalid Request` response; the
+  SDK never writes an empty response array.
+- Response entries are routed by request ID. The framing layer retains malformed
+  values, but the protocol actor ignores values that are response-shaped and
+  not call-shaped because a JSON-RPC response must not itself receive a
+  response; ambiguous call-shaped values still receive `Invalid Request`.
+- The SDK does not originate batches of requests or notifications. Individual
+  calls continue to receive individual responses; a response array is emitted
+  only for an incoming call batch.
+
+Relays, wrappers, and tracing bridges must forward the complete
+`TransportFrame`. Flattening a batch changes observable JSON-RPC semantics even
+when every individual message remains valid.
+
+Lifecycle-sensitive calls should normally be sent individually. As a
+compatibility measure, `AgentProtocolRouter` can select a v1 or v2 agent when
+the first call-shaped entry is `initialize`, while preserving the original
+frame for the selected implementation. Response-only frames received before
+initialization are ignored. `ClientProtocolConnector` starts each attempted
+client implementation with an individual `initialize` request.
 
 ## Message Flow
 
@@ -188,19 +237,21 @@ Transport Incoming Actor
     | TransportFrame (single message or incoming batch)
     |
 Incoming Protocol Actor
-    | - Route responses → reply_actor
+    | - Route responses → pending request awaiters
     | - Route requests → registered handlers
     v
-Handler or Reply Actor
+Handler or request awaiter
 ```
 
 ### Message Ordering in the Conductor
 
-When the conductor forwards messages between components, it must preserve send order to prevent race conditions. The conductor achieves this by routing all message forwarding through a central message queue.
-
-**Key insight**: While the transport actors operate independently, the **conductor's routing logic** serializes all forwarding decisions through a central event loop. This ensures that even though responses use a "fast path" (reply_actor with oneshot channels) at the transport level, the decision to forward them is serialized with notification forwarding at the protocol level.
-
-Without this serialization, responses could overtake notifications when both are forwarded through proxy chains, causing the client to receive messages out of order. See [Conductor Implementation](./conductor.md#message-ordering-invariant) for details.
+The conductor's central routing loop serializes forwarding decisions for
+incoming requests and notifications. Responses stay paired with the request
+contexts managed by the protocol layer and may take a direct response path.
+The conductor therefore does not promise a global total order across unrelated
+concurrent requests, but every underlying transport sink preserves the order in
+which complete frames are accepted. See [Conductor Routing and
+Ordering](./conductor.md#routing-and-ordering).
 
 ## Component Boundary
 
@@ -246,7 +297,8 @@ Benefits:
 
 - **Zero serialization overhead**: Messages passed by value
 - **Same-process efficiency**: Ideal for conductor with in-process proxies
-- **Full type safety**: No parsing errors possible
+- **Explicit wire state**: No serialize/parse round trip is required, while a
+  malformed value received from a physical transport remains an explicit frame
 
 ## Use Cases
 

--- a/src/agent-client-protocol-conductor/CHANGELOG.md
+++ b/src/agent-client-protocol-conductor/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Curated release notes
+
+- **Breaking change:** Upgrade to `agent-client-protocol` 2.x. Conductor components and the core
+  handlers/types they expose must be migrated together.
+- **Breaking change:** Rename the public `ConductorResponder` background task to
+  `ConductorRunner`, matching the core runner API it implements.
+- **Fixed:** Preserve JSON-RPC batch framing when conductor tracing is enabled.
+- **Documentation:** Remove references to the retired MCP bridge CLI mode and
+  `serve()` API.
+
 ## [1.3.0](https://github.com/agentclientprotocol/rust-sdk/compare/agent-client-protocol-conductor-v1.2.0...agent-client-protocol-conductor-v1.3.0) - 2026-07-20
 
 ### Other

--- a/src/agent-client-protocol-conductor/README.md
+++ b/src/agent-client-protocol-conductor/README.md
@@ -28,23 +28,12 @@ The conductor:
 3. Presents as a single agent on stdin/stdout
 4. Manages the lifecycle of all processes
 
-### MCP Bridge Mode
-
-Connect stdio to a TCP-based MCP server:
-
-```bash
-# Bridge stdio to MCP server on localhost:8080
-agent-client-protocol-conductor mcp 8080
-```
-
-This allows stdio-based tools to communicate with TCP MCP servers.
-
 ## How It Works
 
 **Component Communication:**
 
 - Editor talks to conductor via stdio
-- Conductor uses `_proxy/successor/*` protocol extensions to route messages
+- Conductor uses the `_proxy/successor` envelope to route messages
 - Each proxy can intercept, transform, or forward messages
 - Final agent receives standard ACP messages
 
@@ -65,7 +54,7 @@ Binary will be at `target/release/agent-client-protocol-conductor`.
 ## Related Crates
 
 - **[agent-client-protocol](../agent-client-protocol/)** — Core ACP protocol types and traits
-- **[agent-client-protocol-tokio](../agent-client-protocol-tokio/)** — Tokio utilities for process spawning
+- **[agent-client-protocol-polyfill](../agent-client-protocol-polyfill/)** — Compatibility proxies, including the legacy v1 MCP-over-ACP bridge
 - **[agent-client-protocol-trace-viewer](../agent-client-protocol-trace-viewer/)** — Interactive trace visualization
 
 ## License

--- a/src/agent-client-protocol-conductor/src/conductor.rs
+++ b/src/agent-client-protocol-conductor/src/conductor.rs
@@ -22,15 +22,15 @@
 //!
 //! ## Recursive Chain Building
 //!
-//! The chain is built recursively through the `_proxy/successor/*` protocol:
+//! The chain is built recursively through the `_proxy/successor` envelope:
 //!
 //! 1. Editor connects to Component 0 via the conductor
 //! 2. When Component 0 wants to communicate with its successor, it sends
-//!    requests/notifications with method prefix `_proxy/successor/`
-//! 3. The conductor intercepts these messages, strips the prefix, and forwards
-//!    to Component 1
+//!    a `_proxy/successor` request or notification containing the inner method
+//!    and params
+//! 3. The conductor unwraps the inner message and forwards it to Component 1
 //! 4. Component 1 does the same for Component 2, and so on
-//! 5. The last component talks directly to the agent (no `_proxy/successor/` prefix)
+//! 5. The last component receives the unwrapped ACP message directly
 //!
 //! This allows each component to be written as if it's talking to a single successor,
 //! without knowing about the full chain.
@@ -52,7 +52,7 @@
 //! The conductor runs an event loop processing messages from:
 //!
 //! - **Editor to first component**: Standard ACP messages
-//! - **Component to successor**: Via `_proxy/successor/*` prefix
+//! - **Component to successor**: Via the `_proxy/successor` envelope
 //! - **Component responses**: Via futures channels back to requesters
 //!
 //! The message flow ensures bidirectional communication while maintaining the
@@ -216,7 +216,7 @@ impl<Host: ConductorHostRole> ConductorImpl<Host> {
             trace_future = Box::pin(std::future::ready(Ok(())));
         }
 
-        let responder = ConductorResponder {
+        let runner = ConductorRunner {
             conductor_rx,
             conductor_tx: conductor_tx.clone(),
             instantiator: Some(self.instantiator),
@@ -236,7 +236,7 @@ impl<Host: ConductorHostRole> ConductorImpl<Host> {
             },
         )
         .name(self.name)
-        .with_runner(responder)
+        .with_runner(runner)
         .with_spawned(|_cx| trace_future)
         .connect_to(transport)
         .await
@@ -306,7 +306,7 @@ impl<Host: ConductorHostRole> HandleDispatchFrom<Host::Counterpart>
 /// It maintains connections to all components in the chain and routes messages
 /// bidirectionally between the editor, components, and agent.
 ///
-pub struct ConductorResponder<Host>
+pub struct ConductorRunner<Host>
 where
     Host: ConductorHostRole,
 {
@@ -335,12 +335,12 @@ where
     host: Host,
 }
 
-impl<Host> std::fmt::Debug for ConductorResponder<Host>
+impl<Host> std::fmt::Debug for ConductorRunner<Host>
 where
     Host: ConductorHostRole,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ConductorResponder")
+        f.debug_struct("ConductorRunner")
             .field("conductor_rx", &self.conductor_rx)
             .field("conductor_tx", &self.conductor_tx)
             .field("proxies", &self.proxies)
@@ -350,7 +350,7 @@ where
     }
 }
 
-impl<Host> RunWithConnectionTo<Host::Counterpart> for ConductorResponder<Host>
+impl<Host> RunWithConnectionTo<Host::Counterpart> for ConductorRunner<Host>
 where
     Host: ConductorHostRole,
 {
@@ -371,7 +371,7 @@ where
     }
 }
 
-impl<Host> ConductorResponder<Host>
+impl<Host> ConductorRunner<Host>
 where
     Host: ConductorHostRole,
 {
@@ -382,7 +382,7 @@ where
     /// 2. Create the component (either spawn subprocess or use mock)
     /// 3. Set up JSON-RPC connection and message handlers
     /// 4. Recursively call itself to spawn the next component
-    /// 5. When no components remain, start the message routing loop via `serve()`
+    /// 5. When no components remain, continue in the central runner's message-routing loop
     ///
     /// Central message handling logic for the conductor.
     /// The conductor routes all [`ConductorMessage`] messages through to this function.
@@ -397,11 +397,10 @@ where
     ///     * Zero or more *proxies*, which receive messages and forward them to the next component in the chain.
     ///     * And finally the *agent*, which is the final component in the chain and handles the actual work.
     ///
-    /// For the most part, we just pass messages through the chain without modification, but there are a few exceptions:
+    /// For the most part, we pass messages through the chain without modification. The initialization
+    /// handshake is the exception:
     ///
     /// * We send `InitializeProxyRequest` to proxy components and `InitializeRequest` to the agent component.
-    /// * We modify "session/new" requests that use `acp:...` as the URL for an MCP server to redirect
-    ///   through a stdio server that runs on localhost and bridges messages.
     async fn handle_conductor_message(
         &mut self,
         client: ConnectionTo<Host::Counterpart>,
@@ -540,7 +539,7 @@ where
     /// Send a message (request or notification) from 'left to right'.
     /// Left-to-right means from the client or an intermediate proxy to the component
     /// at `target_component_index` (could be a proxy or the agent).
-    /// Makes changes to select messages along the way (e.g., `initialize` and `session/new`).
+    /// Ensures the component chain is initialized before forwarding the message.
     async fn forward_client_to_agent_message(
         &mut self,
         target_component_index: usize,
@@ -1089,7 +1088,7 @@ where
 /// - Components and their clients (editor or predecessor)
 ///
 /// All spawned tasks send messages via this enum through a shared channel,
-/// allowing centralized routing logic in the `serve()` loop.
+/// allowing centralized routing logic in the conductor runner's event loop.
 #[derive(Debug)]
 pub enum ConductorMessage {
     /// If this message is a request or notification, then it is going "left-to-right"
@@ -1130,7 +1129,7 @@ pub trait ConductorHostRole: Role<Counterpart: HasPeer<Client>> {
         message: Dispatch,
         connection: ConnectionTo<Self::Counterpart>,
         instantiator: Self::Instantiator,
-        responder: &mut ConductorResponder<Self>,
+        runner: &mut ConductorRunner<Self>,
     ) -> impl Future<Output = Result<Dispatch, agent_client_protocol::Error>> + Send;
 
     /// Handle an incoming message from the client or conductor, depending on `Self`
@@ -1151,7 +1150,7 @@ impl ConductorHostRole for Agent {
         message: Dispatch,
         client_connection: ConnectionTo<Client>,
         instantiator: Self::Instantiator,
-        responder: &mut ConductorResponder<Self>,
+        runner: &mut ConductorRunner<Self>,
     ) -> Result<Dispatch, agent_client_protocol::Error> {
         let invalid_request = || Error::invalid_request().data("expected `initialize` request");
 
@@ -1192,7 +1191,7 @@ impl ConductorHostRole for Agent {
                 // Intercept agent-to-client messages from the agent.
                 .on_receive_dispatch(
                     {
-                        let mut conductor_tx = responder.conductor_tx.clone();
+                        let mut conductor_tx = runner.conductor_tx.clone();
                         async move |dispatch: Dispatch, _cx| {
                             conductor_tx
                                 .send(ConductorMessage::RightToLeft {
@@ -1207,10 +1206,10 @@ impl ConductorHostRole for Agent {
                 ),
             agent_component,
         )?;
-        responder.successor = Arc::new(connection_to_agent);
+        runner.successor = Arc::new(connection_to_agent);
 
         // Spawn the proxy components
-        responder.spawn_proxies(client_connection.clone(), proxy_components)?;
+        runner.spawn_proxies(client_connection.clone(), proxy_components)?;
 
         Ok(Dispatch::Request(
             modified_req.to_untyped_message()?,
@@ -1251,7 +1250,7 @@ impl ConductorHostRole for Proxy {
         message: Dispatch,
         client_connection: ConnectionTo<Conductor>,
         instantiator: Self::Instantiator,
-        responder: &mut ConductorResponder<Self>,
+        runner: &mut ConductorRunner<Self>,
     ) -> Result<Dispatch, agent_client_protocol::Error> {
         let invalid_request = || Error::invalid_request().data("expected `initialize` request");
 
@@ -1283,10 +1282,10 @@ impl ConductorHostRole for Proxy {
         let (modified_req, proxy_components) = instantiator.instantiate_proxies(initialize).await?;
 
         // In proxy mode, our successor is the outer conductor (via our client connection)
-        responder.successor = Arc::new(GrandSuccessor);
+        runner.successor = Arc::new(GrandSuccessor);
 
         // Spawn the proxy components
-        responder.spawn_proxies(client_connection.clone(), proxy_components)?;
+        runner.spawn_proxies(client_connection.clone(), proxy_components)?;
 
         Ok(Dispatch::Request(
             modified_req.to_untyped_message()?,
@@ -1341,16 +1340,16 @@ pub trait ConductorSuccessor<Host: ConductorHostRole>: Send + Sync + 'static {
         &self,
         message: Dispatch,
         connection_to_conductor: ConnectionTo<Host::Counterpart>,
-        responder: &'a mut ConductorResponder<Host>,
+        runner: &'a mut ConductorRunner<Host>,
     ) -> BoxFuture<'a, Result<(), agent_client_protocol::Error>>;
 }
 
 impl<Host: ConductorHostRole> ConductorSuccessor<Host> for agent_client_protocol::Error {
     fn send_message<'a>(
         &self,
-        #[expect(unused_variables)] message: Dispatch,
-        #[expect(unused_variables)] connection_to_conductor: ConnectionTo<Host::Counterpart>,
-        #[expect(unused_variables)] responder: &'a mut ConductorResponder<Host>,
+        _message: Dispatch,
+        _connection_to_conductor: ConnectionTo<Host::Counterpart>,
+        _runner: &'a mut ConductorRunner<Host>,
     ) -> BoxFuture<'a, Result<(), agent_client_protocol::Error>> {
         let error = self.clone();
         Box::pin(std::future::ready(Err(error)))
@@ -1374,7 +1373,7 @@ impl ConductorSuccessor<Proxy> for GrandSuccessor {
         &self,
         message: Dispatch,
         connection: ConnectionTo<Conductor>,
-        _responder: &'a mut ConductorResponder<Proxy>,
+        _runner: &'a mut ConductorRunner<Proxy>,
     ) -> BoxFuture<'a, Result<(), agent_client_protocol::Error>> {
         Box::pin(async move {
             debug!("Proxy mode: forwarding successor message to conductor's successor");
@@ -1391,12 +1390,12 @@ impl ConductorSuccessor<Agent> for ConnectionTo<Agent> {
         &self,
         message: Dispatch,
         connection: ConnectionTo<Client>,
-        responder: &'a mut ConductorResponder<Agent>,
+        runner: &'a mut ConductorRunner<Agent>,
     ) -> BoxFuture<'a, Result<(), agent_client_protocol::Error>> {
         let connection_to_agent = self.clone();
         Box::pin(async move {
             debug!("Proxy mode: forwarding successor message to conductor's successor");
-            responder
+            runner
                 .forward_message_to_agent(connection, message, connection_to_agent)
                 .await
         })

--- a/src/agent-client-protocol-conductor/src/lib.rs
+++ b/src/agent-client-protocol-conductor/src/lib.rs
@@ -32,7 +32,7 @@
 //!
 //! **Component Communication:**
 //! - Editor talks to conductor via stdio
-//! - Conductor uses `_proxy/successor/*` protocol extensions to route messages
+//! - Conductor uses the `_proxy/successor` envelope to route messages
 //! - Each proxy can intercept, transform, or forward messages
 //! - Final agent receives standard ACP messages
 //!
@@ -59,9 +59,9 @@
 //!
 //! ## Related Crates
 //!
-//! - **[agent-client-protocol-proxy](https://crates.io/crates/agent-client-protocol-proxy)** - Framework for building proxy components
 //! - **[agent-client-protocol](https://crates.io/crates/agent-client-protocol)** - Core ACP SDK
-//! - **[agent-client-protocol](https://crates.io/crates/agent-client-protocol)** - Core protocol types, traits, and process spawning
+//! - **[agent-client-protocol-polyfill](https://crates.io/crates/agent-client-protocol-polyfill)** - Compatibility proxies, including the legacy v1 MCP-over-ACP bridge
+//! - **[agent-client-protocol-trace-viewer](https://crates.io/crates/agent-client-protocol-trace-viewer)** - Interactive trace visualization
 
 use std::path::PathBuf;
 use std::str::FromStr;

--- a/src/agent-client-protocol-conductor/src/trace.rs
+++ b/src/agent-client-protocol-conductor/src/trace.rs
@@ -44,7 +44,7 @@ pub enum TraceEvent {
 pub enum Protocol {
     /// Standard ACP protocol messages.
     Acp,
-    /// MCP-over-ACP messages (agent calling proxy's MCP server).
+    /// Legacy v1 MCP-over-ACP messages (agent calling a proxy's MCP server).
     Mcp,
 }
 
@@ -70,7 +70,7 @@ pub struct RequestEvent {
     /// JSON-RPC method name.
     pub method: String,
 
-    /// ACP session ID, if known (null before session/new completes).
+    /// ACP session ID, if known; omitted when no session context is available.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session: Option<String>,
 
@@ -556,7 +556,6 @@ impl MessageInfo {
     ///
     /// This unwraps protocol wrappers to get the "real" message:
     /// - `_proxy/successor` messages are unwrapped to get the inner message
-    /// - `_proxy/initialize` messages are unwrapped to get `initialize`
     /// - `_mcp/message` messages are detected and marked as MCP protocol
     ///
     /// Returns (protocol, method, params).

--- a/src/agent-client-protocol-cookbook/CHANGELOG.md
+++ b/src/agent-client-protocol-cookbook/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Curated release notes
+
+- **Changed:** Align the cookbook release and examples with `agent-client-protocol` 2.x.
+- **Documentation:** Update permission, streaming, MCP server, and conductor examples
+  for the 2.0 APIs.
+
 ## [1.2.0](https://github.com/agentclientprotocol/rust-sdk/compare/agent-client-protocol-cookbook-v1.1.0...agent-client-protocol-cookbook-v1.2.0) - 2026-07-07
 
 ### Added

--- a/src/agent-client-protocol-cookbook/src/lib.rs
+++ b/src/agent-client-protocol-cookbook/src/lib.rs
@@ -174,14 +174,15 @@ pub mod connecting_as_client {
     //! Client.builder()
     //!     .on_receive_request(async |req: RequestPermissionRequest, responder, _connection| {
     //!         // Auto-approve by selecting the first option (YOLO mode)
-    //!         let option_id = req.options.first().map(|opt| opt.id.clone());
-    //!         responder.respond(RequestPermissionResponse {
-    //!             outcome: match option_id {
-    //!                 Some(id) => RequestPermissionOutcome::Selected { option_id: id },
+    //!         let option_id = req.options.first().map(|opt| opt.option_id.clone());
+    //!         responder.respond(RequestPermissionResponse::new(
+    //!             match option_id {
+    //!                 Some(id) => RequestPermissionOutcome::Selected(
+    //!                     SelectedPermissionOutcome::new(id),
+    //!                 ),
     //!                 None => RequestPermissionOutcome::Cancelled,
-    //!             },
-    //!             meta: None,
-    //!         })
+    //!             }
+    //!         ))
     //!     }, agent_client_protocol::on_receive_request!())
     //!     .connect_with(transport, async |connection| { /* ... */ })
     //!     .await
@@ -263,28 +264,17 @@ pub mod building_an_agent {
     //! ```ignore
     //! .on_receive_request(async |req: PromptRequest, responder, connection| {
     //!     // Stream some text
-    //!     connection.send_notification(SessionNotification {
-    //!         session_id: req.session_id.clone(),
-    //!         update: SessionUpdate::Text(TextUpdate {
-    //!             text: "Hello, ".into(),
-    //!             // ...
-    //!         }),
-    //!         meta: None,
-    //!     })?;
+    //!     connection.send_notification(SessionNotification::new(
+    //!         req.session_id.clone(),
+    //!         SessionUpdate::AgentMessageChunk(ContentChunk::new("Hello, ".into())),
+    //!     ))?;
     //!
-    //!     connection.send_notification(SessionNotification {
-    //!         session_id: req.session_id.clone(),
-    //!         update: SessionUpdate::Text(TextUpdate {
-    //!             text: "world!".into(),
-    //!             // ...
-    //!         }),
-    //!         meta: None,
-    //!     })?;
+    //!     connection.send_notification(SessionNotification::new(
+    //!         req.session_id.clone(),
+    //!         SessionUpdate::AgentMessageChunk(ContentChunk::new("world!".into())),
+    //!     ))?;
     //!
-    //!     responder.respond(PromptResponse {
-    //!         stop_reason: StopReason::EndTurn,
-    //!         meta: None,
-    //!     })
+    //!     responder.respond(PromptResponse::new(StopReason::EndTurn))
     //! }, agent_client_protocol::on_receive_request!())
     //! ```
     //!
@@ -294,18 +284,23 @@ pub mod building_an_agent {
     //! or writing files), send a [`RequestPermissionRequest`]:
     //!
     //! ```ignore
-    //! let response = connection.send_request(RequestPermissionRequest {
-    //!     session_id: session_id.clone(),
-    //!     action: PermissionAction::Bash { command: "rm -rf /".into() },
-    //!     options: vec![
-    //!         PermissionOption { id: "allow".into(), label: "Allow".into() },
-    //!         PermissionOption { id: "deny".into(), label: "Deny".into() },
+    //! let response = connection.send_request(RequestPermissionRequest::new(
+    //!     session_id.clone(),
+    //!     ToolCallUpdate::new(
+    //!         "dangerous-command",
+    //!         ToolCallUpdateFields::new()
+    //!             .title("Run rm -rf /")
+    //!             .kind(ToolKind::Execute)
+    //!             .status(ToolCallStatus::Pending),
+    //!     ),
+    //!     vec![
+    //!         PermissionOption::new("allow", "Allow", PermissionOptionKind::AllowOnce),
+    //!         PermissionOption::new("deny", "Deny", PermissionOptionKind::RejectOnce),
     //!     ],
-    //!     meta: None,
-    //! }).block_task().await?;
+    //! )).block_task().await?;
     //!
     //! match response.outcome {
-    //!     RequestPermissionOutcome::Selected { option_id } if option_id == "allow" => {
+    //!     RequestPermissionOutcome::Selected(selected) if selected.option_id == "allow" => {
     //!         // User approved, proceed with action
     //!     }
     //!     _ => {
@@ -473,7 +468,7 @@ pub mod global_mcp_server {
     //!         agent_client_protocol::tool_fn!())
     //!     .build();
     //!
-    //! // The proxy component is generic over the MCP server's responder type
+    //! // The proxy component is generic over the MCP server's runner type
     //! struct MyProxy<R> {
     //!     mcp_server: McpServer<Conductor, R>,
     //! }
@@ -799,21 +794,12 @@ pub mod running_proxies_with_conductor {
     //! # Using the `agent-client-protocol-conductor` binary
     //!
     //! The simplest way to run a proxy is with the [`agent-client-protocol-conductor`] binary.
-    //! Configure it with a JSON file:
-    //!
-    //! ```json
-    //! {
-    //!   "proxies": [
-    //!     { "command": ["cargo", "run", "--bin", "my-proxy"] }
-    //!   ],
-    //!   "agent": { "command": ["claude-code", "--agent"] }
-    //! }
-    //! ```
-    //!
-    //! Then run:
+    //! Pass the proxy commands followed by the final agent command:
     //!
     //! ```bash
-    //! agent-client-protocol-conductor --config conductor.json
+    //! agent-client-protocol-conductor agent \
+    //!   "cargo run --bin my-proxy" \
+    //!   "claude-code --agent"
     //! ```
     //!
     //! # Using the conductor as a library
@@ -821,19 +807,20 @@ pub mod running_proxies_with_conductor {
     //! For more control, use [`agent-client-protocol-conductor`] as a library with the `ConductorImpl` type:
     //!
     //! ```ignore
+    //! use agent_client_protocol::{AcpAgent, ConnectTo};
     //! use agent_client_protocol_conductor::{ConductorImpl, ProxiesAndAgent};
     //!
     //! // Define your proxy as a ConnectTo<Conductor>
     //! let my_proxy = MyProxy::new();
     //!
-    //! // Spawn the agent process
-    //! let agent_process = agent_client_protocol::spawn_process("claude-code", &["--agent"]).await?;
+    //! // Configure the agent process
+    //! let agent = AcpAgent::from_args(["claude-code", "--agent"])?;
     //!
     //! // Create the conductor with your proxy chain
-    //! let conductor = ConductorImpl::new(ProxiesAndAgent {
-    //!     proxies: vec![Box::new(my_proxy)],
-    //!     agent: agent_process,
-    //! });
+    //! let conductor = ConductorImpl::new_agent(
+    //!     "my-conductor",
+    //!     ProxiesAndAgent::new(agent).proxy(my_proxy),
+    //! );
     //!
     //! // Run the conductor (it will accept client connections on stdin/stdout)
     //! conductor.connect_to(client_transport).await?;
@@ -855,5 +842,5 @@ pub mod running_proxies_with_conductor {
     //!
     //! [`agent-client-protocol-conductor`]: https://crates.io/crates/agent-client-protocol-conductor
     //! [`SuccessorMessage`]: agent_client_protocol::schema::SuccessorMessage
-    //! [`agent-client-protocol-conductor` tests]: https://github.com/anthropics/acp-rust-sdk/tree/main/src/agent-client-protocol-conductor/tests
+    //! [`agent-client-protocol-conductor` tests]: https://github.com/agentclientprotocol/rust-sdk/tree/main/src/agent-client-protocol-conductor/tests
 }

--- a/src/agent-client-protocol-derive/CHANGELOG.md
+++ b/src/agent-client-protocol-derive/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Curated 2.0 release notes
+
+**Added**
+
+- Support generic request, notification, and response types in the JSON-RPC derive macros.
+- Accept any Rust type expression, including generic types such as `Option<Response>`, in a
+  request's `response` attribute.
+
+**Changed**
+
+- Align this release line with `agent-client-protocol` 2.x; generated implementations target the
+  corresponding core API.
+- Update the macro parser to `syn` 3 and generate collision-resistant internal identifiers and
+  fully qualified support-crate paths.
+
 ## [1.0.1](https://github.com/agentclientprotocol/rust-sdk/compare/agent-client-protocol-derive-v1.0.0...agent-client-protocol-derive-v1.0.1) - 2026-06-29
 
 ### Other

--- a/src/agent-client-protocol-http/CHANGELOG.md
+++ b/src/agent-client-protocol-http/CHANGELOG.md
@@ -2,10 +2,19 @@
 
 ## [Unreleased]
 
-### Fixed
+### Curated release notes
 
-- Preserve incoming JSON-RPC batch frames and grouped responses across HTTP and WebSocket
+- **Breaking:** Upgrade to `agent-client-protocol` 2.x. Transport implementations and the core
+  handlers/types they connect must be migrated together.
+- **Fixed:** Preserve incoming JSON-RPC batch frames and grouped responses across HTTP and WebSocket
   transports, including session-aware HTTP routing.
+- **Fixed:** Keep call-bearing and invalid-request batch POSTs in peer order while allowing
+  response-only frames, including malformed response-shaped values, to bypass a
+  pending request when completing an SSE callback.
+- **Fixed:** Allow an initial HTTP batch whose first call-shaped entry is `initialize`
+  to create a connection and return its success or rejection as one grouped
+  JSON-RPC response, ignoring any leading response-only entries and buffering
+  sibling side traffic for the connection stream until initialization completes.
 
 ## [1.3.0](https://github.com/agentclientprotocol/rust-sdk/compare/agent-client-protocol-http-v1.2.0...agent-client-protocol-http-v1.3.0) - 2026-07-20
 

--- a/src/agent-client-protocol-http/src/client.rs
+++ b/src/agent-client-protocol-http/src/client.rs
@@ -4,7 +4,8 @@ use std::{
 };
 
 use agent_client_protocol::{
-    Agent, Channel, Client, ConnectTo, Error as AcpError, RawJsonRpcMessage, TransportFrame,
+    Agent, Channel, Client, ConnectTo, Error as AcpError, RawJsonRpcMessage, TransportBatchEntry,
+    TransportFrame,
     schema::v1::{RequestId, Response as RpcResponse},
 };
 use async_tungstenite::tungstenite::Message as WsMessage;
@@ -19,8 +20,8 @@ use thiserror::Error;
 use tracing::{debug, error, trace, warn};
 
 use crate::protocol::{
-    HEADER_CONNECTION_ID, HEADER_SESSION_ID, is_initialize_request, method_for_message,
-    method_requires_session_header, session_id_from_message,
+    HEADER_CONNECTION_ID, HEADER_SESSION_ID, is_initialize_request, is_response_only_shape,
+    method_for_message, method_requires_session_header, session_id_from_message,
 };
 
 #[derive(Debug, Error)]
@@ -227,6 +228,7 @@ async fn run(client: HttpClient, channel: Channel) -> Result<(), AcpError> {
             }
         };
 
+        let is_response_only = is_response_only_frame(&frame);
         let msg = match frame {
             TransportFrame::Single(message) => message,
             frame @ (TransportFrame::Malformed { .. } | TransportFrame::Batch(_)) => {
@@ -235,7 +237,10 @@ async fn run(client: HttpClient, channel: Channel) -> Result<(), AcpError> {
                         .data("ACP HTTP transport: first message must be `initialize`"));
                 }
                 match state.prepare_frame_post(frame) {
-                    Ok(post) => response_posts.push(post),
+                    // Response-only batches answer SSE-delivered callbacks and
+                    // must not be blocked behind the request they answer.
+                    Ok(post) if is_response_only => response_posts.push(post),
+                    Ok(post) => ordered_posts.push(post),
                     Err(error) => {
                         error!("POST failed: {error}");
                         break Err(AcpError::internal_error().data(format!("POST: {error}")));
@@ -269,11 +274,10 @@ async fn run(client: HttpClient, channel: Channel) -> Result<(), AcpError> {
             lifecycle.start_sse(Some(session_id), sse_event_tx.clone());
         }
 
-        let is_response = matches!(msg, RawJsonRpcMessage::Response(_));
         match state.prepare_post(msg) {
             // Responses answer SSE-delivered callbacks and must not be blocked
             // behind a POST that may be waiting for that callback response.
-            Ok(post) if is_response => response_posts.push(post),
+            Ok(post) if is_response_only => response_posts.push(post),
             Ok(post) => ordered_posts.push(post),
             Err(e) => {
                 error!("POST failed: {e}");
@@ -284,6 +288,25 @@ async fn run(client: HttpClient, channel: Channel) -> Result<(), AcpError> {
 
     lifecycle.close().await;
     result
+}
+
+fn is_response_only_frame(frame: &TransportFrame) -> bool {
+    match frame {
+        TransportFrame::Single(RawJsonRpcMessage::Response(_)) => true,
+        TransportFrame::Batch(batch) => batch.entries().all(|entry| match entry {
+            TransportBatchEntry::Message(RawJsonRpcMessage::Response(_)) => true,
+            TransportBatchEntry::Malformed { raw, .. } => is_response_only_shape(raw),
+            TransportBatchEntry::Message(
+                RawJsonRpcMessage::Request(_) | RawJsonRpcMessage::Notification(_),
+            ) => false,
+        }),
+        TransportFrame::Malformed { raw, .. } => {
+            serde_json::from_str(raw).is_ok_and(|value| is_response_only_shape(&value))
+        }
+        TransportFrame::Single(
+            RawJsonRpcMessage::Request(_) | RawJsonRpcMessage::Notification(_),
+        ) => false,
+    }
 }
 
 enum HttpLoopEvent {
@@ -573,14 +596,13 @@ impl ClientState {
 
         let body = response.text().await.map_err(|error| error.to_string())?;
         let message = match TransportFrame::parse_json(&body) {
-            Some(TransportFrame::Single(message)) => message,
-            Some(TransportFrame::Malformed { error, .. }) => {
+            TransportFrame::Single(message) => message,
+            TransportFrame::Malformed { error, .. } => {
                 return Err(format!("invalid initialize response: {error}"));
             }
-            Some(TransportFrame::Batch(_)) => {
+            TransportFrame::Batch(_) => {
                 return Err("initialize response must not be a JSON-RPC batch".to_string());
             }
-            None => return Err("initialize response was ignored as malformed".to_string()),
         };
 
         if matches!(
@@ -746,10 +768,7 @@ async fn read_sse(
         if payload.is_empty() {
             continue;
         }
-        let Some(frame) = TransportFrame::parse_json(&payload) else {
-            debug!("ignoring malformed response-shaped SSE payload");
-            continue;
-        };
+        let frame = TransportFrame::parse_json(&payload);
 
         if event_tx.unbounded_send(SseMessage { frame }).is_err() {
             return Err("upstream channel closed".to_string());
@@ -846,10 +865,7 @@ where
                     if discard_incoming {
                         continue;
                     }
-                    let Some(frame) = TransportFrame::parse_json(text.as_str()) else {
-                        debug!("ignoring malformed response-shaped WebSocket payload");
-                        continue;
-                    };
+                    let frame = TransportFrame::parse_json(text.as_str());
                     if incoming.unbounded_send(frame).is_err() {
                         debug!(
                             "upstream channel closed; discarding WS input while draining output"
@@ -960,6 +976,35 @@ mod tests {
         fn unwrap(self) -> RawJsonRpcMessage {
             into_single_message(self).unwrap()
         }
+    }
+
+    #[test]
+    fn malformed_response_shapes_bypass_only_when_the_whole_frame_is_response_only() {
+        let standalone_response = TransportFrame::parse_json(
+            r#"{"jsonrpc":"2.0","id":1,"result":{},"error":{"code":-32603}}"#,
+        );
+        assert!(is_response_only_frame(&standalone_response));
+
+        let response_batch = TransportFrame::parse_json(
+            r#"[
+                {"jsonrpc":"2.0","id":1,"result":{}},
+                {"jsonrpc":"2.0","id":2,"result":{},"error":{"code":-32603}}
+            ]"#,
+        );
+        assert!(is_response_only_frame(&response_batch));
+
+        let scalar_batch = TransportFrame::parse_json(
+            r#"[
+                {"jsonrpc":"2.0","id":1,"result":{}},
+                17
+            ]"#,
+        );
+        assert!(!is_response_only_frame(&scalar_batch));
+
+        let call_shaped = TransportFrame::parse_json(
+            r#"{"jsonrpc":"2.0","id":1,"method":"custom/call","result":{}}"#,
+        );
+        assert!(!is_response_only_frame(&call_shaped));
     }
 
     impl WsSink for RecordingWsSink {
@@ -1599,6 +1644,131 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(fork_sse_header.as_deref(), Some("forked-session"));
+
+        drop(caller);
+        timeout(Duration::from_secs(1), transport)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn only_response_batches_bypass_ordered_posts() {
+        let slow_started = Arc::new(Notify::new());
+        let release_slow = Arc::new(Notify::new());
+        let call_batch_seen = Arc::new(Notify::new());
+        let response_batch_seen = Arc::new(Notify::new());
+        let app = Router::new().route(
+            "/acp",
+            post({
+                let slow_started = slow_started.clone();
+                let release_slow = release_slow.clone();
+                let call_batch_seen = call_batch_seen.clone();
+                let response_batch_seen = response_batch_seen.clone();
+                move |body: String| {
+                    let slow_started = slow_started.clone();
+                    let release_slow = release_slow.clone();
+                    let call_batch_seen = call_batch_seen.clone();
+                    let response_batch_seen = response_batch_seen.clone();
+                    async move {
+                        let value = serde_json::from_str::<serde_json::Value>(&body).unwrap();
+                        if value.get("method").and_then(serde_json::Value::as_str)
+                            == Some("initialize")
+                        {
+                            return initialize_response().await.into_response();
+                        }
+                        if value.get("method").and_then(serde_json::Value::as_str)
+                            == Some("custom/slow")
+                        {
+                            slow_started.notify_one();
+                            release_slow.notified().await;
+                        } else if let Some(entries) = value.as_array() {
+                            if entries.iter().all(|entry| entry.get("method").is_none()) {
+                                response_batch_seen.notify_one();
+                            } else {
+                                call_batch_seen.notify_one();
+                            }
+                        }
+                        StatusCode::ACCEPTED.into_response()
+                    }
+                }
+            })
+            .get(pending_sse)
+            .delete(|| async { StatusCode::ACCEPTED }),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        let client = HttpClient::new(format!("http://{addr}")).unwrap();
+        let (mut caller, transport) = Channel::duplex();
+        let transport = tokio::spawn(run(client, transport));
+
+        caller
+            .tx
+            .unbounded_send(single_frame(
+                RawJsonRpcMessage::request(
+                    "initialize".to_string(),
+                    json!({}),
+                    RequestId::Number(1),
+                )
+                .unwrap(),
+            ))
+            .unwrap();
+        timeout(Duration::from_secs(1), caller.rx.next())
+            .await
+            .unwrap()
+            .unwrap();
+
+        caller
+            .tx
+            .unbounded_send(single_frame(
+                RawJsonRpcMessage::notification("custom/slow".to_string(), json!({})).unwrap(),
+            ))
+            .unwrap();
+        timeout(Duration::from_secs(1), slow_started.notified())
+            .await
+            .unwrap();
+
+        caller
+            .tx
+            .unbounded_send(TransportFrame::Batch(
+                TransportBatch::from_messages([
+                    RawJsonRpcMessage::notification("custom/one".to_string(), json!({})).unwrap(),
+                    RawJsonRpcMessage::notification("custom/two".to_string(), json!({})).unwrap(),
+                ])
+                .unwrap(),
+            ))
+            .unwrap();
+        assert!(
+            timeout(Duration::from_millis(100), call_batch_seen.notified())
+                .await
+                .is_err(),
+            "call-bearing batches must remain behind an earlier ordered POST"
+        );
+
+        caller
+            .tx
+            .unbounded_send(TransportFrame::Batch(
+                TransportBatch::from_messages([
+                    RawJsonRpcMessage::response(RequestId::Number(10), Ok(json!({}))),
+                    RawJsonRpcMessage::response(RequestId::Number(11), Ok(json!({}))),
+                ])
+                .unwrap(),
+            ))
+            .unwrap();
+        timeout(Duration::from_secs(1), response_batch_seen.notified())
+            .await
+            .expect("response-only batch should bypass the ordered POST queue");
+
+        release_slow.notify_one();
+        timeout(Duration::from_secs(1), call_batch_seen.notified())
+            .await
+            .expect("call-bearing batch should be sent after the earlier POST completes");
 
         drop(caller);
         timeout(Duration::from_secs(1), transport)

--- a/src/agent-client-protocol-http/src/connection.rs
+++ b/src/agent-client-protocol-http/src/connection.rs
@@ -156,24 +156,14 @@ impl Connection {
         }));
     }
 
-    async fn route_outbound(&self, frame: TransportFrame) {
+    pub(crate) async fn route_outbound(&self, frame: TransportFrame) {
         self.outbound_transport.route_outbound(frame).await;
     }
 
-    pub(crate) async fn recv_initial(&self) -> Option<RawJsonRpcMessage> {
+    pub(crate) async fn recv_initial(&self) -> Option<TransportFrame> {
         let mut guard = self.outbound_rx.lock().await;
         let rx = guard.as_mut()?;
-        match rx.recv().await? {
-            TransportFrame::Single(message) => Some(message),
-            TransportFrame::Malformed { error, .. } => {
-                error!(?error, "agent emitted malformed initial JSON-RPC input");
-                None
-            }
-            TransportFrame::Batch(_) => {
-                error!("agent emitted an invalid batched initial JSON-RPC message");
-                None
-            }
-        }
+        rx.recv().await
     }
 
     pub(crate) async fn shutdown(&self) {
@@ -804,17 +794,19 @@ mod tests {
         let registry = ConnectionRegistry::new(Arc::new(RespondThenExitAgentFactory));
         let (connection_id, connection) = registry.create_connection().await;
 
-        let message = timeout(Duration::from_secs(1), connection.recv_initial())
+        let frame = timeout(Duration::from_secs(1), connection.recv_initial())
             .await
             .unwrap()
             .expect("buffered response should be forwarded before teardown");
 
         assert!(matches!(
-            message,
-            RawJsonRpcMessage::Response(agent_client_protocol::schema::v1::Response::Result {
-                id: RequestId::Number(1),
-                ..
-            })
+            frame,
+            TransportFrame::Single(RawJsonRpcMessage::Response(
+                agent_client_protocol::schema::v1::Response::Result {
+                    id: RequestId::Number(1),
+                    ..
+                }
+            ))
         ));
         timeout(Duration::from_secs(1), async {
             loop {

--- a/src/agent-client-protocol-http/src/http_server.rs
+++ b/src/agent-client-protocol-http/src/http_server.rs
@@ -1,7 +1,8 @@
 use std::{convert::Infallible, error::Error as _, sync::Arc, time::Duration};
 
 use agent_client_protocol::{
-    RawJsonRpcMessage, TransportBatchEntry, TransportFrame, schema::v1::Response as RpcResponse,
+    RawJsonRpcMessage, TransportBatchEntry, TransportFrame, schema::v1::RequestId,
+    schema::v1::Response as RpcResponse,
 };
 use axum::{
     body::Body,
@@ -15,8 +16,8 @@ use crate::{
     connection::{Connection, ConnectionRegistry, ResponseRoute},
     protocol::{
         EVENT_STREAM_MIME_TYPE, HEADER_CONNECTION_ID, HEADER_SESSION_ID, JSON_MIME_TYPE,
-        apply_session_header_to_message, is_initialize_request, method_for_message,
-        method_requires_session_header, session_id_from_message,
+        apply_session_header_to_message, is_initialize_request, is_response_only_shape,
+        method_for_message, method_requires_session_header, session_id_from_message,
     },
 };
 
@@ -66,43 +67,51 @@ pub(crate) async fn handle_post(
                 .into_response();
         }
     };
-    let Some(mut frame) = TransportFrame::parse_json(body) else {
-        // Response-shaped invalid input is deliberately ignored by the JSON-RPC
-        // parser because responses must not themselves receive responses.
-        return StatusCode::ACCEPTED.into_response();
-    };
+    let mut frame = TransportFrame::parse_json(body);
 
-    if matches!(
-        &frame,
-        TransportFrame::Single(message) if is_initialize_request(message)
-    ) {
-        let TransportFrame::Single(message) = frame else {
-            unreachable!("initialize was matched as a single frame");
-        };
+    if let Some((initialize_id, initialize_index)) =
+        initial_initialize_request(&frame).map(|(id, index)| (id.clone(), index))
+    {
+        if let TransportFrame::Batch(batch) = &mut frame {
+            for (index, entry) in batch.entries_mut().enumerate() {
+                if Some(index) == initialize_index {
+                    continue;
+                }
+                let TransportBatchEntry::Message(message) = entry else {
+                    continue;
+                };
+                if let Err(error) = prepare_message_route(message, session_id.as_deref()) {
+                    return (StatusCode::BAD_REQUEST, error).into_response();
+                }
+            }
+        }
         let (connection_id, connection) = registry.create_connection().await;
         let initialize_cleanup =
             InitializeCleanup::new(registry.clone(), connection_id.clone(), connection.clone());
-        if connection
-            .send_frame_to_agent(TransportFrame::Single(message))
-            .is_err()
-        {
+        if connection.send_frame_to_agent(frame).is_err() {
             initialize_cleanup.cleanup().await;
             return StatusCode::INTERNAL_SERVER_ERROR.into_response();
         }
 
-        let Some(init_response) = connection.recv_initial().await else {
-            initialize_cleanup.cleanup().await;
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "agent closed before initialize response",
-            )
-                .into_response();
+        let (init_response_frame, initialize_failed) = loop {
+            let Some(frame) = connection.recv_initial().await else {
+                initialize_cleanup.cleanup().await;
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "agent closed before initialize response",
+                )
+                    .into_response();
+            };
+            if let Some(initialize_failed) = initialize_response_failed(&frame, &initialize_id) {
+                break (frame, initialize_failed);
+            }
+
+            // A batched sibling may emit a callback or notification before all
+            // response slots complete. Buffer that side traffic for the SSE
+            // stream instead of mistaking it for the initialize response.
+            connection.route_outbound(frame).await;
         };
-        let initialize_failed = matches!(
-            init_response,
-            RawJsonRpcMessage::Response(RpcResponse::Error { .. })
-        );
-        let init_response = match serde_json::to_string(&init_response) {
+        let init_response = match init_response_frame.to_json() {
             Ok(response) => response,
             Err(e) => {
                 initialize_cleanup.cleanup().await;
@@ -169,6 +178,61 @@ pub(crate) async fn handle_post(
         return StatusCode::INTERNAL_SERVER_ERROR.into_response();
     }
     StatusCode::ACCEPTED.into_response()
+}
+
+fn initial_initialize_request(frame: &TransportFrame) -> Option<(&RequestId, Option<usize>)> {
+    fn initialize_id(message: &RawJsonRpcMessage) -> Option<&RequestId> {
+        if !is_initialize_request(message) {
+            return None;
+        }
+        let RawJsonRpcMessage::Request(request) = message else {
+            unreachable!("initialize messages are requests");
+        };
+        Some(&request.id)
+    }
+
+    match frame {
+        TransportFrame::Single(message) => initialize_id(message).map(|id| (id, None)),
+        TransportFrame::Malformed { .. } => None,
+        TransportFrame::Batch(batch) => {
+            for (index, entry) in batch.entries().enumerate() {
+                match entry {
+                    TransportBatchEntry::Message(RawJsonRpcMessage::Response(_)) => {}
+                    TransportBatchEntry::Message(message) => {
+                        return initialize_id(message).map(|id| (id, Some(index)));
+                    }
+                    TransportBatchEntry::Malformed { raw, .. } if is_response_only_shape(raw) => {}
+                    TransportBatchEntry::Malformed { .. } => return None,
+                }
+            }
+            None
+        }
+    }
+}
+
+fn initialize_response_failed(frame: &TransportFrame, initialize_id: &RequestId) -> Option<bool> {
+    fn response_failed(message: &RawJsonRpcMessage, initialize_id: &RequestId) -> Option<bool> {
+        match message {
+            RawJsonRpcMessage::Response(RpcResponse::Result { id, .. }) if id == initialize_id => {
+                Some(false)
+            }
+            RawJsonRpcMessage::Response(RpcResponse::Error { id, .. }) if id == initialize_id => {
+                Some(true)
+            }
+            RawJsonRpcMessage::Request(_)
+            | RawJsonRpcMessage::Notification(_)
+            | RawJsonRpcMessage::Response(_) => None,
+        }
+    }
+
+    match frame {
+        TransportFrame::Single(message) => response_failed(message, initialize_id),
+        TransportFrame::Batch(batch) => batch.entries().find_map(|entry| match entry {
+            TransportBatchEntry::Message(message) => response_failed(message, initialize_id),
+            TransportBatchEntry::Malformed { .. } => None,
+        }),
+        TransportFrame::Malformed { .. } => None,
+    }
 }
 
 fn prepare_message_route(
@@ -454,17 +518,41 @@ mod tests {
         ) {
             let (mut agent, transport) = Channel::duplex();
             let future = Box::pin(async move {
-                if let Some(TransportFrame::Single(RawJsonRpcMessage::Request(request))) =
-                    agent.rx.next().await
-                {
-                    agent
-                        .tx
-                        .unbounded_send(TransportFrame::Single(RawJsonRpcMessage::response(
-                            request.id,
-                            Err(agent_client_protocol::Error::invalid_request()
-                                .data("initialize rejected")),
-                        )))
-                        .unwrap();
+                match agent.rx.next().await {
+                    Some(TransportFrame::Single(RawJsonRpcMessage::Request(request))) => {
+                        agent
+                            .tx
+                            .unbounded_send(TransportFrame::Single(RawJsonRpcMessage::response(
+                                request.id,
+                                Err(agent_client_protocol::Error::invalid_request()
+                                    .data("initialize rejected")),
+                            )))
+                            .unwrap();
+                    }
+                    Some(TransportFrame::Batch(batch)) => {
+                        let responses = batch.entries().filter_map(|entry| {
+                            let TransportBatchEntry::Message(RawJsonRpcMessage::Request(request)) =
+                                entry
+                            else {
+                                return None;
+                            };
+                            let result = if request.method.as_ref() == "initialize" {
+                                Err(agent_client_protocol::Error::invalid_request()
+                                    .data("initialize rejected"))
+                            } else {
+                                Ok(json!({ "ok": true }))
+                            };
+                            Some(RawJsonRpcMessage::response(request.id.clone(), result))
+                        });
+                        agent
+                            .tx
+                            .unbounded_send(TransportFrame::Batch(
+                                TransportBatch::from_messages(responses)
+                                    .expect("request batch has responses"),
+                            ))
+                            .unwrap();
+                    }
+                    Some(TransportFrame::Single(_) | TransportFrame::Malformed { .. }) | None => {}
                 }
                 std::future::pending::<agent_client_protocol::Result<()>>().await
             });
@@ -516,21 +604,41 @@ mod tests {
                 let mut methods = Vec::new();
                 let mut responses = Vec::new();
                 for entry in batch.entries() {
-                    let TransportBatchEntry::Message(RawJsonRpcMessage::Request(request)) = entry
-                    else {
-                        panic!("expected a request batch entry");
-                    };
-                    methods.push((
-                        request.method.to_string(),
-                        request
-                            .params
-                            .as_ref()
-                            .and_then(crate::protocol::session_id_from_params),
-                    ));
-                    responses.push(RawJsonRpcMessage::response(
-                        request.id.clone(),
-                        Ok(json!({ "ok": true })),
-                    ));
+                    match entry {
+                        TransportBatchEntry::Message(RawJsonRpcMessage::Request(request)) => {
+                            methods.push((
+                                request.method.to_string(),
+                                request
+                                    .params
+                                    .as_ref()
+                                    .and_then(crate::protocol::session_id_from_params),
+                            ));
+                            responses.push(RawJsonRpcMessage::response(
+                                request.id.clone(),
+                                Ok(json!({ "ok": true })),
+                            ));
+                        }
+                        TransportBatchEntry::Message(RawJsonRpcMessage::Notification(
+                            notification,
+                        )) => {
+                            methods.push((
+                                notification.method.to_string(),
+                                notification
+                                    .params
+                                    .as_ref()
+                                    .and_then(crate::protocol::session_id_from_params),
+                            ));
+                        }
+                        TransportBatchEntry::Message(RawJsonRpcMessage::Response(_)) => {}
+                        TransportBatchEntry::Malformed { raw, .. }
+                            if is_response_only_shape(raw) => {}
+                        TransportBatchEntry::Malformed { error, .. } => {
+                            responses.push(RawJsonRpcMessage::response(
+                                RequestId::Null,
+                                Err(error.clone()),
+                            ));
+                        }
+                    }
                 }
                 forwarded.send(methods).unwrap();
                 let responses =
@@ -538,6 +646,55 @@ mod tests {
                 agent
                     .tx
                     .unbounded_send(TransportFrame::Batch(responses))
+                    .unwrap();
+                std::future::pending::<agent_client_protocol::Result<()>>().await
+            });
+
+            (transport, future)
+        }
+    }
+
+    struct SideTrafficBeforeInitializeResponseAgentFactory;
+
+    impl AgentFactory for SideTrafficBeforeInitializeResponseAgentFactory {
+        fn spawn_agent(
+            &self,
+        ) -> (
+            Channel,
+            BoxFuture<'static, agent_client_protocol::Result<()>>,
+        ) {
+            let (mut agent, transport) = Channel::duplex();
+            let future = Box::pin(async move {
+                let Some(TransportFrame::Batch(batch)) = agent.rx.next().await else {
+                    panic!("expected one initial batch frame");
+                };
+                let responses = batch.entries().filter_map(|entry| {
+                    let TransportBatchEntry::Message(RawJsonRpcMessage::Request(request)) = entry
+                    else {
+                        return None;
+                    };
+                    Some(RawJsonRpcMessage::response(
+                        request.id.clone(),
+                        Ok(json!({ "ok": true })),
+                    ))
+                });
+
+                agent
+                    .tx
+                    .unbounded_send(TransportFrame::Single(
+                        RawJsonRpcMessage::notification(
+                            "custom/during-initialize".into(),
+                            json!({ "phase": "before-response" }),
+                        )
+                        .expect("test notification should serialize"),
+                    ))
+                    .unwrap();
+                agent
+                    .tx
+                    .unbounded_send(TransportFrame::Batch(
+                        TransportBatch::from_messages(responses)
+                            .expect("initial batch has response-bearing requests"),
+                    ))
                     .unwrap();
                 std::future::pending::<agent_client_protocol::Result<()>>().await
             });
@@ -566,6 +723,238 @@ mod tests {
         let response = handle_post(State(registry), request).await;
 
         assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn initial_batch_bootstraps_connection_and_returns_grouped_response() {
+        let (forwarded_tx, mut forwarded_rx) = mpsc::unbounded_channel();
+        let registry = Arc::new(ConnectionRegistry::new(Arc::new(BatchAgentFactory {
+            forwarded: forwarded_tx,
+        })));
+        let body = json!([
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {}
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "custom/after-initialize",
+                "params": {}
+            }
+        ])
+        .to_string();
+        let request = Request::builder()
+            .method("POST")
+            .uri("/acp")
+            .header(header::CONTENT_TYPE, JSON_MIME_TYPE)
+            .body(Body::from(body))
+            .unwrap();
+
+        let response = handle_post(State(registry.clone()), request).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let connection_id = response
+            .headers()
+            .get(HEADER_CONNECTION_ID)
+            .expect("successful initialize should return a connection ID")
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(
+            timeout(Duration::from_secs(1), forwarded_rx.recv())
+                .await
+                .unwrap()
+                .unwrap(),
+            [
+                ("initialize".to_string(), None),
+                ("custom/after-initialize".to_string(), None),
+            ]
+        );
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let response = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        let entries = response
+            .as_array()
+            .expect("initial batch response should remain grouped");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0]["id"], 1);
+        assert_eq!(entries[1]["id"], 2);
+
+        let connection = registry
+            .remove(&connection_id)
+            .await
+            .expect("initialized connection should remain registered");
+        connection.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn initial_batch_buffers_side_traffic_until_grouped_response() {
+        let registry = Arc::new(ConnectionRegistry::new(Arc::new(
+            SideTrafficBeforeInitializeResponseAgentFactory,
+        )));
+        let body = json!([
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {}
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "custom/after-initialize",
+                "params": {}
+            }
+        ])
+        .to_string();
+        let request = Request::builder()
+            .method("POST")
+            .uri("/acp")
+            .header(header::CONTENT_TYPE, JSON_MIME_TYPE)
+            .body(Body::from(body))
+            .unwrap();
+
+        let response = handle_post(State(registry.clone()), request).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let connection_id = response
+            .headers()
+            .get(HEADER_CONNECTION_ID)
+            .expect("successful initialize should return a connection ID")
+            .to_str()
+            .unwrap()
+            .to_string();
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let response = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(response.as_array().map(Vec::len), Some(2));
+
+        let connection = registry
+            .get(&connection_id)
+            .await
+            .expect("initialized connection should remain registered");
+        let (replay, _outbound) = connection.subscribe_connection_stream().await;
+        assert_eq!(replay.len(), 1);
+        let side_traffic = serde_json::from_str::<serde_json::Value>(&replay[0]).unwrap();
+        assert_eq!(side_traffic["method"], "custom/during-initialize");
+        assert_eq!(side_traffic["params"]["phase"], "before-response");
+
+        let connection = registry
+            .remove(&connection_id)
+            .await
+            .expect("initialized connection should remain registered");
+        connection.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn initial_batch_skips_leading_response_only_entries() {
+        let (forwarded_tx, mut forwarded_rx) = mpsc::unbounded_channel();
+        let registry = Arc::new(ConnectionRegistry::new(Arc::new(BatchAgentFactory {
+            forwarded: forwarded_tx,
+        })));
+        let body = json!([
+            {
+                "jsonrpc": "2.0",
+                "id": 98,
+                "result": { "ignored": true }
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 99,
+                "result": { "ignored": true },
+                "error": { "code": -32603, "message": "also ignored" }
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {}
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "custom/after-initialize",
+                "params": {}
+            }
+        ])
+        .to_string();
+        let request = Request::builder()
+            .method("POST")
+            .uri("/acp")
+            .header(header::CONTENT_TYPE, JSON_MIME_TYPE)
+            .body(Body::from(body))
+            .unwrap();
+
+        let response = handle_post(State(registry.clone()), request).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let connection_id = response
+            .headers()
+            .get(HEADER_CONNECTION_ID)
+            .expect("successful initialize should return a connection ID")
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(
+            timeout(Duration::from_secs(1), forwarded_rx.recv())
+                .await
+                .unwrap()
+                .unwrap(),
+            [
+                ("initialize".to_string(), None),
+                ("custom/after-initialize".to_string(), None),
+            ]
+        );
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let response = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        let entries = response
+            .as_array()
+            .expect("initial batch response should remain grouped");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0]["id"], 1);
+        assert_eq!(entries[1]["id"], 2);
+
+        let connection = registry
+            .remove(&connection_id)
+            .await
+            .expect("initialized connection should remain registered");
+        connection.shutdown().await;
+    }
+
+    #[test]
+    fn initial_batch_rejects_invalid_or_call_shaped_predecessors() {
+        for frame in [
+            TransportFrame::parse_json(
+                &json!([
+                    17,
+                    { "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {} }
+                ])
+                .to_string(),
+            ),
+            TransportFrame::parse_json(
+                &json!([
+                    { "jsonrpc": "2.0", "method": "custom/before-initialize" },
+                    { "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {} }
+                ])
+                .to_string(),
+            ),
+            TransportFrame::parse_json(
+                &json!([
+                    { "jsonrpc": "2.0", "id": 7, "method": "custom/before-initialize" },
+                    { "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {} }
+                ])
+                .to_string(),
+            ),
+        ] {
+            assert!(initial_initialize_request(&frame).is_none());
+        }
     }
 
     #[tokio::test]
@@ -739,6 +1128,52 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    #[tokio::test]
+    async fn rejected_initialize_in_batch_returns_group_and_cleans_up_connection() {
+        let registry = Arc::new(ConnectionRegistry::new(Arc::new(
+            RejectingInitializeAgentFactory,
+        )));
+        let body = json!([
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {}
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "custom/sibling",
+                "params": {}
+            }
+        ])
+        .to_string();
+        let request = Request::builder()
+            .method("POST")
+            .uri("/acp")
+            .header(header::CONTENT_TYPE, JSON_MIME_TYPE)
+            .body(Body::from(body))
+            .unwrap();
+
+        let response = handle_post(State(registry.clone()), request).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response.headers().get(HEADER_CONNECTION_ID).is_none());
+        assert_eq!(registry.len().await, 0);
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let response = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        let entries = response
+            .as_array()
+            .expect("rejected initial batch response should remain grouped");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0]["id"], 1);
+        assert_eq!(entries[0]["error"]["code"], -32600);
+        assert_eq!(entries[1]["id"], 2);
+        assert_eq!(entries[1]["result"], json!({ "ok": true }));
     }
 
     #[tokio::test]

--- a/src/agent-client-protocol-http/src/protocol.rs
+++ b/src/agent-client-protocol-http/src/protocol.rs
@@ -27,6 +27,13 @@ pub(crate) fn is_initialize_request(msg: &RawJsonRpcMessage) -> bool {
     matches!(msg, RawJsonRpcMessage::Request(req) if req.method.as_ref() == "initialize")
 }
 
+pub(crate) fn is_response_only_shape(value: &serde_json::Value) -> bool {
+    value.as_object().is_some_and(|object| {
+        !object.contains_key("method")
+            && (object.contains_key("result") || object.contains_key("error"))
+    })
+}
+
 pub(crate) fn method_for_message(msg: &RawJsonRpcMessage) -> Option<&str> {
     match msg {
         RawJsonRpcMessage::Request(req) => Some(req.method.as_ref()),

--- a/src/agent-client-protocol-http/src/websocket_server.rs
+++ b/src/agent-client-protocol-http/src/websocket_server.rs
@@ -75,21 +75,15 @@ async fn run_ws(
                     Some(Ok(WsMessage::Text(text))) => {
                         let text_str = text.to_string();
                         trace!(connection_id = %connection_id, payload = %text_str, "Client → Agent: {} bytes", text_str.len());
-                        match TransportFrame::parse_json(&text_str) {
-                            Some(frame) => {
-                                if let TransportFrame::Single(parsed) = &frame
-                                    && let Some(sid) = session_id_from_message(parsed)
-                                    && let RawJsonRpcMessage::Request(req) = parsed {
-                                        trace!(connection_id = %connection_id, session_id = %sid, request_id = ?req.id, "Client → Agent (session)");
-                                    }
-                                if connection.send_frame_to_agent(frame).is_err() {
-                                    error!(connection_id = %connection_id, "Agent channel closed");
-                                    break;
-                                }
-                            }
-                            None => {
-                                trace!(connection_id = %connection_id, "Ignoring malformed response-shaped JSON-RPC frame");
-                            }
+                        let frame = TransportFrame::parse_json(&text_str);
+                        if let TransportFrame::Single(parsed) = &frame
+                            && let Some(sid) = session_id_from_message(parsed)
+                            && let RawJsonRpcMessage::Request(req) = parsed {
+                                trace!(connection_id = %connection_id, session_id = %sid, request_id = ?req.id, "Client → Agent (session)");
+                        }
+                        if connection.send_frame_to_agent(frame).is_err() {
+                            error!(connection_id = %connection_id, "Agent channel closed");
+                            break;
                         }
                     }
                     Some(Ok(WsMessage::Close(frame))) => {

--- a/src/agent-client-protocol-polyfill/CHANGELOG.md
+++ b/src/agent-client-protocol-polyfill/CHANGELOG.md
@@ -7,10 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+### Curated release notes
 
-- Preserve JSON-RPC batch frames through the MCP-over-ACP HTTP bridge and keep
-  malformed POST errors correlated with their originating HTTP requests.
+- **Breaking:** Upgrade to `agent-client-protocol` 2.x. Polyfill components and the core
+  handlers/types they connect must be migrated together.
+- **Changed:** Align the bridge background-task terminology with the core runner APIs.
+- **Documentation:** Update legacy v1 MCP-over-ACP conductor composition examples for the current
+  constructor and distinguish it from the draft native MCP-over-ACP transport.
+- **Fixed:** Preserve JSON-RPC batch frames through the legacy MCP-over-ACP HTTP bridge, answer
+  malformed calls on their originating POST, and ignore malformed response-shaped input.
+- **Fixed:** Serialize overlapping request IDs (including `id: null`) and response-bearing batches
+  without identifiable request IDs, and retain active correlations after an HTTP caller
+  disconnects, preventing late or concurrent responses from being delivered to the wrong POST.
 
 ## [1.0.1](https://github.com/agentclientprotocol/rust-sdk/compare/agent-client-protocol-polyfill-v1.0.0...agent-client-protocol-polyfill-v1.0.1) - 2026-06-29
 

--- a/src/agent-client-protocol-polyfill/src/lib.rs
+++ b/src/agent-client-protocol-polyfill/src/lib.rs
@@ -5,9 +5,10 @@
 //!
 //! ## MCP-over-ACP Polyfill
 //!
-//! The [`mcp_over_acp`] module provides a proxy that bridges MCP-over-ACP transport
-//! for agents that don't support `mcpCapabilities.acp`. It intercepts `NewSessionRequest`
-//! to transform `McpServer::Http` entries with `acp:` URLs into localhost TCP bridges,
-//! and handles `_mcp/*` messages by routing them through those bridges.
+//! The [`mcp_over_acp`] module implements the legacy v1 MCP-over-ACP extension for
+//! agents that don't support `mcpCapabilities.acp`. It transforms `McpServer::Http`
+//! entries with `acp:` URLs into localhost TCP bridges and routes the legacy
+//! `_mcp/connect`, `_mcp/message`, and `_mcp/disconnect` methods through those bridges.
+//! This is distinct from the draft native `McpServer::Acp` transport and its `mcp/*` methods.
 
 pub mod mcp_over_acp;

--- a/src/agent-client-protocol-polyfill/src/mcp_over_acp/actor.rs
+++ b/src/agent-client-protocol-polyfill/src/mcp_over_acp/actor.rs
@@ -13,7 +13,7 @@ pub(crate) struct BridgeConnectionActor {
     /// How to connect to the MCP server (e.g., stdio or HTTP transport).
     transport: DynConnectTo<mcp::Client>,
 
-    /// Sender for messages back to the polyfill's bridge responder loop.
+    /// Sender for messages back to the polyfill's bridge runner loop.
     bridge_tx: mpsc::Sender<BridgeMessage>,
 
     /// Receiver for messages from the polyfill to forward to the MCP client.

--- a/src/agent-client-protocol-polyfill/src/mcp_over_acp/http.rs
+++ b/src/agent-client-protocol-polyfill/src/mcp_over_acp/http.rs
@@ -183,6 +183,7 @@ enum HttpMessage {
 struct RunningServer {
     waiting_sessions: FxHashMap<RequestId, RegisteredSession>,
     waiting_batch_sessions: Vec<WaitingBatchSession>,
+    pending_calls: VecDeque<PendingCall>,
     general_sessions: Vec<RegisteredSession>,
     message_deque: VecDeque<TransportFrame>,
 }
@@ -192,6 +193,7 @@ impl RunningServer {
         RunningServer {
             waiting_sessions: HashMap::default(),
             waiting_batch_sessions: Vec::new(),
+            pending_calls: VecDeque::new(),
             general_sessions: Vec::default(),
             message_deque: VecDeque::with_capacity(32),
         }
@@ -226,6 +228,7 @@ impl RunningServer {
             }
 
             self.drain_jsonrpc_messages();
+            self.activate_pending_calls(&mut channel.tx)?;
         }
 
         Ok(())
@@ -245,11 +248,14 @@ impl RunningServer {
             } => {
                 tracing::debug!(%http_request_id, ?request, "handling request");
                 let request_id = request.id.clone();
-                channel_tx
-                    .unbounded_send(TransportFrame::Single(RawJsonRpcMessage::Request(request)))
-                    .map_err(agent_client_protocol::util::internal_error)?;
-                let session = RegisteredSession::new(response_tx);
-                self.waiting_sessions.insert(request_id, session);
+                self.send_or_queue_call(
+                    PendingCall {
+                        frame: TransportFrame::Single(RawJsonRpcMessage::Request(request)),
+                        request_ids: vec![request_id],
+                        session: RegisteredSession::new(response_tx),
+                    },
+                    channel_tx,
+                )?;
             }
             HttpMessage::Notification {
                 http_request_id: _,
@@ -279,13 +285,17 @@ impl RunningServer {
             } => {
                 tracing::debug!(%http_request_id, ?frame, "handling retained frame");
                 if let Some(response_tx) = response_tx {
-                    let session = RegisteredSession::new(response_tx);
                     match &frame {
                         TransportFrame::Batch(_) => {
-                            self.waiting_batch_sessions.push(WaitingBatchSession {
-                                request_ids,
-                                session,
-                            });
+                            self.send_or_queue_call(
+                                PendingCall {
+                                    frame,
+                                    request_ids,
+                                    session: RegisteredSession::new(response_tx),
+                                },
+                                channel_tx,
+                            )?;
+                            return Ok(());
                         }
                         TransportFrame::Single(_) | TransportFrame::Malformed { .. } => {
                             unreachable!("only batches use the retained frame variant")
@@ -306,6 +316,107 @@ impl RunningServer {
         }
         self.purge_closed_sessions();
         Ok(())
+    }
+
+    fn send_or_queue_call(
+        &mut self,
+        call: PendingCall,
+        channel_tx: &mut mpsc::UnboundedSender<TransportFrame>,
+    ) -> Result<(), agent_client_protocol::Error> {
+        if self.call_conflicts_with_active(&call.request_ids) {
+            tracing::debug!(
+                request_ids = ?call.request_ids,
+                "queueing HTTP call until overlapping request IDs are no longer in flight"
+            );
+            self.pending_calls.push_back(call);
+            return Ok(());
+        }
+
+        self.activate_call(call, channel_tx)
+    }
+
+    fn activate_call(
+        &mut self,
+        call: PendingCall,
+        channel_tx: &mut mpsc::UnboundedSender<TransportFrame>,
+    ) -> Result<(), agent_client_protocol::Error> {
+        let PendingCall {
+            frame,
+            request_ids,
+            session,
+        } = call;
+        let is_batch = matches!(frame, TransportFrame::Batch(_));
+        channel_tx
+            .unbounded_send(frame)
+            .map_err(agent_client_protocol::util::internal_error)?;
+
+        if is_batch {
+            self.waiting_batch_sessions.push(WaitingBatchSession {
+                request_ids,
+                session,
+            });
+        } else {
+            let request_id = request_ids
+                .into_iter()
+                .next()
+                .expect("single request calls always have one request ID");
+            self.waiting_sessions.insert(request_id, session);
+        }
+
+        Ok(())
+    }
+
+    fn activate_pending_calls(
+        &mut self,
+        channel_tx: &mut mpsc::UnboundedSender<TransportFrame>,
+    ) -> Result<(), agent_client_protocol::Error> {
+        loop {
+            let Some(call) = self.pending_calls.front() else {
+                return Ok(());
+            };
+            if call.session.outgoing_tx.is_closed() {
+                self.pending_calls.pop_front();
+                continue;
+            }
+            if self.call_conflicts_with_active(&call.request_ids) {
+                return Ok(());
+            }
+
+            let call = self
+                .pending_calls
+                .pop_front()
+                .expect("pending call was checked above");
+            self.activate_call(call, channel_tx)?;
+        }
+    }
+
+    fn call_conflicts_with_active(&self, request_ids: &[RequestId]) -> bool {
+        let unidentified_batch_is_active = self
+            .waiting_batch_sessions
+            .iter()
+            .any(|waiting| waiting.request_ids.is_empty());
+
+        if request_ids.is_empty() {
+            // A response-bearing batch without a request ID (for example, a
+            // notification plus an invalid scalar) receives a grouped error
+            // response whose only ID is null. Keep those responses ordered,
+            // including with explicit null-ID calls, because the wire response
+            // does not otherwise carry enough provenance to distinguish them.
+            return unidentified_batch_is_active || self.request_id_is_active(&RequestId::Null);
+        }
+
+        request_ids
+            .iter()
+            .any(|request_id| self.request_id_is_active(request_id))
+            || unidentified_batch_is_active && request_ids.contains(&RequestId::Null)
+    }
+
+    fn request_id_is_active(&self, request_id: &RequestId) -> bool {
+        self.waiting_sessions.contains_key(request_id)
+            || self
+                .waiting_batch_sessions
+                .iter()
+                .any(|waiting| waiting.request_ids.contains(request_id))
     }
 
     fn drain_jsonrpc_messages(&mut self) {
@@ -342,19 +453,19 @@ impl RunningServer {
                         .iter()
                         .any(|id| response_ids.contains(&id))
             });
-            let fallback = self
-                .waiting_batch_sessions
-                .iter()
-                .position(|waiting| waiting.request_ids.is_empty());
+            let fallback = response_ids.contains(&&RequestId::Null).then(|| {
+                self.waiting_batch_sessions
+                    .iter()
+                    .position(|waiting| waiting.request_ids.is_empty())
+            });
+            let fallback = fallback.flatten();
             if let Some(index) = correlated.or(fallback) {
                 let session = self.waiting_batch_sessions.remove(index).session;
-                match session.outgoing_tx.unbounded_send(message) {
-                    Ok(()) => return None,
-                    Err(error) => {
-                        assert!(error.is_disconnected());
-                        message = error.into_inner();
-                    }
-                }
+                // This response belongs to that HTTP POST even if its SSE
+                // receiver has gone away. Never let it fall through to a
+                // later request that reuses the same JSON-RPC ID.
+                drop(session.outgoing_tx.unbounded_send(message));
+                return None;
             }
         }
 
@@ -370,13 +481,11 @@ impl RunningServer {
         if let Some(ref message_id) = message_id
             && let Some(session) = self.waiting_sessions.remove(message_id)
         {
-            match session.outgoing_tx.unbounded_send(message) {
-                Ok(()) => return None,
-                Err(m) => {
-                    assert!(m.is_disconnected());
-                    message = m.into_inner();
-                }
-            }
+            // This response belongs to that HTTP POST even if its SSE
+            // receiver has gone away. Never let it fall through to a later
+            // request that reuses the same JSON-RPC ID.
+            drop(session.outgoing_tx.unbounded_send(message));
+            return None;
         }
 
         self.purge_closed_sessions();
@@ -386,6 +495,11 @@ impl RunningServer {
             .chain(self.waiting_sessions.values_mut())
             .chain(
                 self.waiting_batch_sessions
+                    .iter_mut()
+                    .map(|waiting| &mut waiting.session),
+            )
+            .chain(
+                self.pending_calls
                     .iter_mut()
                     .map(|waiting| &mut waiting.session),
             );
@@ -405,11 +519,19 @@ impl RunningServer {
     fn purge_closed_sessions(&mut self) {
         self.general_sessions
             .retain(|session| !session.outgoing_tx.is_closed());
-        self.waiting_sessions
-            .retain(|_, session| !session.outgoing_tx.is_closed());
-        self.waiting_batch_sessions
-            .retain(|waiting| !waiting.session.outgoing_tx.is_closed());
+        self.pending_calls
+            .retain(|call| !call.session.outgoing_tx.is_closed());
+
+        // Calls already forwarded to the JSON-RPC peer stay registered until
+        // their response arrives. Otherwise a late response could be routed
+        // to a newer HTTP POST that reused the same request ID.
     }
+}
+
+struct PendingCall {
+    frame: TransportFrame,
+    request_ids: Vec<RequestId>,
+    session: RegisteredSession,
 }
 
 struct WaitingBatchSession {
@@ -440,9 +562,7 @@ async fn handle_post(
     body: String,
 ) -> Result<Response, HttpError> {
     let http_request_id = uuid::Uuid::new_v4();
-    let Some(frame) = TransportFrame::parse_json(&body) else {
-        return Ok(StatusCode::ACCEPTED.into_response());
-    };
+    let frame = TransportFrame::parse_json(&body);
 
     match frame {
         TransportFrame::Single(message) => match message {
@@ -480,23 +600,35 @@ async fn handle_post(
                 Ok(StatusCode::ACCEPTED.into_response())
             }
         },
-        TransportFrame::Malformed { error, .. } => Ok(immediate_sse_response(
-            TransportFrame::Single(RawJsonRpcMessage::response(RequestId::Null, Err(error))),
-        )),
+        TransportFrame::Malformed { raw, error } => {
+            if raw
+                .parse::<serde_json::Value>()
+                .is_ok_and(|value| is_response_only_shape(&value))
+            {
+                return Ok(StatusCode::ACCEPTED.into_response());
+            }
+            Ok(immediate_sse_response(TransportFrame::Single(
+                RawJsonRpcMessage::response(RequestId::Null, Err(error)),
+            )))
+        }
         TransportFrame::Batch(batch) => {
             if batch
                 .entries()
                 .all(|entry| matches!(entry, TransportBatchEntry::Malformed { .. }))
             {
                 let responses = agent_client_protocol::TransportBatch::from_messages(
-                    batch.entries().map(|entry| {
-                        let TransportBatchEntry::Malformed { error, .. } = entry else {
+                    batch.entries().filter_map(|entry| {
+                        let TransportBatchEntry::Malformed { raw, error } = entry else {
                             unreachable!("all batch entries were checked as malformed")
                         };
-                        RawJsonRpcMessage::response(RequestId::Null, Err(error.clone()))
+                        (!is_response_only_shape(raw)).then(|| {
+                            RawJsonRpcMessage::response(RequestId::Null, Err(error.clone()))
+                        })
                     }),
-                )
-                .expect("a TransportBatch is non-empty");
+                );
+                let Some(responses) = responses else {
+                    return Ok(StatusCode::ACCEPTED.into_response());
+                };
                 return Ok(immediate_sse_response(TransportFrame::Batch(responses)));
             }
 
@@ -508,7 +640,9 @@ async fn handle_post(
                         request_ids.push(request.id.clone());
                         expects_response = true;
                     }
-                    TransportBatchEntry::Malformed { .. } => expects_response = true,
+                    TransportBatchEntry::Malformed { raw, .. } => {
+                        expects_response |= !is_response_only_shape(raw);
+                    }
                     TransportBatchEntry::Message(
                         RawJsonRpcMessage::Notification(_) | RawJsonRpcMessage::Response(_),
                     ) => {}
@@ -541,6 +675,13 @@ async fn handle_post(
             }
         }
     }
+}
+
+fn is_response_only_shape(value: &serde_json::Value) -> bool {
+    value.as_object().is_some_and(|object| {
+        !object.contains_key("method")
+            && (object.contains_key("result") || object.contains_key("error"))
+    })
 }
 
 /// Accept a GET request from an MCP client.
@@ -671,6 +812,379 @@ mod tests {
                     error,
                     ..
                 }) if error.code == agent_client_protocol::ErrorCode::ParseError
+            ));
+        });
+    }
+
+    #[test]
+    fn malformed_response_shaped_posts_are_ignored_without_registration() {
+        futures::executor::block_on(async {
+            let (registration_tx, mut registration_rx) = mpsc::unbounded();
+            let state = Arc::new(BridgeState { registration_tx });
+            let malformed_response = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": null,
+                "error": { "code": -32603, "message": "Internal error" }
+            });
+
+            let single = handle_post(State(state.clone()), malformed_response.to_string())
+                .await
+                .expect("malformed response-shaped POST");
+            assert_eq!(single.status(), StatusCode::ACCEPTED);
+
+            let batch = handle_post(
+                State(state),
+                serde_json::Value::Array(vec![malformed_response]).to_string(),
+            )
+            .await
+            .expect("malformed response-only batch POST");
+            assert_eq!(batch.status(), StatusCode::ACCEPTED);
+            assert!(
+                registration_rx.try_recv().is_err(),
+                "ignored responses must not be forwarded or register HTTP waiters"
+            );
+        });
+    }
+
+    #[test]
+    fn malformed_response_sibling_does_not_hide_invalid_batch_value() {
+        futures::executor::block_on(async {
+            let (registration_tx, mut registration_rx) = mpsc::unbounded();
+            let state = Arc::new(BridgeState { registration_tx });
+            let response = handle_post(
+                State(state),
+                serde_json::json!([
+                    17,
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "result": null,
+                        "error": { "code": -32603, "message": "Internal error" }
+                    }
+                ])
+                .to_string(),
+            )
+            .await
+            .expect("mixed malformed batch POST");
+
+            let payload = single_sse_payload(response).await;
+            let entries = payload.as_array().expect("batch response array");
+            assert_eq!(entries.len(), 1);
+            assert_eq!(entries[0]["id"], serde_json::Value::Null);
+            assert_eq!(
+                entries[0]["error"]["code"],
+                i32::from(agent_client_protocol::ErrorCode::InvalidRequest)
+            );
+            assert!(
+                registration_rx.try_recv().is_err(),
+                "an all-malformed batch is answered by its originating POST"
+            );
+        });
+    }
+
+    #[test]
+    fn concurrent_null_id_posts_are_serialized_to_preserve_response_provenance() {
+        futures::executor::block_on(async {
+            let (registration_tx, mut registration_rx) = mpsc::unbounded();
+            let state = Arc::new(BridgeState { registration_tx });
+
+            let first_http_response = handle_post(
+                State(state.clone()),
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": null,
+                    "method": "example/first",
+                    "params": {}
+                })
+                .to_string(),
+            )
+            .await
+            .expect("first null-ID POST");
+            let second_http_response = handle_post(
+                State(state),
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": null,
+                    "method": "example/second",
+                    "params": {}
+                })
+                .to_string(),
+            )
+            .await
+            .expect("second null-ID POST");
+
+            let first_registration = registration_rx.next().await.unwrap();
+            let second_registration = registration_rx.next().await.unwrap();
+            let mut server = RunningServer::new();
+            let (mut channel_tx, mut channel_rx) = mpsc::unbounded();
+
+            server
+                .handle_http_message(first_registration, &mut channel_tx)
+                .unwrap();
+            server
+                .handle_http_message(second_registration, &mut channel_tx)
+                .unwrap();
+            assert!(matches!(
+                channel_rx.next().await,
+                Some(TransportFrame::Single(RawJsonRpcMessage::Request(request)))
+                    if request.method.as_ref() == "example/first"
+                        && request.id == RequestId::Null
+            ));
+            assert!(
+                channel_rx.try_recv().is_err(),
+                "an overlapping null-ID request must wait for the first response"
+            );
+
+            assert!(
+                server
+                    .try_dispatch_jsonrpc_message(TransportFrame::Single(
+                        RawJsonRpcMessage::response(
+                            RequestId::Null,
+                            Ok(serde_json::json!({ "source": "first" })),
+                        ),
+                    ))
+                    .is_none()
+            );
+            server.activate_pending_calls(&mut channel_tx).unwrap();
+            assert!(matches!(
+                channel_rx.next().await,
+                Some(TransportFrame::Single(RawJsonRpcMessage::Request(request)))
+                    if request.method.as_ref() == "example/second"
+                        && request.id == RequestId::Null
+            ));
+
+            assert!(
+                server
+                    .try_dispatch_jsonrpc_message(TransportFrame::Single(
+                        RawJsonRpcMessage::response(
+                            RequestId::Null,
+                            Ok(serde_json::json!({ "source": "second" })),
+                        ),
+                    ))
+                    .is_none()
+            );
+
+            assert!(matches!(
+                single_sse_message(first_http_response).await,
+                RawJsonRpcMessage::Response(RpcResponse::Result {
+                    id: RequestId::Null,
+                    result,
+                    ..
+                }) if result == serde_json::json!({ "source": "first" })
+            ));
+            assert!(matches!(
+                single_sse_message(second_http_response).await,
+                RawJsonRpcMessage::Response(RpcResponse::Result {
+                    id: RequestId::Null,
+                    result,
+                    ..
+                }) if result == serde_json::json!({ "source": "second" })
+            ));
+        });
+    }
+
+    #[test]
+    fn unidentified_batch_posts_are_serialized_to_preserve_response_provenance() {
+        futures::executor::block_on(async {
+            fn unidentified_batch(method: &str) -> TransportFrame {
+                TransportFrame::parse_json(
+                    &serde_json::json!([
+                        {
+                            "jsonrpc": "2.0",
+                            "method": method,
+                            "params": {}
+                        },
+                        17
+                    ])
+                    .to_string(),
+                )
+            }
+
+            fn grouped_response(source: &str) -> TransportFrame {
+                TransportFrame::Batch(
+                    agent_client_protocol::TransportBatch::from_messages([
+                        RawJsonRpcMessage::response(
+                            RequestId::Null,
+                            Ok(serde_json::json!({ "source": source })),
+                        ),
+                    ])
+                    .expect("grouped response is non-empty"),
+                )
+            }
+
+            let mut server = RunningServer::new();
+            let (mut channel_tx, mut channel_rx) = mpsc::unbounded();
+            let (first_tx, mut first_rx) = mpsc::unbounded();
+            let (second_tx, mut second_rx) = mpsc::unbounded();
+
+            let first_frame = unidentified_batch("example/first");
+            let second_frame = unidentified_batch("example/second");
+            let expected_first_frame = first_frame.to_json().unwrap();
+            let expected_second_frame = second_frame.to_json().unwrap();
+            server
+                .handle_http_message(
+                    HttpMessage::Frame {
+                        http_request_id: uuid::Uuid::new_v4(),
+                        frame: first_frame,
+                        request_ids: Vec::new(),
+                        response_tx: Some(first_tx),
+                    },
+                    &mut channel_tx,
+                )
+                .unwrap();
+            server
+                .handle_http_message(
+                    HttpMessage::Frame {
+                        http_request_id: uuid::Uuid::new_v4(),
+                        frame: second_frame,
+                        request_ids: Vec::new(),
+                        response_tx: Some(second_tx),
+                    },
+                    &mut channel_tx,
+                )
+                .unwrap();
+
+            assert_eq!(
+                channel_rx.next().await.unwrap().to_json().unwrap(),
+                expected_first_frame
+            );
+            assert!(
+                channel_rx.try_recv().is_err(),
+                "a second unidentified batch must wait for the first response"
+            );
+
+            let callback = TransportFrame::Batch(
+                agent_client_protocol::TransportBatch::from_messages([
+                    RawJsonRpcMessage::notification("callback".into(), serde_json::json!({}))
+                        .unwrap(),
+                ])
+                .expect("callback batch is non-empty"),
+            );
+            assert!(server.try_dispatch_jsonrpc_message(callback).is_none());
+            assert!(matches!(
+                first_rx.next().await,
+                Some(TransportFrame::Batch(_))
+            ));
+
+            let first_response = grouped_response("first");
+            let expected_first_response = first_response.to_json().unwrap();
+            assert!(
+                server
+                    .try_dispatch_jsonrpc_message(first_response)
+                    .is_none()
+            );
+            assert_eq!(
+                first_rx.next().await.unwrap().to_json().unwrap(),
+                expected_first_response
+            );
+
+            server.activate_pending_calls(&mut channel_tx).unwrap();
+            assert_eq!(
+                channel_rx.next().await.unwrap().to_json().unwrap(),
+                expected_second_frame
+            );
+
+            let second_response = grouped_response("second");
+            let expected_second_response = second_response.to_json().unwrap();
+            assert!(
+                server
+                    .try_dispatch_jsonrpc_message(second_response)
+                    .is_none()
+            );
+            assert_eq!(
+                second_rx.next().await.unwrap().to_json().unwrap(),
+                expected_second_response
+            );
+        });
+    }
+
+    #[test]
+    fn late_response_to_disconnected_post_cannot_reach_reused_id() {
+        futures::executor::block_on(async {
+            fn request(method: &str) -> RpcRequest<RawJsonRpcParams> {
+                let RawJsonRpcMessage::Request(request) = RawJsonRpcMessage::request(
+                    method.to_owned(),
+                    serde_json::json!({}),
+                    RequestId::Null,
+                )
+                .unwrap() else {
+                    unreachable!("request constructor always returns a request")
+                };
+                request
+            }
+
+            let mut server = RunningServer::new();
+            let (mut channel_tx, mut channel_rx) = mpsc::unbounded();
+            let (first_tx, first_rx) = mpsc::unbounded();
+            let (second_tx, mut second_rx) = mpsc::unbounded();
+
+            server
+                .handle_http_message(
+                    HttpMessage::Request {
+                        http_request_id: uuid::Uuid::new_v4(),
+                        request: request("example/first"),
+                        response_tx: first_tx,
+                    },
+                    &mut channel_tx,
+                )
+                .unwrap();
+            server
+                .handle_http_message(
+                    HttpMessage::Request {
+                        http_request_id: uuid::Uuid::new_v4(),
+                        request: request("example/second"),
+                        response_tx: second_tx,
+                    },
+                    &mut channel_tx,
+                )
+                .unwrap();
+            assert!(matches!(
+                channel_rx.next().await,
+                Some(TransportFrame::Single(RawJsonRpcMessage::Request(request)))
+                    if request.method.as_ref() == "example/first"
+            ));
+            drop(first_rx);
+
+            let callback = TransportFrame::Single(
+                RawJsonRpcMessage::notification("callback".into(), serde_json::json!({})).unwrap(),
+            );
+            assert!(server.try_dispatch_jsonrpc_message(callback).is_none());
+            assert!(matches!(
+                second_rx.next().await,
+                Some(TransportFrame::Single(RawJsonRpcMessage::Notification(_)))
+            ));
+
+            let first_response = TransportFrame::Single(RawJsonRpcMessage::response(
+                RequestId::Null,
+                Ok(serde_json::json!({ "source": "first" })),
+            ));
+            assert!(
+                server
+                    .try_dispatch_jsonrpc_message(first_response)
+                    .is_none()
+            );
+            server.activate_pending_calls(&mut channel_tx).unwrap();
+            assert!(matches!(
+                channel_rx.next().await,
+                Some(TransportFrame::Single(RawJsonRpcMessage::Request(request)))
+                    if request.method.as_ref() == "example/second"
+            ));
+
+            let second_response = TransportFrame::Single(RawJsonRpcMessage::response(
+                RequestId::Null,
+                Ok(serde_json::json!({ "source": "second" })),
+            ));
+            assert!(
+                server
+                    .try_dispatch_jsonrpc_message(second_response)
+                    .is_none()
+            );
+            assert!(matches!(
+                second_rx.next().await,
+                Some(TransportFrame::Single(RawJsonRpcMessage::Response(
+                    RpcResponse::Result { result, .. }
+                ))) if result == serde_json::json!({ "source": "second" })
             ));
         });
     }

--- a/src/agent-client-protocol-polyfill/src/mcp_over_acp/mod.rs
+++ b/src/agent-client-protocol-polyfill/src/mcp_over_acp/mod.rs
@@ -1,11 +1,14 @@
-//! MCP-over-ACP polyfill proxy.
+//! Legacy v1 MCP-over-ACP polyfill proxy.
 //!
-//! This proxy bridges MCP-over-ACP transport for agents that don't support
+//! This proxy bridges the legacy v1 MCP-over-ACP transport for agents that don't support
 //! `mcpCapabilities.acp` natively. It sits in the proxy chain and:
 //!
 //! - Intercepts `NewSessionRequest` to transform `McpServer::Http` entries with `acp:` URLs
 //!   into localhost TCP bridges
 //! - Handles `_mcp/connect`, `_mcp/message`, `_mcp/disconnect` by routing through those bridges
+//!
+//! This extension is distinct from the draft native `McpServer::Acp` transport and
+//! its `mcp/*` methods.
 //!
 //! # Usage
 //!
@@ -16,7 +19,6 @@
 //! let conductor = ConductorImpl::new_agent(
 //!     "conductor",
 //!     ProxiesAndAgent::new(my_agent).proxy(McpOverAcpPolyfill::http()),
-//!     McpBridgeMode::default(),
 //! );
 //! ```
 
@@ -107,9 +109,9 @@ pub enum BridgeMode {
     Http,
 }
 
-/// MCP-over-ACP polyfill proxy.
+/// Legacy v1 MCP-over-ACP polyfill proxy.
 ///
-/// Bridges MCP-over-ACP transport for agents that don't support `mcpCapabilities.acp`.
+/// Bridges the legacy transport for agents that don't support `mcpCapabilities.acp`.
 #[derive(Debug)]
 pub struct McpOverAcpPolyfill {
     mode: BridgeMode,
@@ -144,7 +146,7 @@ impl ConnectTo<Conductor> for McpOverAcpPolyfill {
         Proxy
             .builder()
             .name("mcp-over-acp-polyfill")
-            .with_runner(BridgeResponder {
+            .with_runner(BridgeRunner {
                 bridge_tx: bridge_tx.clone(),
                 bridge_rx,
                 bridge_connections: HashMap::new(),
@@ -309,22 +311,22 @@ impl BridgeListeners {
     }
 }
 
-/// Responder that runs alongside the proxy, managing bridge state.
-struct BridgeResponder {
+/// Runner that manages bridge state alongside the proxy.
+struct BridgeRunner {
     bridge_tx: mpsc::Sender<BridgeMessage>,
     bridge_rx: mpsc::Receiver<BridgeMessage>,
     bridge_connections: HashMap<String, BridgeConnection>,
 }
 
-impl std::fmt::Debug for BridgeResponder {
+impl std::fmt::Debug for BridgeRunner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("BridgeResponder")
+        f.debug_struct("BridgeRunner")
             .field("bridge_connections", &self.bridge_connections.len())
             .finish_non_exhaustive()
     }
 }
 
-impl agent_client_protocol::RunWithConnectionTo<Conductor> for BridgeResponder {
+impl agent_client_protocol::RunWithConnectionTo<Conductor> for BridgeRunner {
     async fn run_with_connection_to(
         mut self,
         connection: ConnectionTo<Conductor>,

--- a/src/agent-client-protocol-rmcp/CHANGELOG.md
+++ b/src/agent-client-protocol-rmcp/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Curated release notes
+
+- **Breaking change:** Upgrade the public `agent-client-protocol` dependency from 1.x to
+  2.x. Downstream code using core SDK types through this crate must migrate both
+  crates together; this requires `agent-client-protocol-rmcp` 3.0.0.
+- **Changed:** Align `McpServerBuilder`'s background-task terminology with the core
+  runner APIs.
+- **Documentation:** Replace removed handler and `serve()` APIs in examples and
+  document compatibility with both public dependencies.
+
 ## [2.0.1](https://github.com/agentclientprotocol/rust-sdk/compare/agent-client-protocol-rmcp-v2.0.0...agent-client-protocol-rmcp-v2.0.1) - 2026-07-20
 
 ### Other

--- a/src/agent-client-protocol-rmcp/README.md
+++ b/src/agent-client-protocol-rmcp/README.md
@@ -38,21 +38,25 @@ This crate is separate from `agent-client-protocol` to avoid coupling the core p
 
 - `agent-client-protocol` to remain focused on the ACP protocol
 - `agent-client-protocol-rmcp` to track `rmcp` updates independently
-- Breaking changes in `rmcp` only require updating this crate
+- Integrations to choose compatible `agent-client-protocol` and `rmcp` major
+  versions explicitly
 
 ## Versioning
 
-`rmcp` is a public dependency of this crate: its types appear in the public API (e.g. `McpServerExt::from_rmcp`). Each major release of `rmcp` therefore requires a major release of this crate, independent of the other `agent-client-protocol` crates.
+Both `agent-client-protocol` and `rmcp` are public dependencies of this crate:
+their types and traits appear in its public API. A source-incompatible major
+release of either dependency therefore requires a major release of this crate.
 
-| agent-client-protocol-rmcp | rmcp |
-| -------------------------- | ---- |
-| 2.x                        | 2.x  |
-| 1.x                        | 1.x  |
+| agent-client-protocol-rmcp | agent-client-protocol | rmcp |
+| -------------------------- | --------------------- | ---- |
+| 3.x                        | 2.x                   | 2.x  |
+| 2.x                        | 1.x                   | 2.x  |
+| 1.x                        | 1.x                   | 1.x  |
 
 ## Related Crates
 
 - **[agent-client-protocol](../agent-client-protocol/)** — Core ACP protocol types and traits
-- **[agent-client-protocol-tokio](../agent-client-protocol-tokio/)** — Tokio utilities for spawning agent processes
+- **[agent-client-protocol-conductor](../agent-client-protocol-conductor/)** — Proxy-chain orchestration
 
 ## License
 

--- a/src/agent-client-protocol-rmcp/src/builder.rs
+++ b/src/agent-client-protocol-rmcp/src/builder.rs
@@ -44,14 +44,14 @@ use agent_client_protocol::{
 ///     .build();
 /// ```
 #[derive(Debug)]
-pub struct McpServerBuilder<Counterpart: Role, Responder>
+pub struct McpServerBuilder<Counterpart: Role, Runner>
 where
-    Responder: RunWithConnectionTo<Counterpart>,
+    Runner: RunWithConnectionTo<Counterpart>,
 {
     phantom: PhantomData<Counterpart>,
     name: String,
     data: McpToolRegistry<Counterpart>,
-    responder: Responder,
+    runner: Runner,
 }
 
 impl<Counterpart: Role> McpServerBuilder<Counterpart, NullRun> {
@@ -60,14 +60,14 @@ impl<Counterpart: Role> McpServerBuilder<Counterpart, NullRun> {
             name,
             phantom: PhantomData,
             data: McpToolRegistry::default(),
-            responder: NullRun,
+            runner: NullRun,
         }
     }
 }
 
-impl<Counterpart: Role, Responder> McpServerBuilder<Counterpart, Responder>
+impl<Counterpart: Role, Runner> McpServerBuilder<Counterpart, Runner>
 where
-    Responder: RunWithConnectionTo<Counterpart>,
+    Runner: RunWithConnectionTo<Counterpart>,
 {
     /// Set the server instructions that are provided to the client.
     #[must_use]
@@ -115,19 +115,19 @@ where
         Ok(self)
     }
 
-    /// Private fn: adds the tool but also adds a responder that will be
+    /// Private fn: adds the tool but also adds a runner that will be
     /// run while the MCP server is active.
-    fn tool_with_responder(
+    fn tool_with_runner(
         self,
         tool: impl McpTool<Counterpart> + 'static,
-        tool_responder: impl RunWithConnectionTo<Counterpart>,
+        tool_runner: impl RunWithConnectionTo<Counterpart>,
     ) -> McpServerBuilder<Counterpart, impl RunWithConnectionTo<Counterpart>> {
         let this = self.tool(tool);
         McpServerBuilder {
             phantom: PhantomData,
             name: this.name,
             data: this.data,
-            responder: ChainRun::new(this.responder, tool_responder),
+            runner: ChainRun::new(this.runner, tool_runner),
         }
     }
 
@@ -171,9 +171,9 @@ where
         Ret: JsonSchema + Serialize + 'static + Send,
         F: AsyncFnMut(P, McpConnectionTo<Counterpart>) -> Result<Ret, acp::Error> + Send,
     {
-        let (tool, responder) =
+        let (tool, runner) =
             acp::mcp_server::tool_fn_mut(name, description, func, tool_future_hack);
-        self.tool_with_responder(tool, responder)
+        self.tool_with_runner(tool, runner)
     }
 
     /// Convenience wrapper for defining a stateless tool that can run concurrently.
@@ -218,21 +218,21 @@ where
             + Sync
             + 'static,
     {
-        let (tool, responder) = acp::mcp_server::tool_fn(name, description, func, tool_future_hack);
-        self.tool_with_responder(tool, responder)
+        let (tool, runner) = acp::mcp_server::tool_fn(name, description, func, tool_future_hack);
+        self.tool_with_runner(tool, runner)
     }
 
     /// Create an MCP server from this builder.
     ///
     /// This builder can be attached to new sessions (see [`SessionBuilder::with_mcp_server`](`agent_client_protocol::SessionBuilder::with_mcp_server`))
     /// or served up as part of a proxy (see [`Builder::with_mcp_server`](`agent_client_protocol::Builder::with_mcp_server`)).
-    pub fn build(self) -> McpServer<Counterpart, Responder> {
+    pub fn build(self) -> McpServer<Counterpart, Runner> {
         McpServer::new(
             McpServerBuilt {
                 name: self.name,
                 data: Arc::new(self.data),
             },
-            self.responder,
+            self.runner,
         )
     }
 }

--- a/src/agent-client-protocol-rmcp/src/lib.rs
+++ b/src/agent-client-protocol-rmcp/src/lib.rs
@@ -22,10 +22,10 @@
 //!
 //! let server = McpServer::from_rmcp("my-server", MyRmcpService::new);
 //!
-//! // Use as a handler
+//! // Attach it to a proxy and connect the proxy to its transport.
 //! Proxy.builder()
-//!     .with_handler(server)
-//!     .serve(client)
+//!     .with_mcp_server(server)
+//!     .connect_to(transport)
 //!     .await?;
 //! ```
 

--- a/src/agent-client-protocol-trace-viewer/CHANGELOG.md
+++ b/src/agent-client-protocol-trace-viewer/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Curated 2.0 release notes
+
+**Changed**
+
+- Align the release line with the ACP SDK 2.0 version group. The trace viewer's
+  public API and three-variant JSON event schema are unchanged by the core
+  transport-frame migration.
+
 ## [1.3.0](https://github.com/agentclientprotocol/rust-sdk/compare/agent-client-protocol-trace-viewer-v1.2.0...agent-client-protocol-trace-viewer-v1.3.0) - 2026-07-20
 
 ### Other

--- a/src/agent-client-protocol/CHANGELOG.md
+++ b/src/agent-client-protocol/CHANGELOG.md
@@ -2,48 +2,65 @@
 
 ## [Unreleased]
 
-### Added
+### Curated 2.0 release notes
 
+**Added**
+
+- Accept incoming JSON-RPC batches in stable v1 and draft v2 connections, process entries
+  independently, and group replies into one response array. The SDK still sends requests and
+  notifications individually.
 - Allow mapped `SentRequest` values to be consumed without implementing `JsonRpcResponse`, and
   accept one-shot mappers.
 
-### Changed
+**Breaking and changed**
 
-- **Breaking:** Make `Channel` the batch-aware `TransportFrame` boundary and remove the hidden
-  `FramedChannel` compatibility path. See the
-  [2.0 migration guide](../../md/migration_v2.0.md).
+- **Breaking:** Make `Channel` the batch-aware `TransportFrame` boundary instead of carrying
+  individual message results. Public frame types are cloneable, and `TransportBatch` exposes
+  owned entry iteration. See the [2.0 migration guide].
 - **Breaking:** Rename `ResponseRouter` response methods to use routing terminology and return
-  borrowed `RequestId` values from response and request handles. See the
-  [2.0 migration guide](../../md/migration_v2.0.md).
+  borrowed `RequestId` values from response and request handles. See the [2.0 migration guide].
 - **Breaking:** Remove ambiguous JSON-RPC error-response and dispatch-conversion helpers, and
-  require `Dispatch` notification types to implement `JsonRpcNotification`. See the
-  [2.0 migration guide](../../md/migration_v2.0.md).
+  require `Dispatch` notification types to implement `JsonRpcNotification`. In particular,
+  remove `ConnectionTo::send_error_notification` and `Dispatch::respond_with_error`: JSON-RPC
+  notifications never receive responses. Make `TypeNotification` role-independent and construct
+  it without a connection. See the [2.0 migration guide].
 - **Breaking:** Replace cloneable dynamic-handler registrations with `DynamicHandlerGuard` and
   use `detach()` to keep handlers registered without leaking a connection handle. See the
-  [2.0 migration guide](../../md/migration_v2.0.md).
+  [2.0 migration guide].
 - **Breaking:** Rename `Builder::with_responder` to `with_runner` to describe background
-  connection tasks separately from JSON-RPC response handles. See the
-  [2.0 migration guide](../../md/migration_v2.0.md).
+  connection tasks separately from JSON-RPC response handles. See the [2.0 migration guide].
 - **Breaking:** Rename `MatchDispatch::if_message` to `if_dispatch` and
-  `MatchDispatchFrom::if_message_from` to `if_dispatch_from`. See the
-  [2.0 migration guide](../../md/migration_v2.0.md).
+  `MatchDispatchFrom::if_message_from` to `if_dispatch_from`. See the [2.0 migration guide].
 - **Breaking:** Return borrowed identifiers, connection handles, modes, and metadata from
   `McpConnectionTo` and `ActiveSession`; remove `acp_url` and rename `connection_to` to
-  `connection`. See the [2.0 migration guide](../../md/migration_v2.0.md).
+  `connection`. See the [2.0 migration guide].
 - **Breaking:** Narrow low-level helpers by borrowing `DynConnectTo` type names, hiding transport
-  fields and session/stream internals, and removing `util::both`. See the
-  [2.0 migration guide](../../md/migration_v2.0.md).
+  fields and session/stream internals, and removing `util::both`. See the [2.0 migration guide].
 - **Breaking:** Replace the MCP wire-schema configuration accepted by `AcpAgent` with the SDK-local
   `AcpAgentConfig`; use `config()` and `into_config()`, and represent JSON environment variables as
-  an object.
+  an object. See the [2.0 migration guide].
 - **Breaking:** Remove the deprecated `zed_claude_code` and `zed_codex` constructors and the
-  `google_gemini` convenience constructor from `AcpAgent`.
+  `google_gemini` convenience constructor from `AcpAgent`. See the [2.0 migration guide].
+- Update `agent-client-protocol-schema` to 1.5.0. The stable v1 schema remains compatible; the
+  opt-in draft v2 API gains semantic newtypes, revised diff and terminal types, and generic
+  fallible conversion helpers. See the
+  [draft v2 migration notes](https://agentclientprotocol.github.io/rust-sdk/migration_v2.0.html#draft-v2-schema-updates).
 
-### Fixed
+**Fixed**
 
-- Preserve JSON-RPC batch framing across component adapters, and suppress replies
-  to malformed response-shaped input.
+- Preserve JSON-RPC batch framing across component adapters, protocol routing, and tracing
+  bridges. Invalid call entries no longer abort relays, fully filtered response batches are not
+  serialized as empty arrays, and malformed response-only input is ignored rather than answered.
+- Complete a batched request with `Internal Error` when its handler drops the responder, so
+  completed sibling replies can flush; an explicit handler error still takes precedence.
+- Route response-dispatch handler errors to the pending local `SentRequest` instead of losing the
+  original error or sending protocol traffic in response to a response.
+- Let the version-selecting agent router ignore response-only frames before `initialize` and
+  preserve response-only entries beside a valid batched initialization.
+- Release abandoned v2 and v1 probe implementations before continuing a negotiated v1 fallback.
 - Preserve `MatchDispatchFrom` retry state across chained matchers.
+
+[2.0 migration guide]: https://agentclientprotocol.github.io/rust-sdk/migration_v2.0.html
 
 ## [1.3.0](https://github.com/agentclientprotocol/rust-sdk/compare/v1.2.0...v1.3.0) - 2026-07-20
 

--- a/src/agent-client-protocol/README.md
+++ b/src/agent-client-protocol/README.md
@@ -19,13 +19,15 @@ enabling features like tool use, permission requests, and streaming responses.
 
 The most common use case is connecting to an existing ACP agent as a client:
 
-```rust
-use agent_client_protocol::{Client, Agent, ConnectTo};
+```rust,no_run
+use agent_client_protocol::{AcpAgent, Client, Result};
 use agent_client_protocol::schema::{ProtocolVersion, v1::InitializeRequest};
 
+# async fn connect() -> Result<()> {
+let agent = AcpAgent::from_args(["my-agent"])?;
 Client.builder()
     .name("my-client")
-    .connect_with(transport, async |cx| {
+    .connect_with(agent, async |cx| {
         // Initialize the connection
         cx.send_request(InitializeRequest::new(ProtocolVersion::V1))
             .block_task()
@@ -33,21 +35,24 @@ Client.builder()
 
         Ok(())
     })
-    .await?;
+    .await
+# }
 ```
 
 ## Learning More
 
 See the [crate documentation](https://docs.rs/agent-client-protocol) for:
 
-- **[Cookbook](https://docs.rs/agent-client-protocol/latest/agent_client_protocol/cookbook/)** — Patterns for building clients, proxies, and agents
+- **[Cookbook](https://docs.rs/agent-client-protocol-cookbook)** — Patterns for building clients, proxies, and agents
 - **[Examples](https://github.com/agentclientprotocol/rust-sdk/tree/main/src/agent-client-protocol/examples)** — Working code you can run
 
 ## Related Crates
 
-- **[agent-client-protocol-tokio](../agent-client-protocol-tokio/)** — Tokio utilities for spawning agent processes
+- **[agent-client-protocol-http](../agent-client-protocol-http/)** — HTTP/SSE and WebSocket transports
 - **[agent-client-protocol-rmcp](../agent-client-protocol-rmcp/)** — MCP tool builders and `rmcp` integration
 - **[agent-client-protocol-derive](../agent-client-protocol-derive/)** — Derive macros for JSON-RPC traits
+- **[agent-client-protocol-conductor](../agent-client-protocol-conductor/)** — Proxy-chain orchestration
+- **[agent-client-protocol-polyfill](../agent-client-protocol-polyfill/)** — Compatibility proxies, including MCP-over-ACP bridging
 - **[agent-client-protocol-trace-viewer](../agent-client-protocol-trace-viewer/)** — Interactive trace visualization
 
 ## Contribution Policy

--- a/src/agent-client-protocol/src/acp_agent.rs
+++ b/src/agent-client-protocol/src/acp_agent.rs
@@ -778,20 +778,6 @@ impl<Counterpart: AcpAgentCounterpartRole> crate::ConnectTo<Counterpart> for Acp
             futures::future::Either::Right(((), main_race)) => main_race.await,
         }
     }
-
-    fn into_channel_and_future(
-        self,
-    ) -> (
-        crate::Channel,
-        crate::BoxFuture<'static, Result<(), crate::Error>>,
-    ) {
-        let (channel_for_caller, channel_for_agent) = crate::Channel::duplex();
-        let future = Box::pin(crate::ConnectTo::<Counterpart>::connect_to(
-            self,
-            channel_for_agent,
-        ));
-        (channel_for_caller, future)
-    }
 }
 
 impl AcpAgent {

--- a/src/agent-client-protocol/src/jsonrpc.rs
+++ b/src/agent-client-protocol/src/jsonrpc.rs
@@ -50,7 +50,7 @@ use crate::role::HasPeer;
 use crate::role::Role;
 use crate::{Agent, Client, ConnectTo, RoleId};
 
-/// Raw JSON-RPC message transported by [`Channel`].
+/// One valid JSON-RPC message carried inside a [`TransportFrame`].
 ///
 /// This uses the JSON-RPC envelope types from `agent-client-protocol-schema`
 /// while keeping method params as raw, JSON-RPC-valid params at the transport boundary.
@@ -70,7 +70,7 @@ pub enum RawJsonRpcMessage {
 /// Malformed wire input is represented explicitly; transport failures are
 /// reported by the future that drives the transport rather than sent through a
 /// [`Channel`].
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum TransportFrame {
     /// One valid JSON-RPC message.
     Single(RawJsonRpcMessage),
@@ -86,14 +86,14 @@ pub enum TransportFrame {
 }
 
 /// A structurally non-empty JSON-RPC batch retained across framed relays.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct TransportBatch {
     first: TransportBatchEntry,
     rest: Vec<TransportBatchEntry>,
 }
 
 /// One entry in a [`TransportBatch`].
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum TransportBatchEntry {
     /// A valid JSON-RPC message.
     Message(RawJsonRpcMessage),
@@ -104,6 +104,17 @@ pub enum TransportBatchEntry {
         /// The JSON-RPC error associated with the malformed value.
         error: crate::Error,
     },
+}
+
+pub(crate) fn is_response_only_shape(value: &serde_json::Value) -> bool {
+    value.as_object().is_some_and(|object| {
+        !object.contains_key("method")
+            && (object.contains_key("result") || object.contains_key("error"))
+    })
+}
+
+pub(crate) fn raw_is_response_only_shape(raw: &str) -> bool {
+    serde_json::from_str(raw).is_ok_and(|value| is_response_only_shape(&value))
 }
 
 impl TransportBatchEntry {
@@ -119,6 +130,7 @@ impl TransportBatchEntry {
         Self::Malformed { raw, error }
     }
 
+    #[cfg(test)]
     fn as_result(&self) -> Result<&RawJsonRpcMessage, &crate::Error> {
         match self {
             Self::Message(message) => Ok(message),
@@ -126,6 +138,7 @@ impl TransportBatchEntry {
         }
     }
 
+    #[cfg(any(feature = "unstable_protocol_v2", test))]
     fn into_result(self) -> Result<RawJsonRpcMessage, crate::Error> {
         match self {
             Self::Message(message) => Ok(message),
@@ -182,6 +195,11 @@ impl TransportBatch {
         std::iter::once(&mut self.first).chain(&mut self.rest)
     }
 
+    /// Consume this batch and iterate over its entries in source order.
+    pub fn into_entries(self) -> impl Iterator<Item = TransportBatchEntry> {
+        std::iter::once(self.first).chain(self.rest)
+    }
+
     /// Return the number of entries in this non-empty batch.
     #[must_use]
     pub fn len(&self) -> usize {
@@ -197,27 +215,18 @@ impl TransportBatch {
         false
     }
 
-    #[cfg(any(feature = "unstable_protocol_v2", test))]
+    #[cfg(test)]
     pub(crate) fn iter_results(
         &self,
     ) -> impl Iterator<Item = Result<&RawJsonRpcMessage, &crate::Error>> {
         self.entries().map(TransportBatchEntry::as_result)
     }
 
+    #[cfg(any(feature = "unstable_protocol_v2", test))]
     pub(crate) fn into_results(
         self,
     ) -> impl Iterator<Item = Result<RawJsonRpcMessage, crate::Error>> {
-        std::iter::once(self.first)
-            .chain(self.rest)
-            .map(TransportBatchEntry::into_result)
-    }
-
-    #[cfg(feature = "unstable_protocol_v2")]
-    pub(crate) fn first_result_mut(&mut self) -> Result<&mut RawJsonRpcMessage, crate::Error> {
-        match &mut self.first {
-            TransportBatchEntry::Message(message) => Ok(message),
-            TransportBatchEntry::Malformed { error, .. } => Err(error.clone()),
-        }
+        self.into_entries().map(TransportBatchEntry::into_result)
     }
 
     fn messages(&self) -> impl Iterator<Item = &RawJsonRpcMessage> {
@@ -523,17 +532,20 @@ fn params_from_transport(params: Option<RawJsonRpcParams>) -> serde_json::Value 
 ///
 /// # Implementing Custom Handlers
 ///
-/// For advanced use cases, you can implement `HandleMessageAs` directly:
+/// For advanced use cases, you can implement [`HandleDispatchFrom`] directly:
 ///
-/// ```ignore
+/// ```no_run
+/// use agent_client_protocol::{
+///     Client, ConnectionTo, Dispatch, Error, HandleDispatchFrom, Handled,
+/// };
+///
 /// struct MyHandler;
 ///
-/// impl HandleMessageAs<Agent> for MyHandler {
-///
-///     async fn handle_dispatch(
+/// impl HandleDispatchFrom<Client> for MyHandler {
+///     async fn handle_dispatch_from(
 ///         &mut self,
 ///         message: Dispatch,
-///         cx: ConnectionTo<Self::Role>,
+///         _connection: ConnectionTo<Client>,
 ///     ) -> Result<Handled<Dispatch>, Error> {
 ///         if message.method() == "my/custom/method" {
 ///             // Handle it
@@ -581,9 +593,10 @@ fn params_from_transport(params: Option<RawJsonRpcParams>) -> serde_json::Value 
 /// Handlers are registered with a [`Builder`] and are called in order until
 /// one claims the message.
 ///
-/// The type parameter `R` is the role this handler plays - who I am.
-/// For an agent handler, `R = Agent` (I handle messages as an agent).
-/// For a client handler, `R = Client` (I handle messages as a client).
+/// The type parameter is the counterpart role that messages arrive from and
+/// that the supplied [`ConnectionTo`] addresses. An agent handler therefore
+/// implements `HandleDispatchFrom<Client>`, while a client handler implements
+/// `HandleDispatchFrom<Agent>`.
 pub trait HandleDispatchFrom<Counterpart: Role>: Send {
     /// Attempt to claim an incoming dispatch (request, notification, or response).
     ///
@@ -602,8 +615,9 @@ pub trait HandleDispatchFrom<Counterpart: Role>: Send {
     ///
     /// * `Ok(Handled::Yes)` if the message was claimed. It will not be propagated further.
     /// * `Ok(Handled::No(message))` if not; the (possibly changed) message will be passed to the remaining handlers.
-    /// * `Err` if processing fails. Requests receive an Error Response; notification
-    ///   and response errors are logged without a wire reply.
+    /// * `Err` if processing fails. Requests receive an Error Response, response
+    ///   errors are routed to the local request awaiter, and notification errors
+    ///   are logged without a wire reply.
     fn handle_dispatch_from(
         &mut self,
         message: Dispatch,
@@ -1252,9 +1266,10 @@ impl<
 
     /// Register a handler for JSON-RPC requests of type `Req`.
     ///
-    /// Your handler receives two arguments:
+    /// Your handler receives three arguments:
     /// 1. The request (type `Req`)
-    /// 2. A [`Responder<R, Req::Response>`] for sending the response
+    /// 2. A [`Responder<Req::Response>`] for sending the response
+    /// 3. A [`ConnectionTo`] for the peer that sent the request
     ///
     /// The request context allows you to:
     /// - Send the response with [`Responder::respond`]
@@ -1263,23 +1278,21 @@ impl<
     ///
     /// # Example
     ///
-    /// ```ignore
-    /// # use agent_client_protocol::UntypedRole;
-    /// # use agent_client_protocol::{Builder};
+    /// ```no_run
+    /// # use agent_client_protocol::{Agent, ConnectTo};
     /// # use agent_client_protocol::schema::v1::{PromptRequest, PromptResponse, SessionNotification};
-    /// # fn example<R: agent_client_protocol::Role>(connection: Builder<R, impl agent_client_protocol::HandleMessageAs<R>>) {
-    /// connection.on_receive_request(async |request: PromptRequest, responder, cx| {
+    /// # async fn example(transport: impl ConnectTo<Agent>) -> Result<(), agent_client_protocol::Error> {
+    /// Agent.builder().on_receive_request(async |request: PromptRequest, responder, cx| {
     ///     // Send a notification while processing
     ///     let notif: SessionNotification = todo!();
     ///     cx.send_notification(notif)?;
     ///
-    ///     // Do some work...
-    ///     let result = todo!("process the prompt");
-    ///
     ///     // Send the response
     ///     let response: PromptResponse = todo!();
     ///     responder.respond(response)
-    /// }, agent_client_protocol::on_receive_request!());
+    /// }, agent_client_protocol::on_receive_request!())
+    /// .connect_to(transport)
+    /// .await
     /// # }
     /// ```
     ///
@@ -1562,14 +1575,15 @@ impl<
     /// - An error occurs
     ///
     /// Handler errors are normally contained: requests receive an Error Response,
-    /// while notification and response errors are logged without a wire reply.
+    /// response-handler errors are routed to the pending local request, and
+    /// notification errors are logged without a wire reply.
     ///
     /// On clean EOF, messages already accepted by the outgoing queue—including
     /// handler responses and close-callback notifications—are drained through
     /// the transport sink before this returns `Ok(())`.
     ///
-    /// The transport is responsible for serializing and deserializing [`RawJsonRpcMessage`]
-    /// values to/from the underlying I/O mechanism (byte streams, channels, etc.).
+    /// The transport boundary carries [`TransportFrame`] values. Physical stream adapters
+    /// serialize and deserialize frames, while channel-based components relay them directly.
     ///
     /// Use this mode when you only need to respond to incoming messages and don't need
     /// to initiate your own requests. If you need to send requests to the other side,
@@ -1802,12 +1816,6 @@ where
 {
     async fn connect_to(self, client: impl ConnectTo<R>) -> Result<(), crate::Error> {
         Builder::connect_to(self, client).await
-    }
-
-    fn into_channel_and_future(self) -> (Channel, BoxFuture<'static, Result<(), crate::Error>>) {
-        let (channel_for_caller, channel_for_builder) = Channel::duplex();
-        let future = Box::pin(Builder::connect_to(self, channel_for_builder));
-        (channel_for_caller, future)
     }
 }
 
@@ -2391,6 +2399,8 @@ impl ResponseDestination {
         let state = Arc::new(Mutex::new(BatchResponseState {
             remaining: slot_count,
             responses: (0..slot_count).map(|_| None).collect(),
+            abandoned: (0..slot_count).map(|_| None).collect(),
+            active_handler_attempts: (0..slot_count).map(|_| 0).collect(),
             dispatch_complete: false,
             emitted: false,
         }));
@@ -2413,6 +2423,38 @@ impl ResponseDestination {
         match self {
             Self::Individual => Some(TransportFrame::Single(response)),
             Self::Batch(slot) => slot.complete(response).map(batch_response_frame),
+        }
+    }
+
+    fn abandon(self, fallback: RawJsonRpcMessage) -> Option<TransportFrame> {
+        match self {
+            Self::Individual => None,
+            Self::Batch(slot) => slot.abandon(fallback).map(batch_response_frame),
+        }
+    }
+
+    fn is_batch(&self) -> bool {
+        matches!(self, Self::Batch(_))
+    }
+
+    fn begin_handler_attempt(
+        &self,
+        message_tx: OutgoingMessageTx,
+    ) -> Option<ResponderHandlerAttempt> {
+        let Self::Batch(slot) = self else {
+            return None;
+        };
+        slot.begin_handler_attempt();
+        Some(ResponderHandlerAttempt {
+            message_tx,
+            destination: self.clone(),
+        })
+    }
+
+    fn finish_handler_attempt(self) -> Option<TransportFrame> {
+        match self {
+            Self::Individual => None,
+            Self::Batch(slot) => slot.finish_handler_attempt().map(batch_response_frame),
         }
     }
 }
@@ -2448,7 +2490,20 @@ impl BatchDispatchCompletion {
             return None;
         }
         state.dispatch_complete = true;
+        for index in 0..state.responses.len() {
+            promote_abandoned_response(&mut state, index);
+        }
         take_completed_batch(&mut state).map(batch_response_frame)
+    }
+}
+
+fn promote_abandoned_response(state: &mut BatchResponseState, index: usize) {
+    if state.active_handler_attempts[index] == 0
+        && state.responses[index].is_none()
+        && let Some(fallback) = state.abandoned[index].take()
+    {
+        state.responses[index] = Some(fallback);
+        state.remaining -= 1;
     }
 }
 
@@ -2487,6 +2542,28 @@ impl std::fmt::Debug for BatchResponseSlot {
 }
 
 impl BatchResponseSlot {
+    fn begin_handler_attempt(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("batch response accumulator mutex poisoned");
+        state.active_handler_attempts[self.index] += 1;
+    }
+
+    fn finish_handler_attempt(self) -> Option<Vec<RawJsonRpcMessage>> {
+        let mut state = self
+            .state
+            .lock()
+            .expect("batch response accumulator mutex poisoned");
+        state.active_handler_attempts[self.index] = state.active_handler_attempts[self.index]
+            .checked_sub(1)
+            .expect("handler attempt completion without a matching start");
+        if state.dispatch_complete {
+            promote_abandoned_response(&mut state, self.index);
+        }
+        take_completed_batch(&mut state)
+    }
+
     fn complete(self, response: RawJsonRpcMessage) -> Option<Vec<RawJsonRpcMessage>> {
         let mut state = self
             .state
@@ -2499,11 +2576,11 @@ impl BatchResponseSlot {
             );
             return None;
         }
-        let Some(slot) = state.responses.get_mut(self.index) else {
+        if self.index >= state.responses.len() {
             tracing::error!(index = self.index, "Invalid JSON-RPC batch response slot");
             return None;
-        };
-        if slot.is_some() {
+        }
+        if state.responses[self.index].is_some() {
             tracing::warn!(
                 index = self.index,
                 "Ignoring duplicate completion of JSON-RPC batch response slot"
@@ -2511,8 +2588,34 @@ impl BatchResponseSlot {
             return None;
         }
 
-        *slot = Some(response);
+        state.abandoned[self.index] = None;
+        state.responses[self.index] = Some(response);
         state.remaining -= 1;
+        take_completed_batch(&mut state)
+    }
+
+    fn abandon(self, fallback: RawJsonRpcMessage) -> Option<Vec<RawJsonRpcMessage>> {
+        let mut state = self
+            .state
+            .lock()
+            .expect("batch response accumulator mutex poisoned");
+        if state.emitted || state.responses[self.index].is_some() {
+            return None;
+        }
+        if state.abandoned[self.index].is_some() {
+            tracing::warn!(
+                index = self.index,
+                "Ignoring duplicate abandonment of JSON-RPC batch response slot"
+            );
+            return None;
+        }
+
+        if state.dispatch_complete && state.active_handler_attempts[self.index] == 0 {
+            state.responses[self.index] = Some(fallback);
+            state.remaining -= 1;
+        } else {
+            state.abandoned[self.index] = Some(fallback);
+        }
         take_completed_batch(&mut state)
     }
 }
@@ -2520,6 +2623,8 @@ impl BatchResponseSlot {
 struct BatchResponseState {
     remaining: usize,
     responses: Vec<Option<RawJsonRpcMessage>>,
+    abandoned: Vec<Option<RawJsonRpcMessage>>,
+    active_handler_attempts: Vec<usize>,
     dispatch_complete: bool,
     emitted: bool,
 }
@@ -2531,6 +2636,80 @@ struct RequestReplyTarget {
     destination: ResponseDestination,
 }
 
+struct ResponderHandlerAttempt {
+    message_tx: OutgoingMessageTx,
+    destination: ResponseDestination,
+}
+
+impl Drop for ResponderHandlerAttempt {
+    fn drop(&mut self) {
+        if let Err(error) = send_raw_message(
+            &self.message_tx,
+            OutgoingMessage::BatchHandlerAttemptComplete {
+                destination: self.destination.clone(),
+            },
+        ) {
+            tracing::debug!(?error, "could not complete JSON-RPC batch handler attempt");
+        }
+    }
+}
+
+#[derive(Clone)]
+struct ResponseReplyTarget {
+    id: RequestId,
+    method: String,
+    sender: Arc<Mutex<Option<oneshot::Sender<ResponsePayload>>>>,
+}
+
+impl ResponseReplyTarget {
+    fn route(self, result: Result<serde_json::Value, crate::Error>) {
+        let sender = self
+            .sender
+            .lock()
+            .expect("response reply mutex poisoned")
+            .take();
+        let Some(sender) = sender else {
+            tracing::debug!(
+                method = %self.method,
+                id = ?self.id,
+                "response was already routed to its local awaiter"
+            );
+            return;
+        };
+
+        if sender
+            .send(ResponsePayload {
+                result,
+                ack_tx: None,
+            })
+            .is_err()
+        {
+            tracing::debug!(
+                method = %self.method,
+                id = ?self.id,
+                "dropped response because local receiver was gone"
+            );
+        }
+    }
+}
+
+enum HandlerErrorTarget {
+    Request(RequestReplyTarget),
+    Response(ResponseReplyTarget),
+}
+
+impl HandlerErrorTarget {
+    fn begin_handler_attempt(
+        &self,
+        message_tx: &OutgoingMessageTx,
+    ) -> Option<ResponderHandlerAttempt> {
+        match self {
+            Self::Request(target) => target.destination.begin_handler_attempt(message_tx.clone()),
+            Self::Response(_) => None,
+        }
+    }
+}
+
 #[derive(Debug)]
 enum OutgoingMessage {
     /// Close the outgoing application queue and acknowledge after every
@@ -2540,6 +2719,19 @@ enum OutgoingMessage {
     /// Mark every entry in an incoming batch as dispatched. A completed
     /// response array may only be emitted after this barrier.
     BatchDispatchComplete { completion: BatchDispatchCompletion },
+
+    /// Finish arbitration for a handler attempt that may have dropped a batch
+    /// responder immediately before returning an error.
+    BatchHandlerAttemptComplete { destination: ResponseDestination },
+
+    /// Record that a claimed batch request dropped its responder without
+    /// replying. The fallback remains provisional while its handler attempt is
+    /// active so a handler error can supply the authoritative response.
+    AbandonedBatchResponse {
+        id: RequestId,
+        method: String,
+        destination: ResponseDestination,
+    },
 
     /// Send a request to the server.
     Request {
@@ -3303,9 +3495,8 @@ impl<Counterpart: Role> ConnectionTo<Counterpart> {
     /// Register a dynamic message handler, used to intercept messages specific to a particular session
     /// or some similar modal thing.
     ///
-    /// Dynamic message handlers are called first for every incoming message.
-    ///
-    /// If they decline to handle the message, then the message is passed to the regular registered handlers.
+    /// Dynamic message handlers run after the handlers registered on [`Builder`] and before the
+    /// role's default handler. They receive messages that the builder handlers decline.
     ///
     /// The handler will stay registered until the returned registration guard is dropped.
     pub fn add_dynamic_handler(
@@ -3411,6 +3602,13 @@ impl<R: Role> Drop for DynamicHandlerGuard<R> {
 ///
 /// See the [Event Loop and Concurrency](Builder#event-loop-and-concurrency)
 /// section for more details.
+///
+/// # Drop behavior
+///
+/// Dropping a responder for a request that arrived in a batch completes that
+/// slot with an Internal Error, so one abandoned request cannot withhold valid
+/// sibling responses forever. A responder for an individual request retains
+/// the historical behavior: dropping it does not automatically send a reply.
 #[must_use]
 pub struct Responder<T: JsonRpcResponse = serde_json::Value> {
     /// The method of the request.
@@ -3430,6 +3628,47 @@ pub struct Responder<T: JsonRpcResponse = serde_json::Value> {
     /// For incoming requests: serializes to JSON and sends over the wire.
     /// For incoming responses: sends to the waiting oneshot channel.
     send_fn: Box<dyn FnOnce(Result<T, crate::Error>) -> Result<(), crate::Error> + Send>,
+
+    /// Completes an abandoned batch slot unless an explicit response disarms it.
+    drop_guard: ResponderDropGuard,
+}
+
+struct ResponderDropGuard {
+    message_tx: OutgoingMessageTx,
+    id: RequestId,
+    method: String,
+    destination: ResponseDestination,
+    armed: bool,
+}
+
+impl ResponderDropGuard {
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ResponderDropGuard {
+    fn drop(&mut self) {
+        if !self.armed || !self.destination.is_batch() {
+            return;
+        }
+
+        if let Err(error) = send_raw_message(
+            &self.message_tx,
+            OutgoingMessage::AbandonedBatchResponse {
+                id: self.id.clone(),
+                method: self.method.clone(),
+                destination: self.destination.clone(),
+            },
+        ) {
+            tracing::debug!(
+                id = ?self.id,
+                method = %self.method,
+                ?error,
+                "could not complete abandoned JSON-RPC batch response slot"
+            );
+        }
+    }
 }
 
 impl<T: JsonRpcResponse> std::fmt::Debug for Responder<T> {
@@ -3457,6 +3696,13 @@ impl Responder<serde_json::Value> {
         let method_clone = method.clone();
         let cancellation = cancellation_registry.register(&id);
         let send_destination = destination.clone();
+        let drop_guard = ResponderDropGuard {
+            message_tx: message_tx.clone(),
+            id: id.clone(),
+            method: method.clone(),
+            destination: destination.clone(),
+            armed: true,
+        };
         Self {
             method,
             id,
@@ -3473,6 +3719,7 @@ impl Responder<serde_json::Value> {
                     },
                 )
             }),
+            drop_guard,
         }
     }
 
@@ -3521,13 +3768,15 @@ impl<T: JsonRpcResponse> Responder<T> {
     }
 
     /// Return a new Responder with a different method name.
-    pub fn wrap_method(self, method: String) -> Responder<T> {
+    pub fn wrap_method(mut self, method: String) -> Responder<T> {
+        self.drop_guard.method.clone_from(&method);
         Responder {
             method,
             id: self.id,
             cancellation: self.cancellation,
             destination: self.destination,
             send_fn: self.send_fn,
+            drop_guard: self.drop_guard,
         }
     }
 
@@ -3549,15 +3798,17 @@ impl<T: JsonRpcResponse> Responder<T> {
                 let t_value = wrap_fn(&method, input);
                 (self.send_fn)(t_value)
             }),
+            drop_guard: self.drop_guard,
         }
     }
 
     /// Respond to the JSON-RPC request with either a value (`Ok`) or an error (`Err`).
     pub fn respond_with_result(
-        self,
+        mut self,
         response: Result<T, crate::Error>,
     ) -> Result<(), crate::Error> {
         tracing::debug!(id = ?self.id, "respond called");
+        self.drop_guard.disarm();
         (self.send_fn)(response)
     }
 
@@ -3617,6 +3868,9 @@ pub struct ResponseRouter<T: JsonRpcResponse = serde_json::Value> {
 
     /// Function to send the response to the waiting task.
     send_fn: Box<dyn FnOnce(Result<T, crate::Error>) -> Result<(), crate::Error> + Send>,
+
+    /// Shared route used to deliver a dispatch-handler error to the same waiter.
+    reply_target: ResponseReplyTarget,
 }
 
 impl<T: JsonRpcResponse> std::fmt::Debug for ResponseRouter<T> {
@@ -3642,8 +3896,12 @@ impl ResponseRouter<serde_json::Value> {
         sender: oneshot::Sender<ResponsePayload>,
         cancellation_disarm: SentRequestCancellationDisarm,
     ) -> Self {
-        let response_method = method.clone();
-        let response_id = id.clone();
+        let reply_target = ResponseReplyTarget {
+            id: id.clone(),
+            method: method.clone(),
+            sender: Arc::new(Mutex::new(Some(sender))),
+        };
+        let send_target = reply_target.clone();
         // A response for the request reached this router, so the request is
         // settled from the peer's perspective and a `$/cancel_request` could
         // only ever be redundant. Disarm immediately so handlers may retain
@@ -3654,21 +3912,10 @@ impl ResponseRouter<serde_json::Value> {
             id,
             role_id,
             send_fn: Box::new(move |response: Result<serde_json::Value, crate::Error>| {
-                if sender
-                    .send(ResponsePayload {
-                        result: response,
-                        ack_tx: None,
-                    })
-                    .is_err()
-                {
-                    tracing::debug!(
-                        method = %response_method,
-                        id = ?response_id,
-                        "dropped response because local receiver was gone"
-                    );
-                }
+                send_target.route(response);
                 Ok(())
             }),
+            reply_target,
         }
     }
 
@@ -3728,6 +3975,7 @@ impl<T: JsonRpcResponse> ResponseRouter<T> {
                 let t_value = wrap_fn(&method, input);
                 (self.send_fn)(t_value)
             }),
+            reply_target: self.reply_target,
         }
     }
 
@@ -3950,10 +4198,15 @@ impl<Req: JsonRpcRequest, Notif: JsonRpcNotification> Dispatch<Req, Notif> {
         }
     }
 
-    fn request_reply_target(&self) -> Option<RequestReplyTarget> {
+    fn handler_error_target(&self) -> Option<HandlerErrorTarget> {
         match self {
-            Dispatch::Request(_, responder) => Some(responder.reply_target()),
-            Dispatch::Notification(_) | Dispatch::Response(_, _) => None,
+            Dispatch::Request(_, responder) => {
+                Some(HandlerErrorTarget::Request(responder.reply_target()))
+            }
+            Dispatch::Notification(_) => None,
+            Dispatch::Response(_, router) => {
+                Some(HandlerErrorTarget::Response(router.reply_target.clone()))
+            }
         }
     }
 

--- a/src/agent-client-protocol/src/jsonrpc/dynamic_handler.rs
+++ b/src/agent-client-protocol/src/jsonrpc/dynamic_handler.rs
@@ -4,9 +4,9 @@ use uuid::Uuid;
 use crate::role::Role;
 use crate::{ConnectionTo, Dispatch, HandleDispatchFrom, Handled};
 
-/// Internal dyn-safe wrapper around `HandleMessageAs`
+/// Internal dyn-safe wrapper around [`HandleDispatchFrom`].
 ///
-/// The type parameter `R` is the role's counterpart (who we connect to).
+/// The type parameter is the role's counterpart (who we connect to).
 pub(crate) trait DynHandleDispatchFrom<Counterpart: Role>: Send {
     fn dyn_handle_dispatch_from(
         &mut self,

--- a/src/agent-client-protocol/src/jsonrpc/incoming_actor.rs
+++ b/src/agent-client-protocol/src/jsonrpc/incoming_actor.rs
@@ -11,6 +11,7 @@ use crate::UntypedMessage;
 use crate::jsonrpc::ConnectionTo;
 use crate::jsonrpc::HandleConnectionClose;
 use crate::jsonrpc::HandleDispatchFrom;
+use crate::jsonrpc::HandlerErrorTarget;
 use crate::jsonrpc::OutgoingMessage;
 use crate::jsonrpc::PendingReplies;
 use crate::jsonrpc::PendingReply;
@@ -20,11 +21,13 @@ use crate::jsonrpc::RequestReplyTarget;
 use crate::jsonrpc::Responder;
 use crate::jsonrpc::ResponseDestination;
 use crate::jsonrpc::ResponseRouter;
+use crate::jsonrpc::TransportBatchEntry;
 use crate::jsonrpc::TransportFrame;
 use crate::jsonrpc::dynamic_handler::DynHandleDispatchFrom;
 use crate::jsonrpc::dynamic_handler::DynamicHandlerMessage;
 use crate::jsonrpc::outgoing_actor::send_raw_message;
 use crate::jsonrpc::protocol_compat::ProtocolCompat;
+use crate::jsonrpc::{is_response_only_shape, raw_is_response_only_shape};
 
 use crate::role::Role;
 use crate::schema::v1::{RequestId, Response};
@@ -110,7 +113,10 @@ pub(super) async fn incoming_protocol_actor<Counterpart: Role>(
                     let mut new_pending_messages = vec![];
                     for pending_message in pending_messages {
                         tracing::trace!(method = pending_message.method(), handler = ?handler.dyn_describe_chain(), "Retrying message");
-                        let reply_target = pending_message.request_reply_target();
+                        let reply_target = pending_message.handler_error_target();
+                        let handler_attempt = reply_target.as_ref().and_then(|target| {
+                            target.begin_handler_attempt(&connection.message_tx)
+                        });
                         let method = pending_message.method().to_string();
                         match handler
                             .dyn_handle_dispatch_from(pending_message, connection.clone())
@@ -131,6 +137,7 @@ pub(super) async fn incoming_protocol_actor<Counterpart: Role>(
                                 handle_handler_error(connection, reply_target, method, err)?;
                             }
                         }
+                        drop(handler_attempt);
                     }
                     pending_messages = new_pending_messages;
 
@@ -178,11 +185,11 @@ pub(super) async fn incoming_protocol_actor<Counterpart: Role>(
                                 Err(error) => {
                                     handle_handler_error(
                                         connection,
-                                        Some(RequestReplyTarget {
+                                        Some(HandlerErrorTarget::Request(RequestReplyTarget {
                                             id: request_id,
                                             method: request_method.clone(),
                                             destination,
-                                        }),
+                                        })),
                                         request_method,
                                         error,
                                     )?;
@@ -297,13 +304,24 @@ fn frame_entries(
                 .then_some(ResponseDestination::Individual);
             return (vec![(Ok(message), destination)], None);
         }
-        TransportFrame::Malformed { error, .. } => {
+        TransportFrame::Malformed { raw, error } => {
+            if raw_is_response_only_shape(&raw) {
+                return (Vec::new(), None);
+            }
             return (
                 vec![(Err(error), Some(ResponseDestination::Individual))],
                 None,
             );
         }
-        TransportFrame::Batch(batch) => batch.into_results().collect(),
+        TransportFrame::Batch(batch) => batch
+            .into_entries()
+            .filter_map(|entry| match entry {
+                TransportBatchEntry::Message(message) => Some(Ok(message)),
+                TransportBatchEntry::Malformed { raw, error } => {
+                    (!is_response_only_shape(&raw)).then_some(Err(error))
+                }
+            })
+            .collect(),
     };
 
     let response_count = entries
@@ -421,7 +439,10 @@ async fn dispatch_dispatch<Counterpart: Role>(
 
     let id = dispatch.id().cloned();
     let method = dispatch.method().to_string();
-    let reply_target = dispatch.request_reply_target();
+    let error_target = dispatch.handler_error_target();
+    let _handler_attempt = error_target
+        .as_ref()
+        .and_then(|target| target.begin_handler_attempt(&connection.message_tx));
 
     match request_cancellations.cancel_if_requested(&dispatch) {
         Ok(true) => {
@@ -435,7 +456,7 @@ async fn dispatch_dispatch<Counterpart: Role>(
                 ?err,
                 "Request cancellation notification errored"
             );
-            return handle_handler_error(connection, reply_target, method, err);
+            return handle_handler_error(connection, error_target, method, err);
         }
     }
 
@@ -458,7 +479,7 @@ async fn dispatch_dispatch<Counterpart: Role>(
 
         Err(err) => {
             tracing::warn!(?method, ?id, ?err, handler = ?handler.describe_chain(), "Handler errored");
-            return handle_handler_error(connection, reply_target, method, err);
+            return handle_handler_error(connection, error_target, method, err);
         }
     }
 
@@ -482,7 +503,7 @@ async fn dispatch_dispatch<Counterpart: Role>(
 
             Err(err) => {
                 tracing::warn!(?method, ?id, ?err, handler = ?dynamic_handler.dyn_describe_chain(), "Dynamic handler errored");
-                return handle_handler_error(connection, reply_target, method, err);
+                return handle_handler_error(connection, error_target, method, err);
             }
         }
     }
@@ -510,7 +531,7 @@ async fn dispatch_dispatch<Counterpart: Role>(
                 handler = "default",
                 "Default handler errored"
             );
-            return handle_handler_error(connection, reply_target, method, err);
+            return handle_handler_error(connection, error_target, method, err);
         }
     }
 
@@ -548,15 +569,16 @@ async fn dispatch_dispatch<Counterpart: Role>(
 /// Handle a message-processing error without tearing down the connection.
 ///
 /// For requests, sends a JSON-RPC error response to the request's exact output
-/// destination. For notifications and incoming responses, logs without replying.
+/// destination. For responses, routes the error to the local request awaiter.
+/// Notification errors are logged without replying.
 fn handle_handler_error<Counterpart: Role>(
     connection: &ConnectionTo<Counterpart>,
-    reply_target: Option<RequestReplyTarget>,
+    target: Option<HandlerErrorTarget>,
     method: String,
     error: crate::Error,
 ) -> Result<(), crate::Error> {
-    if let Some(reply_target) = reply_target {
-        send_raw_message(
+    match target {
+        Some(HandlerErrorTarget::Request(reply_target)) => send_raw_message(
             &connection.message_tx,
             OutgoingMessage::Response {
                 id: reply_target.id,
@@ -564,13 +586,18 @@ fn handle_handler_error<Counterpart: Role>(
                 response: Err(error),
                 destination: reply_target.destination,
             },
-        )
-    } else {
-        tracing::warn!(
-            %method,
-            ?error,
-            "Ignoring message-processing error because there is no request to answer"
-        );
-        Ok(())
+        ),
+        Some(HandlerErrorTarget::Response(reply_target)) => {
+            reply_target.route(Err(error));
+            Ok(())
+        }
+        None => {
+            tracing::warn!(
+                %method,
+                ?error,
+                "Ignoring message-processing error because there is no request to answer"
+            );
+            Ok(())
+        }
     }
 }

--- a/src/agent-client-protocol/src/jsonrpc/outgoing_actor.rs
+++ b/src/agent-client-protocol/src/jsonrpc/outgoing_actor.rs
@@ -52,6 +52,37 @@ pub(super) async fn outgoing_protocol_actor(
                 }
                 continue;
             }
+            OutgoingMessage::BatchHandlerAttemptComplete { destination } => {
+                if let Some(frame) = destination.finish_handler_attempt() {
+                    transport_tx
+                        .unbounded_send(frame)
+                        .map_err(crate::Error::into_internal_error)?;
+                }
+                continue;
+            }
+            OutgoingMessage::AbandonedBatchResponse {
+                id,
+                method,
+                destination,
+            } => {
+                tracing::warn!(
+                    ?id,
+                    %method,
+                    "Completing abandoned JSON-RPC batch request with Internal Error"
+                );
+                let fallback = RawJsonRpcMessage::response(
+                    id,
+                    Err(crate::Error::internal_error().data(format!(
+                        "request handler dropped its responder for `{method}`"
+                    ))),
+                );
+                if let Some(frame) = destination.abandon(fallback) {
+                    transport_tx
+                        .unbounded_send(frame)
+                        .map_err(crate::Error::into_internal_error)?;
+                }
+                continue;
+            }
             OutgoingMessage::Request {
                 id,
                 method,

--- a/src/agent-client-protocol/src/jsonrpc/transport_actor.rs
+++ b/src/agent-client-protocol/src/jsonrpc/transport_actor.rs
@@ -8,19 +8,9 @@ use futures::channel::mpsc;
 use serde::Deserialize as _;
 
 enum ParsedIncomingLine {
-    Ignored,
     Single(RawJsonRpcMessage),
     Malformed { raw: String, error: crate::Error },
     Batch(TransportBatch),
-}
-
-fn message_shape(value: &serde_json::Value) -> (bool, bool) {
-    value.as_object().map_or((false, false), |object| {
-        (
-            object.contains_key("method"),
-            object.contains_key("result") || object.contains_key("error"),
-        )
-    })
 }
 
 fn parse_incoming_line(line: &str) -> ParsedIncomingLine {
@@ -41,85 +31,49 @@ fn parse_incoming_line(line: &str) -> ParsedIncomingLine {
             error: crate::Error::invalid_request(),
         },
         serde_json::Value::Array(entries) => {
-            let mut has_response_entry = false;
-            let mut has_call_entry = false;
-            let mut entries = entries
+            let entries = entries
                 .into_iter()
-                .filter_map(|entry| {
-                    let (looks_like_call, looks_like_response) = message_shape(&entry);
-                    match RawJsonRpcMessage::deserialize(&entry) {
-                        Ok(message) => {
-                            match &message {
-                                RawJsonRpcMessage::Request(_)
-                                | RawJsonRpcMessage::Notification(_) => has_call_entry = true,
-                                RawJsonRpcMessage::Response(_) => has_response_entry = true,
-                            }
-                            Some(TransportBatchEntry::message(message))
-                        }
-                        Err(error) => {
-                            has_call_entry |= looks_like_call;
-                            has_response_entry |= looks_like_response;
-                            tracing::debug!(?error, "Invalid JSON-RPC batch entry");
-
-                            // A malformed response must not itself receive a
-                            // response, even when request siblings make this a
-                            // mixed batch. Keep ambiguous call-shaped entries
-                            // so invalid requests still receive an error.
-                            (!looks_like_response || looks_like_call).then(|| {
-                                TransportBatchEntry::malformed(
-                                    entry,
-                                    crate::Error::invalid_request(),
-                                )
-                            })
-                        }
+                .map(|entry| match RawJsonRpcMessage::deserialize(&entry) {
+                    Ok(message) => TransportBatchEntry::message(message),
+                    Err(error) => {
+                        tracing::debug!(?error, "Invalid JSON-RPC batch entry");
+                        TransportBatchEntry::malformed(entry, crate::Error::invalid_request())
                     }
                 })
                 .collect::<Vec<_>>();
 
-            if has_response_entry && !has_call_entry {
-                // A response batch is not a request and must not itself receive
-                // responses. Ignore malformed response-like siblings to avoid
-                // sending error responses back and forth between peers.
-                entries.retain(|entry| entry.as_result().is_ok());
-            }
-            match TransportBatch::from_entries(entries) {
-                Some(batch) => ParsedIncomingLine::Batch(batch),
-                None => ParsedIncomingLine::Ignored,
-            }
+            ParsedIncomingLine::Batch(
+                TransportBatch::from_entries(entries)
+                    .expect("a parsed non-empty JSON array retains at least one entry"),
+            )
         }
-        value => {
-            let (looks_like_call, looks_like_response) = message_shape(&value);
-            match serde_json::from_value(value) {
-                Ok(message) => ParsedIncomingLine::Single(message),
-                Err(error) => {
-                    tracing::debug!(?error, "Invalid JSON-RPC message");
-                    if looks_like_response && !looks_like_call {
-                        ParsedIncomingLine::Ignored
-                    } else {
-                        ParsedIncomingLine::Malformed {
-                            raw: line.to_owned(),
-                            error: crate::Error::invalid_request(),
-                        }
-                    }
+        value => match serde_json::from_value(value) {
+            Ok(message) => ParsedIncomingLine::Single(message),
+            Err(error) => {
+                tracing::debug!(?error, "Invalid JSON-RPC message");
+                ParsedIncomingLine::Malformed {
+                    raw: line.to_owned(),
+                    error: crate::Error::invalid_request(),
                 }
             }
-        }
+        },
     }
 }
 
 impl TransportFrame {
     /// Parse one JSON-RPC wire value while preserving batch boundaries.
     ///
-    /// Malformed calls are returned as explicit malformed frames or batch
-    /// entries. Malformed response-shaped input is ignored, yielding `None`,
-    /// because JSON-RPC responses must not themselves receive responses.
+    /// Every malformed value is retained as an explicit malformed frame or
+    /// batch entry. Standalone malformed input keeps its original text; batch
+    /// entries keep their parsed JSON values, source order, and batch boundary,
+    /// though reserialization may normalize whitespace. Protocol actors decide
+    /// whether a malformed value is call-shaped and requires an Error Response.
     #[must_use]
-    pub fn parse_json(input: &str) -> Option<Self> {
+    pub fn parse_json(input: &str) -> Self {
         match parse_incoming_line(input) {
-            ParsedIncomingLine::Ignored => None,
-            ParsedIncomingLine::Single(message) => Some(Self::Single(message)),
-            ParsedIncomingLine::Malformed { raw, error } => Some(Self::Malformed { raw, error }),
-            ParsedIncomingLine::Batch(batch) => Some(Self::Batch(batch)),
+            ParsedIncomingLine::Single(message) => Self::Single(message),
+            ParsedIncomingLine::Malformed { raw, error } => Self::Malformed { raw, error },
+            ParsedIncomingLine::Batch(batch) => Self::Batch(batch),
         }
     }
 
@@ -142,14 +96,15 @@ impl TransportFrame {
     }
 }
 
-/// Transport outgoing actor for line streams: Serializes RawJsonRpcMessage and yields lines.
+/// Transport outgoing actor for line streams: serializes [`TransportFrame`] values and yields
+/// lines.
 ///
 /// This is a line-based variant of `transport_outgoing_actor` that works with a Sink<String>
 /// instead of an AsyncWrite byte stream. This enables interception of lines before they are
 /// written to the underlying transport.
 ///
 /// This actor handles transport mechanics:
-/// - Serializes RawJsonRpcMessage to JSON strings
+/// - Serializes single messages, malformed values, and batches to JSON strings
 /// - Yields newline-terminated strings
 /// - Handles serialization errors
 ///
@@ -253,7 +208,7 @@ pub(super) async fn transport_outgoing_lines_actor(
     transport_outgoing_frames_actor(transport_rx, outgoing_lines).await
 }
 
-/// Transport incoming actor for line streams: Parses lines into RawJsonRpcMessage values.
+/// Transport incoming actor for line streams: parses lines into [`TransportFrame`] values.
 ///
 /// This is a line-based variant of `transport_incoming_actor` that works with a
 /// Stream<Item = io::Result<String>> instead of an AsyncRead byte stream. This enables
@@ -275,7 +230,6 @@ pub(super) async fn transport_incoming_lines_actor(
         tracing::trace!(message = %line, "Received JSON-RPC message");
 
         match parse_incoming_line(&line) {
-            ParsedIncomingLine::Ignored => {}
             ParsedIncomingLine::Single(message) => {
                 transport_tx
                     .unbounded_send(TransportFrame::Single(message))
@@ -323,7 +277,7 @@ mod tests {
     }
 
     #[test]
-    fn ignores_invalid_members_of_response_batches() {
+    fn preserves_every_invalid_member_of_response_batches() {
         let ParsedIncomingLine::Batch(batch) = parse_incoming_line(
             r#"[
                 {"jsonrpc":"2.0","id":1,"result":{"ok":true}},
@@ -335,24 +289,44 @@ mod tests {
             panic!("expected a JSON-RPC batch");
         };
 
-        assert_eq!(batch.len(), 2);
-        assert!(
-            batch
-                .iter_results()
-                .all(|entry| matches!(entry, Ok(RawJsonRpcMessage::Response(_))))
-        );
+        let entries = batch.iter_results().collect::<Vec<_>>();
+        assert_eq!(entries.len(), 4);
+        assert!(matches!(entries[0], Ok(RawJsonRpcMessage::Response(_))));
+        assert_eq!(entries[1].unwrap_err().code, ErrorCode::InvalidRequest);
+        assert_eq!(entries[2].unwrap_err().code, ErrorCode::InvalidRequest);
+        assert!(matches!(entries[3], Ok(RawJsonRpcMessage::Response(_))));
     }
 
     #[test]
-    fn ignores_entirely_malformed_response_shaped_batch() {
-        assert!(matches!(
-            parse_incoming_line(
-                r#"[
+    fn preserves_invalid_value_beside_malformed_response() {
+        let ParsedIncomingLine::Batch(batch) = parse_incoming_line(
+            r#"[
+                17,
                 {"jsonrpc":"2.0","id":1,"result":null,"error":{"code":-32603,"message":"Internal error"}}
-            ]"#
-            ),
-            ParsedIncomingLine::Ignored
-        ));
+            ]"#,
+        ) else {
+            panic!("expected a JSON-RPC batch");
+        };
+
+        let entries = batch.iter_results().collect::<Vec<_>>();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].unwrap_err().code, ErrorCode::InvalidRequest);
+        assert_eq!(entries[1].unwrap_err().code, ErrorCode::InvalidRequest);
+    }
+
+    #[test]
+    fn preserves_entirely_malformed_response_shaped_batch() {
+        let ParsedIncomingLine::Batch(batch) = parse_incoming_line(
+            r#"[
+                {"jsonrpc":"2.0","id":1,"result":null,"error":{"code":-32603,"message":"Internal error"}}
+            ]"#,
+        ) else {
+            panic!("expected a retained JSON-RPC batch");
+        };
+
+        let entries = batch.iter_results().collect::<Vec<_>>();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].unwrap_err().code, ErrorCode::InvalidRequest);
     }
 
     #[test]
@@ -373,7 +347,7 @@ mod tests {
     }
 
     #[test]
-    fn ignores_malformed_response_shaped_member_beside_request() {
+    fn preserves_malformed_response_shaped_member_beside_request() {
         let ParsedIncomingLine::Batch(batch) = parse_incoming_line(
             r#"[
                 {"jsonrpc":"2.0","id":1,"method":"one","params":{}},
@@ -384,18 +358,20 @@ mod tests {
         };
 
         let entries = batch.iter_results().collect::<Vec<_>>();
-        assert_eq!(entries.len(), 1);
+        assert_eq!(entries.len(), 2);
         assert!(matches!(entries[0], Ok(RawJsonRpcMessage::Request(_))));
+        assert_eq!(entries[1].unwrap_err().code, ErrorCode::InvalidRequest);
     }
 
     #[test]
-    fn ignores_malformed_standalone_response() {
-        assert!(matches!(
-            parse_incoming_line(
-                r#"{"jsonrpc":"2.0","id":1,"result":null,"error":{"code":-32603,"message":"Internal error"}}"#
-            ),
-            ParsedIncomingLine::Ignored
-        ));
+    fn preserves_malformed_standalone_response() {
+        let ParsedIncomingLine::Malformed { error, .. } = parse_incoming_line(
+            r#"{"jsonrpc":"2.0","id":1,"result":null,"error":{"code":-32603,"message":"Internal error"}}"#,
+        ) else {
+            panic!("expected one retained invalid response");
+        };
+
+        assert_eq!(error.code, ErrorCode::InvalidRequest);
     }
 
     #[test]

--- a/src/agent-client-protocol/src/mcp_server/tool_fn.rs
+++ b/src/agent-client-protocol/src/mcp_server/tool_fn.rs
@@ -18,7 +18,7 @@ struct ToolCall<P, R, MyRole: Role> {
     result_tx: futures::channel::oneshot::Sender<Result<R, Error>>,
 }
 
-struct ToolFnMutResponder<F, P, R, Counterpart: Role> {
+struct ToolFnMutRunner<F, P, R, Counterpart: Role> {
     func: F,
     call_rx: mpsc::Receiver<ToolCall<P, R, Counterpart>>,
     tool_future_fn: Box<
@@ -32,7 +32,7 @@ struct ToolFnMutResponder<F, P, R, Counterpart: Role> {
 }
 
 impl<F, P, R, Counterpart, Counterpart1> RunWithConnectionTo<Counterpart1>
-    for ToolFnMutResponder<F, P, R, Counterpart>
+    for ToolFnMutRunner<F, P, R, Counterpart>
 where
     Counterpart: Role,
     Counterpart1: Role,
@@ -44,7 +44,7 @@ where
         self,
         _connection: ConnectionTo<Counterpart1>,
     ) -> Result<(), Error> {
-        let ToolFnMutResponder {
+        let ToolFnMutRunner {
             mut func,
             mut call_rx,
             tool_future_fn,
@@ -64,7 +64,7 @@ where
     }
 }
 
-struct ToolFnResponder<F, P, R, Counterpart: Role> {
+struct ToolFnRunner<F, P, R, Counterpart: Role> {
     func: F,
     call_rx: mpsc::Receiver<ToolCall<P, R, Counterpart>>,
     tool_future_fn: Box<
@@ -75,7 +75,7 @@ struct ToolFnResponder<F, P, R, Counterpart: Role> {
 }
 
 impl<F, P, R, Counterpart, Counterpart1> RunWithConnectionTo<Counterpart1>
-    for ToolFnResponder<F, P, R, Counterpart>
+    for ToolFnRunner<F, P, R, Counterpart>
 where
     Counterpart: Role,
     Counterpart1: Role,
@@ -87,7 +87,7 @@ where
         self,
         _connection: ConnectionTo<Counterpart1>,
     ) -> Result<(), Error> {
-        let ToolFnResponder {
+        let ToolFnRunner {
             func,
             call_rx,
             tool_future_fn,
@@ -177,7 +177,7 @@ where
     }
 }
 
-/// Create a "single-threaded" function-backed MCP tool and its responder.
+/// Create a "single-threaded" function-backed MCP tool and its runner.
 ///
 /// Only one invocation of the tool can be running at a time.
 pub fn tool_fn_mut<P, Ret, F, Counterpart>(
@@ -208,7 +208,7 @@ where
             description: description.to_string(),
             call_tx,
         },
-        ToolFnMutResponder {
+        ToolFnMutRunner {
             func,
             call_rx,
             tool_future_fn: Box::new(tool_future_fn),
@@ -216,7 +216,7 @@ where
     )
 }
 
-/// Create a stateless function-backed MCP tool and its concurrent responder.
+/// Create a stateless function-backed MCP tool and its concurrent runner.
 pub fn tool_fn<P, Ret, F, Counterpart>(
     name: impl ToString,
     description: impl ToString,
@@ -246,7 +246,7 @@ where
             description: description.to_string(),
             call_tx,
         },
-        ToolFnResponder {
+        ToolFnRunner {
             func,
             call_rx,
             tool_future_fn: Box::new(tool_future_fn),

--- a/src/agent-client-protocol/src/role/acp.rs
+++ b/src/agent-client-protocol/src/role/acp.rs
@@ -9,7 +9,10 @@ use serde::{Serialize, de::DeserializeOwned};
 use crate::DynConnectTo;
 use crate::jsonrpc::{Builder, handlers::NullHandler, run::NullRun};
 #[cfg(feature = "unstable_protocol_v2")]
-use crate::jsonrpc::{TransportBatch, TransportFrame};
+use crate::jsonrpc::{
+    TransportBatch, TransportBatchEntry, TransportFrame, is_response_only_shape,
+    raw_is_response_only_shape,
+};
 use crate::role::{HasPeer, RemoteStyle};
 use crate::schema::v1::{InitializeRequest, NewSessionRequest, NewSessionResponse, SessionId};
 #[cfg(feature = "unstable_protocol_v2")]
@@ -202,12 +205,25 @@ impl ClientProtocolConnector {
                             initialize_request_id(&fallback_initialize)
                                 .expect("validated initialize request has an id"),
                         );
+                        // The v2 implementation will never receive its initialize response once
+                        // the matching v1 implementation takes over this connection. Drop its
+                        // future and channels before running the v1 session so any resources it
+                        // owns are released promptly.
+                        drop(client);
                         fallback_client.send(fallback_response)?;
                         return pipe_protocol_peers_until_done(fallback_client, agent_connection)
                             .await;
                     }
 
-                    drop((client, agent_connection, initialize_response));
+                    // Neither probe can continue on the replacement connection. Release both
+                    // client implementations and the original agent connection before starting
+                    // the real v1 session so they cannot retain resources for its lifetime.
+                    drop((
+                        client,
+                        fallback_client,
+                        agent_connection,
+                        initialize_response,
+                    ));
                     return connect_client_protocol(ClientProtocol::V1, v1.create(), agent()).await;
                 }
 
@@ -371,21 +387,28 @@ impl AgentProtocolRouter {
 #[cfg(feature = "unstable_protocol_v2")]
 impl ConnectTo<Client> for AgentProtocolRouter {
     async fn connect_to(self, client: impl ConnectTo<Agent>) -> Result<(), crate::Error> {
-        let client = RunningProtocolPeer::new(client);
-        let Some((mut first_frame, client)) = client.next_frame().await? else {
-            return Ok(());
-        };
         let supported = SupportedAgentProtocols {
             v1: self.v1.is_some(),
             v2: self.v2.is_some(),
         };
-        let selected = match initialize_message_mut(&mut first_frame)
-            .and_then(|message| select_agent_protocol(message, supported))
-        {
-            Ok(selected) => selected,
-            Err(error) => {
-                return reject_initialize(client, &first_frame, error).await;
-            }
+        let mut client = RunningProtocolPeer::new(client);
+        let (first_frame, client, selected) = loop {
+            let Some((mut frame, next_client)) = client.next_frame().await? else {
+                return Ok(());
+            };
+            let message = match initialize_message_mut(&mut frame) {
+                Ok(Some(message)) => message,
+                Ok(None) => {
+                    client = next_client;
+                    continue;
+                }
+                Err(error) => return reject_initialize(next_client, &frame, error).await,
+            };
+            let selected = match select_agent_protocol(message, supported) {
+                Ok(selected) => selected,
+                Err(error) => return reject_initialize(next_client, &frame, error).await,
+            };
+            break (frame, next_client, selected);
         };
         let Some(agent) = selected.take_agent(self) else {
             let error = selected.unsupported_error(supported);
@@ -395,14 +418,6 @@ impl ConnectTo<Client> for AgentProtocolRouter {
         let agent = RunningProtocolPeer::new(agent);
         agent.send_frame(first_frame)?;
         pipe_protocol_peers_until_closed(client, agent).await
-    }
-
-    fn into_channel_and_future(
-        self,
-    ) -> (Channel, crate::BoxFuture<'static, Result<(), crate::Error>>) {
-        let (channel_for_caller, channel_for_router) = Channel::duplex();
-        let future = Box::pin(ConnectTo::<Client>::connect_to(self, channel_for_router));
-        (channel_for_caller, future)
     }
 }
 
@@ -613,36 +628,51 @@ fn send_initialize_error(
     frame: &TransportFrame,
     error: crate::Error,
 ) -> Result<(), crate::Error> {
-    fn response_for_entry(
-        entry: Result<&RawJsonRpcMessage, &crate::Error>,
+    fn response_for_message(
+        entry: &RawJsonRpcMessage,
         initialize_error: &crate::Error,
     ) -> Option<RawJsonRpcMessage> {
         match entry {
-            Ok(RawJsonRpcMessage::Request(request)) => Some(RawJsonRpcMessage::response(
+            RawJsonRpcMessage::Request(request) => Some(RawJsonRpcMessage::response(
                 request.id.clone(),
                 Err(initialize_error.clone()),
             )),
-            Err(error) => Some(RawJsonRpcMessage::response(
-                RequestId::Null,
-                Err(error.clone()),
-            )),
-            Ok(RawJsonRpcMessage::Notification(_) | RawJsonRpcMessage::Response(_)) => None,
+            RawJsonRpcMessage::Notification(_) | RawJsonRpcMessage::Response(_) => None,
+        }
+    }
+
+    fn response_for_entry(
+        entry: &TransportBatchEntry,
+        initialize_error: &crate::Error,
+    ) -> Option<RawJsonRpcMessage> {
+        match entry {
+            TransportBatchEntry::Message(message) => {
+                response_for_message(message, initialize_error)
+            }
+            TransportBatchEntry::Malformed { raw, error } if !is_response_only_shape(raw) => Some(
+                RawJsonRpcMessage::response(RequestId::Null, Err(error.clone())),
+            ),
+            TransportBatchEntry::Malformed { .. } => None,
         }
     }
 
     let response = match frame {
         TransportFrame::Single(entry) => {
-            let Some(response) = response_for_entry(Ok(entry), &error) else {
+            let Some(response) = response_for_message(entry, &error) else {
                 return Ok(());
             };
             TransportFrame::Single(response)
         }
-        TransportFrame::Malformed { error, .. } => TransportFrame::Single(
-            RawJsonRpcMessage::response(RequestId::Null, Err(error.clone())),
-        ),
+        TransportFrame::Malformed { raw, error } if !raw_is_response_only_shape(raw) => {
+            TransportFrame::Single(RawJsonRpcMessage::response(
+                RequestId::Null,
+                Err(error.clone()),
+            ))
+        }
+        TransportFrame::Malformed { .. } => return Ok(()),
         TransportFrame::Batch(batch) => {
             let responses = batch
-                .iter_results()
+                .entries()
                 .filter_map(|entry| response_for_entry(entry, &error))
                 .collect::<Vec<_>>();
             let Some(responses) = TransportBatch::from_messages(responses) else {
@@ -760,13 +790,24 @@ fn initialize_message(frame: TransportFrame) -> Result<RawJsonRpcMessage, crate:
 #[cfg(feature = "unstable_protocol_v2")]
 fn initialize_message_mut(
     frame: &mut TransportFrame,
-) -> Result<&mut RawJsonRpcMessage, crate::Error> {
-    let entry = match frame {
-        TransportFrame::Single(entry) => entry,
-        TransportFrame::Malformed { error, .. } => return Err(error.clone()),
-        TransportFrame::Batch(batch) => return batch.first_result_mut(),
-    };
-    Ok(entry)
+) -> Result<Option<&mut RawJsonRpcMessage>, crate::Error> {
+    match frame {
+        TransportFrame::Single(RawJsonRpcMessage::Response(_)) => Ok(None),
+        TransportFrame::Single(entry) => Ok(Some(entry)),
+        TransportFrame::Malformed { raw, .. } if raw_is_response_only_shape(raw) => Ok(None),
+        TransportFrame::Malformed { error, .. } => Err(error.clone()),
+        TransportFrame::Batch(batch) => {
+            for entry in batch.entries_mut() {
+                match entry {
+                    TransportBatchEntry::Message(RawJsonRpcMessage::Response(_)) => {}
+                    TransportBatchEntry::Message(message) => return Ok(Some(message)),
+                    TransportBatchEntry::Malformed { raw, .. } if is_response_only_shape(raw) => {}
+                    TransportBatchEntry::Malformed { error, .. } => return Err(error.clone()),
+                }
+            }
+            Ok(None)
+        }
+    }
 }
 
 #[cfg(feature = "unstable_protocol_v2")]

--- a/src/agent-client-protocol/src/schema/proxy_protocol.rs
+++ b/src/agent-client-protocol/src/schema/proxy_protocol.rs
@@ -83,7 +83,10 @@ pub const METHOD_MCP_CONNECT_REQUEST: &str = "_mcp/connect";
 #[derive(Debug, Clone, Serialize, Deserialize, crate::JsonRpcRequest)]
 #[request(method = "_mcp/connect", response = McpConnectResponse, crate = crate)]
 pub struct McpConnectRequest {
-    /// The ACP identifier for the server (e.g., "acp:uuid"), matching `McpServerAcp.id`
+    /// Legacy ACP identifier for the server (for example, `acp:uuid`).
+    ///
+    /// This `acp_id` belongs to the underscore-prefixed compatibility extension;
+    /// the draft native `McpServerAcp` transport uses `server_id` instead.
     pub acp_id: String,
 
     /// Optional `_meta` metadata.

--- a/src/agent-client-protocol/src/session.rs
+++ b/src/agent-client-protocol/src/session.rs
@@ -75,11 +75,11 @@ where
     /// The vector `dynamic_handler_registrations` contains any dynamic
     /// handle registrations associated with this session (e.g., from MCP servers).
     /// You can simply pass `Default::default()` if not applicable.
-    pub(crate) fn attach_session<'responder>(
+    pub(crate) fn attach_session<'runner>(
         &self,
         response: NewSessionResponse,
         mcp_handler_registrations: Vec<DynamicHandlerGuard<Counterpart>>,
-    ) -> Result<ActiveSession<'responder, Counterpart>, crate::Error> {
+    ) -> Result<ActiveSession<'runner, Counterpart>, crate::Error> {
         let NewSessionResponse {
             session_id,
             modes,
@@ -100,7 +100,7 @@ where
             connection: self.clone(),
             session_handler_registration,
             mcp_handler_registrations,
-            _responder: PhantomData,
+            _runner: PhantomData,
         })
     }
 }
@@ -366,13 +366,13 @@ where
     ///
     /// The `ActiveSession` passed to `op` has a non-`'static` lifetime, which
     /// prevents calling [`ActiveSession::proxy_remaining_messages`] (since the
-    /// responders would terminate when `op` returns).
+    /// session's background runners would terminate when `op` returns).
     ///
     /// Requires calling [`block_task`](Self::block_task) first.
     pub async fn run_until<T>(
         self,
-        op: impl for<'responder> AsyncFnOnce(
-            ActiveSession<'responder, Counterpart>,
+        op: impl for<'runner> AsyncFnOnce(
+            ActiveSession<'runner, Counterpart>,
         ) -> Result<T, crate::Error>,
     ) -> Result<T, crate::Error> {
         let Self {
@@ -402,8 +402,8 @@ where
     /// drift but at the cost of requiring MCP servers that are `Send` and
     /// don't access data from the surrounding scope.
     ///
-    /// Returns an `ActiveSession<'static, _>` because responders are spawned
-    /// into background tasks that live for the connection lifetime.
+    /// Returns an `ActiveSession<'static, _>` because the session's runners are spawned into
+    /// background tasks that live for the connection lifetime.
     ///
     /// Requires calling [`block_task`](Self::block_task) first.
     pub async fn start_session(self) -> Result<ActiveSession<'static, Counterpart>, crate::Error>
@@ -478,14 +478,14 @@ where
 
 /// Active session struct that lets you send prompts and receive updates.
 ///
-/// The `'responder` lifetime represents the span during which responders
-/// (e.g., MCP server handlers) are active. When created via [`SessionBuilder::start_session`],
-/// this is `'static` because responders are spawned into background tasks.
+/// The `'runner` lifetime represents the span during which session support runners
+/// (such as MCP servers) are active. When created via [`SessionBuilder::start_session`],
+/// this is `'static` because the runners are spawned into background tasks.
 /// When created via [`SessionBuilder::run_until`], this is tied to the
 /// closure scope, preventing [`Self::proxy_remaining_messages`] from being called
-/// (since the responders would die when the closure returns).
+/// (since the runners would stop when the closure returns).
 #[derive(Debug)]
-pub struct ActiveSession<'responder, Link>
+pub struct ActiveSession<'runner, Link>
 where
     Link: HasPeer<Agent>,
 {
@@ -506,8 +506,8 @@ where
     /// which will cause them to be deregistered.
     mcp_handler_registrations: Vec<DynamicHandlerGuard<Link>>,
 
-    /// Phantom lifetime representing the responder lifetime.
-    _responder: PhantomData<&'responder ()>,
+    /// Phantom lifetime representing the session-runner lifetime.
+    _runner: PhantomData<&'runner ()>,
 }
 
 /// Incoming message from the agent
@@ -631,8 +631,8 @@ where
     /// This consumes the `ActiveSession` since you're giving up active control.
     ///
     /// This method is only available on `ActiveSession<'static, _>` (from
-    /// [`SessionBuilder::start_session`]) because it requires responders to
-    /// outlive the method call.
+    /// [`SessionBuilder::start_session`]) because it requires the session's runners to outlive
+    /// the method call.
     ///
     /// # Message Ordering Guarantees
     ///
@@ -665,7 +665,7 @@ where
             // These fields are not needed for proxying
             modes: _,
             meta: _,
-            _responder,
+            _runner,
         } = self;
 
         // Step 1: Drop the session handler registration.

--- a/src/agent-client-protocol/src/stdio.rs
+++ b/src/agent-client-protocol/src/stdio.rs
@@ -83,18 +83,4 @@ impl<Counterpart: Role> ConnectTo<Counterpart> for Stdio {
             ConnectTo::<Counterpart>::connect_to(ByteStreams::new(stdout, stdin), client).await
         }
     }
-
-    fn into_channel_and_future(
-        self,
-    ) -> (
-        crate::Channel,
-        crate::BoxFuture<'static, Result<(), crate::Error>>,
-    ) {
-        let (channel_for_caller, channel_for_stdio) = crate::Channel::duplex();
-        let future = Box::pin(ConnectTo::<Counterpart>::connect_to(
-            self,
-            channel_for_stdio,
-        ));
-        (channel_for_caller, future)
-    }
 }

--- a/src/agent-client-protocol/tests/jsonrpc_batch.rs
+++ b/src/agent-client-protocol/tests/jsonrpc_batch.rs
@@ -12,8 +12,9 @@ use std::sync::{
 use std::time::Duration;
 
 use agent_client_protocol::{
-    Agent, ByteStreams, ConnectTo, ConnectionTo, Error, JsonRpcMessage, JsonRpcNotification,
-    JsonRpcRequest, JsonRpcResponse, Responder,
+    Agent, ByteStreams, Channel, ConnectTo, ConnectionTo, Dispatch, Error, HandleDispatchFrom,
+    Handled, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse,
+    RawJsonRpcMessage, Responder, TransportBatch, TransportBatchEntry, TransportFrame,
     role::{Role, UntypedRole},
     schema::ProtocolVersion,
     schema::v1,
@@ -124,6 +125,22 @@ impl JsonRpcMessage for TestNotification {
 
 impl JsonRpcNotification for TestNotification {}
 
+struct RetryErrorHandler;
+
+impl HandleDispatchFrom<UntypedRole> for RetryErrorHandler {
+    async fn handle_dispatch_from(
+        &mut self,
+        _message: Dispatch,
+        _connection: ConnectionTo<UntypedRole>,
+    ) -> Result<Handled<Dispatch>, Error> {
+        Err(Error::internal_error().data("retry handler error won"))
+    }
+
+    fn describe_chain(&self) -> impl std::fmt::Debug {
+        "RetryErrorHandler"
+    }
+}
+
 fn start_server(
     notification_tx: mpsc::UnboundedSender<String>,
 ) -> (
@@ -142,13 +159,19 @@ fn start_server(
                    responder: Responder<TestResponse>,
                    _connection: ConnectionTo<UntypedRole>| {
                 if request.message == "handler error" {
-                    return Err(agent_client_protocol::Error::internal_error());
+                    return Err(
+                        agent_client_protocol::Error::internal_error().data("handler error won")
+                    );
                 }
                 if request.message == "respond then error" {
                     responder.respond(TestResponse {
                         result: "first response wins".into(),
                     })?;
                     return Err(agent_client_protocol::Error::internal_error());
+                }
+                if request.message == "drop responder" {
+                    drop(responder);
+                    return Ok(());
                 }
                 responder.respond(TestResponse {
                     result: format!("echo: {}", request.message),
@@ -346,6 +369,7 @@ async fn mixed_batch_returns_one_array_with_each_response_bearing_entry() {
                 .find(|response| response["id"] == json!(3))
                 .expect("failing request handler should receive an error");
             assert_eq!(handler_error["error"]["code"], json!(-32603));
+            assert_eq!(handler_error["error"]["data"], json!("handler error won"));
 
             write_json_line(
                 &mut peer_writer,
@@ -539,6 +563,184 @@ async fn incomplete_batch_withholds_partial_responses_without_blocking_standalon
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn dropped_batch_responder_gets_internal_error_without_stranding_siblings() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let (notification_tx, _notification_rx) = mpsc::unbounded();
+            let (mut peer_writer, mut peer_reader, server_task) = start_server(notification_tx);
+
+            write_json_line(
+                &mut peer_writer,
+                &json!([
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 14,
+                        "method": "test/echo",
+                        "params": { "message": "drop responder" }
+                    },
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 15,
+                        "method": "test/echo",
+                        "params": { "message": "healthy sibling" }
+                    }
+                ]),
+            )
+            .await;
+
+            let response = read_json_line(&mut peer_reader).await;
+            let responses = response
+                .as_array()
+                .expect("both batch slots should complete in one response array");
+            assert_eq!(responses.len(), 2);
+
+            let abandoned = responses
+                .iter()
+                .find(|response| response["id"] == json!(14))
+                .expect("abandoned request should receive a fallback response");
+            assert_eq!(abandoned["error"]["code"], json!(-32603));
+            assert!(
+                abandoned["error"]["data"]
+                    .as_str()
+                    .is_some_and(|data| data.contains("dropped its responder"))
+            );
+
+            let healthy = responses
+                .iter()
+                .find(|response| response["id"] == json!(15))
+                .expect("healthy sibling response should not be stranded");
+            assert_eq!(
+                healthy["result"],
+                json!({ "result": "echo: healthy sibling" })
+            );
+
+            finish_server(peer_writer, server_task).await;
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn retried_batch_handler_error_wins_over_dropped_responder_fallback() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let (peer_writer, sdk_reader) = tokio::io::duplex(8192);
+            let (sdk_writer, peer_reader) = tokio::io::duplex(8192);
+            let transport = ByteStreams::new(sdk_writer.compat_write(), sdk_reader.compat());
+
+            let server = UntypedRole.builder().on_receive_request(
+                async |request: TestRequest,
+                       responder: Responder<TestResponse>,
+                       connection: ConnectionTo<UntypedRole>| {
+                    match request.message.as_str() {
+                        "retry later" => Ok(Handled::No {
+                            message: (request, responder),
+                            retry: true,
+                        }),
+                        "register retry error" => {
+                            connection.add_dynamic_handler(RetryErrorHandler)?.detach();
+                            responder.respond(TestResponse {
+                                result: "retry handler registered".into(),
+                            })?;
+                            Ok(Handled::Yes)
+                        }
+                        message => {
+                            responder.respond(TestResponse {
+                                result: format!("echo: {message}"),
+                            })?;
+                            Ok(Handled::Yes)
+                        }
+                    }
+                },
+                agent_client_protocol::on_receive_request!(),
+            );
+            let server_task = tokio::task::spawn_local(server.connect_to(transport));
+            let mut peer_writer = peer_writer;
+            let mut peer_reader = BufReader::new(peer_reader);
+
+            write_json_line(
+                &mut peer_writer,
+                &json!([
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 16,
+                        "method": "test/echo",
+                        "params": { "message": "retry later" }
+                    },
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 17,
+                        "method": "test/echo",
+                        "params": { "message": "healthy sibling" }
+                    }
+                ]),
+            )
+            .await;
+
+            // This standalone round trip is ordered after the original batch
+            // dispatch barrier, proving the retry happens after that barrier.
+            write_json_line(
+                &mut peer_writer,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": 18,
+                    "method": "test/echo",
+                    "params": { "message": "barrier" }
+                }),
+            )
+            .await;
+            let barrier = read_json_line(&mut peer_reader).await;
+            assert_eq!(barrier["id"], json!(18));
+            assert_eq!(barrier["result"], json!({ "result": "echo: barrier" }));
+
+            write_json_line(
+                &mut peer_writer,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": 19,
+                    "method": "test/echo",
+                    "params": { "message": "register retry error" }
+                }),
+            )
+            .await;
+
+            let first = read_json_line(&mut peer_reader).await;
+            let second = read_json_line(&mut peer_reader).await;
+            let (registration, batch) = if first.is_array() {
+                (second, first)
+            } else {
+                (first, second)
+            };
+            assert_eq!(registration["id"], json!(19));
+
+            let responses = batch
+                .as_array()
+                .expect("retried request and its sibling should remain grouped");
+            assert_eq!(responses.len(), 2);
+            let retry_error = responses
+                .iter()
+                .find(|response| response["id"] == json!(16))
+                .expect("retried request should receive an error");
+            assert_eq!(retry_error["error"]["code"], json!(-32603));
+            assert_eq!(
+                retry_error["error"]["data"],
+                json!("retry handler error won")
+            );
+
+            let sibling = responses
+                .iter()
+                .find(|response| response["id"] == json!(17))
+                .expect("healthy sibling response should be preserved");
+            assert_eq!(
+                sibling["result"],
+                json!({ "result": "echo: healthy sibling" })
+            );
+
+            finish_server(peer_writer, server_task).await;
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn all_invalid_nonempty_batch_returns_an_error_array_and_connection_stays_usable() {
     tokio::task::LocalSet::new()
         .run_until(async {
@@ -570,6 +772,117 @@ async fn all_invalid_nonempty_batch_returns_an_error_array_and_connection_stays_
             assert_eq!(standalone["id"], json!(14));
 
             finish_server(peer_writer, server_task).await;
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn invalid_scalar_beside_malformed_response_gets_only_one_error() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let (notification_tx, _notification_rx) = mpsc::unbounded();
+            let (mut peer_writer, mut peer_reader, server_task) = start_server(notification_tx);
+
+            write_json_line(
+                &mut peer_writer,
+                &json!([
+                    17,
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 91,
+                        "result": null,
+                        "error": { "code": -32603, "message": "Internal error" }
+                    }
+                ]),
+            )
+            .await;
+
+            let response = read_json_line(&mut peer_reader).await;
+            let responses = response
+                .as_array()
+                .expect("the invalid call-shaped entry should receive one response array");
+            assert_eq!(responses.len(), 1);
+            assert!(responses[0]["id"].is_null());
+            assert_eq!(responses[0]["error"]["code"], json!(-32600));
+
+            write_json_line(
+                &mut peer_writer,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": 92,
+                    "method": "test/echo",
+                    "params": { "message": "after malformed response" }
+                }),
+            )
+            .await;
+            let standalone = read_json_line(&mut peer_reader).await;
+            assert!(standalone.is_object());
+            assert_eq!(standalone["id"], json!(92));
+
+            finish_server(peer_writer, server_task).await;
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn protocol_actor_ignores_response_shaped_malformed_public_frame_entries() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let (server_transport, mut peer) = Channel::duplex();
+            let server = UntypedRole.builder().on_receive_request(
+                async |request: TestRequest,
+                       responder: Responder<TestResponse>,
+                       _connection: ConnectionTo<UntypedRole>| {
+                    responder.respond(TestResponse {
+                        result: format!("echo: {}", request.message),
+                    })
+                },
+                agent_client_protocol::on_receive_request!(),
+            );
+            let server_task = tokio::task::spawn_local(server.connect_to(server_transport));
+
+            let request = serde_json::from_value::<RawJsonRpcMessage>(json!({
+                "jsonrpc": "2.0",
+                "id": 94,
+                "method": "test/echo",
+                "params": { "message": "after retained response" }
+            }))
+            .expect("test request should be valid JSON-RPC");
+            let batch = TransportBatch::from_entries([
+                TransportBatchEntry::malformed(
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": 93,
+                        "result": null,
+                        "error": { "code": -32603, "message": "Internal error" }
+                    }),
+                    Error::invalid_request(),
+                ),
+                TransportBatchEntry::message(request),
+            ])
+            .expect("test batch is non-empty");
+            peer.tx
+                .unbounded_send(TransportFrame::Batch(batch))
+                .expect("server should accept the test batch");
+
+            let frame = tokio::time::timeout(TIMEOUT, peer.rx.next())
+                .await
+                .expect("timed out waiting for the batch response")
+                .expect("server channel closed before responding");
+            let TransportFrame::Batch(batch) = frame else {
+                panic!("request sibling should receive one grouped batch response");
+            };
+            let response = serde_json::to_value(batch).expect("batch response should serialize");
+            let responses = response.as_array().expect("response should be an array");
+            assert_eq!(responses.len(), 1);
+            assert_eq!(responses[0]["id"], json!(94));
+
+            drop(peer);
+            tokio::time::timeout(TIMEOUT, server_task)
+                .await
+                .expect("server did not stop after channel close")
+                .expect("server task panicked")
+                .expect("server connection failed");
         })
         .await;
 }
@@ -929,9 +1242,19 @@ async fn response_batch_routes_two_pending_requests_by_id() {
                 )
                 .await;
 
-                // A malformed member of a response batch must not provoke an
-                // error response. The next outbound message is the request the
-                // client sends after both valid responses resolve.
+                // The scalar is still an invalid call-shaped batch member and
+                // receives an Invalid Request response. Valid response siblings
+                // are routed to their local awaiters rather than answered.
+                let invalid = read_json_line(&mut peer_reader).await;
+                let invalid = invalid
+                    .as_array()
+                    .expect("invalid sibling should receive one response array");
+                assert_eq!(invalid.len(), 1);
+                assert!(invalid[0]["id"].is_null());
+                assert_eq!(invalid[0]["error"]["code"], json!(-32600));
+
+                // The next outbound message is the request sent after both
+                // valid responses resolve.
                 let barrier = read_json_line(&mut peer_reader).await;
                 assert_eq!(barrier["method"], json!("test/echo"));
                 assert_eq!(barrier["params"]["message"], json!("barrier"));

--- a/src/agent-client-protocol/tests/jsonrpc_error_handling.rs
+++ b/src/agent-client-protocol/tests/jsonrpc_error_handling.rs
@@ -8,11 +8,11 @@
 //! - Missing/invalid parameters
 
 use agent_client_protocol::{
-    ConnectionTo, Dispatch, JsonRpcMessage, JsonRpcRequest, JsonRpcResponse, Responder,
-    SentRequest, role::UntypedRole,
+    Channel, ConnectionTo, Dispatch, Handled, JsonRpcMessage, JsonRpcRequest, JsonRpcResponse,
+    RawJsonRpcMessage, Responder, SentRequest, TransportFrame, role::UntypedRole,
 };
 use expect_test::expect;
-use futures::{AsyncRead, AsyncWrite};
+use futures::{AsyncRead, AsyncWrite, StreamExt as _};
 use serde::{Deserialize, Serialize};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
@@ -45,6 +45,68 @@ fn setup_test_streams() -> (
     let client_writer = client_writer.compat_write();
 
     (server_reader, server_writer, client_reader, client_writer)
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn response_dispatch_handler_error_reaches_the_local_request_awaiter() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let (transport, mut peer) = Channel::duplex();
+            let connection = UntypedRole
+                .builder()
+                .on_receive_dispatch(
+                    async |dispatch: Dispatch, _connection: ConnectionTo<UntypedRole>| {
+                        match dispatch {
+                            Dispatch::Response(..) => {
+                                Err(agent_client_protocol::Error::internal_error()
+                                    .data("response interceptor failed"))
+                            }
+                            message => Ok(Handled::No {
+                                message,
+                                retry: false,
+                            }),
+                        }
+                    },
+                    agent_client_protocol::on_receive_dispatch!(),
+                )
+                .connect_with(transport, async |connection| {
+                    let error = connection
+                        .send_request(SimpleRequest {
+                            message: "intercept me".into(),
+                        })
+                        .block_task()
+                        .await
+                        .expect_err("response handler error should fail the pending request");
+                    assert_eq!(
+                        error.data,
+                        Some(serde_json::json!("response interceptor failed"))
+                    );
+                    Ok(())
+                });
+
+            let peer = async move {
+                let frame = peer
+                    .rx
+                    .next()
+                    .await
+                    .expect("connection should send one request");
+                let TransportFrame::Single(RawJsonRpcMessage::Request(request)) = frame else {
+                    panic!("expected one standalone request");
+                };
+                peer.tx
+                    .unbounded_send(TransportFrame::Single(RawJsonRpcMessage::response(
+                        request.id,
+                        Ok(serde_json::json!({ "result": "ignored" })),
+                    )))
+                    .expect("connection should accept the test response");
+                Ok::<(), agent_client_protocol::Error>(())
+            };
+
+            futures::try_join!(connection, peer)?;
+            Ok::<(), agent_client_protocol::Error>(())
+        })
+        .await
+        .unwrap();
 }
 
 // ============================================================================

--- a/src/agent-client-protocol/tests/protocol_v2.rs
+++ b/src/agent-client-protocol/tests/protocol_v2.rs
@@ -4,7 +4,7 @@ use std::{
     path::PathBuf,
     sync::{
         Arc,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
 };
 
@@ -162,6 +162,7 @@ struct InitializingV1Client {
     expected_session_id: &'static str,
     implementation_name: &'static str,
     client_capabilities: Option<v1::ClientCapabilities>,
+    previous_clients_dropped: Vec<Arc<AtomicBool>>,
 }
 
 impl InitializingV1Client {
@@ -170,6 +171,7 @@ impl InitializingV1Client {
             expected_session_id,
             implementation_name: "agent-client-protocol-test",
             client_capabilities: None,
+            previous_clients_dropped: Vec::new(),
         }
     }
 
@@ -181,11 +183,17 @@ impl InitializingV1Client {
             expected_session_id,
             implementation_name,
             client_capabilities: None,
+            previous_clients_dropped: Vec::new(),
         }
     }
 
     fn with_client_capabilities(mut self, client_capabilities: v1::ClientCapabilities) -> Self {
         self.client_capabilities = Some(client_capabilities);
+        self
+    }
+
+    fn expect_previous_client_dropped(mut self, dropped: Arc<AtomicBool>) -> Self {
+        self.previous_clients_dropped.push(dropped);
         self
     }
 }
@@ -195,6 +203,7 @@ impl ConnectTo<Agent> for InitializingV1Client {
         let expected_session_id = self.expected_session_id;
         let implementation_name = self.implementation_name;
         let client_capabilities = self.client_capabilities;
+        let previous_clients_dropped = self.previous_clients_dropped;
         Client
             .builder()
             .connect_with(agent, async move |cx| {
@@ -207,6 +216,12 @@ impl ConnectTo<Agent> for InitializingV1Client {
 
                 let initialize = cx.send_request(request).block_task().await?;
                 assert_eq!(initialize.protocol_version, ProtocolVersion::V1);
+                for dropped in previous_clients_dropped {
+                    assert!(
+                        dropped.load(Ordering::SeqCst),
+                        "each abandoned protocol client must be dropped before v1 continues"
+                    );
+                }
 
                 let session = cx
                     .send_request(v1::NewSessionRequest::new(cwd()?))
@@ -256,6 +271,33 @@ impl ConnectTo<Agent> for ExpectingV2InitializeErrorClient {
 
 struct InitializingV2Client {
     expected_session_id: &'static str,
+}
+
+struct DropTrackedClient<C> {
+    client: C,
+    dropped: Arc<AtomicBool>,
+}
+
+impl<C> DropTrackedClient<C> {
+    fn new(client: C, dropped: Arc<AtomicBool>) -> Self {
+        Self { client, dropped }
+    }
+}
+
+struct DropFlag(Arc<AtomicBool>);
+
+impl Drop for DropFlag {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+}
+
+impl<C: ConnectTo<Agent>> ConnectTo<Agent> for DropTrackedClient<C> {
+    async fn connect_to(self, agent: impl ConnectTo<Client>) -> Result<(), Error> {
+        let Self { client, dropped } = self;
+        let _drop_flag = DropFlag(dropped);
+        client.connect_to(agent).await
+    }
 }
 
 impl InitializingV2Client {
@@ -891,20 +933,30 @@ async fn client_protocol_connector_reuses_matching_connection_before_v1_fallback
 -> Result<(), Error> {
     let connections = Arc::new(AtomicUsize::new(0));
     let agent_connections = Arc::clone(&connections);
+    let v2_client_dropped = Arc::new(AtomicBool::new(false));
+    let v1_drop_observer = Arc::clone(&v2_client_dropped);
+    let v2_drop_observer = Arc::clone(&v2_client_dropped);
 
     Client
         .protocol_connector()
-        .with_v1(|| {
-            InitializingV1Client::new("v1-reused-session").with_client_capabilities(
-                v1::ClientCapabilities::new().session(
-                    v1::ClientSessionCapabilities::new().config_options(
-                        v1::SessionConfigOptionsCapabilities::new()
-                            .boolean(v1::BooleanConfigOptionCapabilities::new()),
+        .with_v1(move || {
+            InitializingV1Client::new("v1-reused-session")
+                .with_client_capabilities(
+                    v1::ClientCapabilities::new().session(
+                        v1::ClientSessionCapabilities::new().config_options(
+                            v1::SessionConfigOptionsCapabilities::new()
+                                .boolean(v1::BooleanConfigOptionCapabilities::new()),
+                        ),
                     ),
-                ),
+                )
+                .expect_previous_client_dropped(Arc::clone(&v1_drop_observer))
+        })
+        .with_v2(move || {
+            DropTrackedClient::new(
+                InitializingV2Client::new("v2-client-should-not-continue"),
+                Arc::clone(&v2_drop_observer),
             )
         })
-        .with_v2(|| InitializingV2Client::new("v2-client-should-not-continue"))
         .connect_to(move || {
             let connection_number = agent_connections.fetch_add(1, Ordering::SeqCst) + 1;
             let initialize_connection_number = connection_number;
@@ -943,6 +995,7 @@ async fn client_protocol_connector_reuses_matching_connection_before_v1_fallback
         .await?;
 
     assert_eq!(connections.load(Ordering::SeqCst), 1);
+    assert!(v2_client_dropped.load(Ordering::SeqCst));
     Ok(())
 }
 
@@ -950,16 +1003,39 @@ async fn client_protocol_connector_reuses_matching_connection_before_v1_fallback
 async fn client_protocol_connector_reconnects_before_v1_fallback() -> Result<(), Error> {
     let connections = Arc::new(AtomicUsize::new(0));
     let agent_connections = Arc::clone(&connections);
+    let v1_factory_calls = Arc::new(AtomicUsize::new(0));
+    let v1_factory_call_counter = Arc::clone(&v1_factory_calls);
+    let v2_client_dropped = Arc::new(AtomicBool::new(false));
+    let v2_drop_tracker = Arc::clone(&v2_client_dropped);
+    let v2_drop_observer = Arc::clone(&v2_client_dropped);
+    let v1_probe_dropped = Arc::new(AtomicBool::new(false));
+    let v1_probe_drop_tracker = Arc::clone(&v1_probe_dropped);
+    let v1_probe_drop_observer = Arc::clone(&v1_probe_dropped);
 
     Client
         .protocol_connector()
-        .with_v1(|| {
-            InitializingV1Client::with_implementation_name(
+        .with_v1(move || {
+            let factory_call = v1_factory_call_counter.fetch_add(1, Ordering::SeqCst);
+            let mut client = InitializingV1Client::with_implementation_name(
                 "v1-reconnected-session",
                 "v1-reconnected-client",
+            );
+            if factory_call == 1 {
+                client = client
+                    .expect_previous_client_dropped(Arc::clone(&v2_drop_observer))
+                    .expect_previous_client_dropped(Arc::clone(&v1_probe_drop_observer));
+            } else {
+                assert_eq!(factory_call, 0, "v1 factory should be called exactly twice");
+            }
+
+            DropTrackedClient::new(client, Arc::clone(&v1_probe_drop_tracker))
+        })
+        .with_v2(move || {
+            DropTrackedClient::new(
+                InitializingV2Client::new("v2-client-should-not-continue"),
+                Arc::clone(&v2_drop_tracker),
             )
         })
-        .with_v2(|| InitializingV2Client::new("v2-client-should-not-continue"))
         .connect_to(move || {
             let connection_number = agent_connections.fetch_add(1, Ordering::SeqCst) + 1;
             let initialize_connection_number = connection_number;
@@ -1003,6 +1079,9 @@ async fn client_protocol_connector_reconnects_before_v1_fallback() -> Result<(),
         .await?;
 
     assert_eq!(connections.load(Ordering::SeqCst), 2);
+    assert_eq!(v1_factory_calls.load(Ordering::SeqCst), 2);
+    assert!(v2_client_dropped.load(Ordering::SeqCst));
+    assert!(v1_probe_dropped.load(Ordering::SeqCst));
     Ok(())
 }
 
@@ -1378,7 +1457,7 @@ async fn protocol_router_rejection_flushes_over_byte_streams() -> Result<(), Err
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn protocol_router_ignores_filtered_response_batch_before_initialize() -> Result<(), Error> {
+async fn protocol_router_ignores_retained_response_batch_before_initialize() -> Result<(), Error> {
     use tokio::io::{AsyncWriteExt as _, BufReader};
 
     let v1_agent = Agent.builder().on_receive_request(
@@ -1419,6 +1498,104 @@ async fn protocol_router_ignores_filtered_response_batch_before_initialize() -> 
     let response = read_wire_json(&mut client_reader).await?;
     assert_eq!(response["id"], 1);
     assert!(response.get("result").is_some(), "{response:?}");
+
+    client_writer
+        .shutdown()
+        .await
+        .map_err(Error::into_internal_error)?;
+    agent_task
+        .await
+        .map_err(agent_client_protocol::util::internal_error)??;
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn protocol_router_ignores_retained_standalone_response_before_initialize()
+-> Result<(), Error> {
+    use tokio::io::{AsyncWriteExt as _, BufReader};
+
+    let v1_agent = Agent.builder().on_receive_request(
+        async |initialize: v1::InitializeRequest, responder, _cx| {
+            responder.respond(v1::InitializeResponse::new(initialize.protocol_version))
+        },
+        agent_client_protocol::on_receive_request!(),
+    );
+    let agent = Agent.protocol_router().with_v1(v1_agent);
+
+    let (mut client_writer, server_reader) = tokio::io::duplex(4096);
+    let (server_writer, client_reader) = tokio::io::duplex(4096);
+    let server_transport = ByteStreams::new(server_writer.compat_write(), server_reader.compat());
+    let agent_task = tokio::spawn(agent.connect_to(server_transport));
+    let mut client_reader = BufReader::new(client_reader);
+
+    write_wire_json(
+        &mut client_writer,
+        &serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 99,
+            "result": null,
+            "error": { "code": -32603, "message": "Internal error" },
+        }),
+    )
+    .await?;
+    write_wire_json(
+        &mut client_writer,
+        &serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": json_value(v1_initialize_request(ProtocolVersion::V1))?,
+        }),
+    )
+    .await?;
+
+    let response = read_wire_json(&mut client_reader).await?;
+    assert_eq!(response["id"], 1);
+    assert!(response.get("result").is_some(), "{response:?}");
+
+    client_writer
+        .shutdown()
+        .await
+        .map_err(Error::into_internal_error)?;
+    agent_task
+        .await
+        .map_err(agent_client_protocol::util::internal_error)??;
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn protocol_router_rejection_does_not_answer_malformed_response_entries() -> Result<(), Error>
+{
+    use tokio::io::{AsyncWriteExt as _, BufReader};
+
+    let agent = Agent.protocol_router().with_v1(Agent.builder());
+    let (mut client_writer, server_reader) = tokio::io::duplex(4096);
+    let (server_writer, client_reader) = tokio::io::duplex(4096);
+    let server_transport = ByteStreams::new(server_writer.compat_write(), server_reader.compat());
+    let agent_task = tokio::spawn(agent.connect_to(server_transport));
+    let mut client_reader = BufReader::new(client_reader);
+
+    write_wire_json(
+        &mut client_writer,
+        &serde_json::json!([
+            17,
+            {
+                "jsonrpc": "2.0",
+                "id": 99,
+                "result": null,
+                "error": { "code": -32603, "message": "Internal error" },
+            }
+        ]),
+    )
+    .await?;
+
+    let response = read_wire_json(&mut client_reader).await?;
+    let responses = response
+        .as_array()
+        .expect("invalid batch entry should receive a response array");
+    assert_eq!(responses.len(), 1);
+    assert!(responses[0]["id"].is_null());
+    assert_eq!(responses[0]["error"]["code"], -32600);
 
     client_writer
         .shutdown()


### PR DESCRIPTION
- preserve JSON-RPC frame boundaries, malformed batch members, response provenance, and grouped replies through core, conductor, HTTP, WebSocket, and polyfill routing
- finish the intentional 2.0 API cleanup and remove obsolete notification-response and transport compatibility surfaces
- release abandoned protocol probes before continuing either v1 fallback path
- align changelogs, migration guidance, architecture docs, examples, and crate dependency majors with the final design

## Breaking changes

- Channel transports carry TransportFrame values so batches remain batches across adapters
- response routing, handler registration, typed matching, session accessors, and several obsolete helpers use their documented 2.0 forms
- published adapter crates target agent-client-protocol 2.x; agent-client-protocol-rmcp moves from 2.x to 3.x
- the full source migration is documented in md/migration_v2.0.md