### PR TITLE
fix(acp)!: enforce response lifecycle ordering

### DIFF
--- a/md/migration_v2.0.md
+++ b/md/migration_v2.0.md
@@ -264,10 +264,19 @@ Pass a finite limit instead of `None` to bound concurrency.
 `ConnectionTo::attach_session` is no longer public. Create sessions through
 `ConnectionTo::build_session`, `build_session_cwd`, or `build_session_from` instead. Use
 `SessionBuilder::on_session_start` to start without blocking the calling task, or call
-`block_task()` followed by `run_until` or `start_session`. Proxy handlers can use
-`on_proxy_session_start`, or `block_task().start_session_proxy(...)`. Directly attaching an
-already-returned `NewSessionResponse` is no longer supported, so move request customization into
-`build_session_from` before the builder sends `session/new`.
+`block_task()` followed by `run_until` or `start_session` outside message handlers. Proxy handlers
+must use `on_proxy_session_start`; only call `block_task().start_session_proxy(...)` from an
+already-spawned task. Directly attaching an already-returned `NewSessionResponse` is no longer
+supported, so move request customization into `build_session_from` before the builder sends
+`session/new`.
+
+When the session response is routed during its original dispatch, `on_session_start` and
+`on_proxy_session_start` install session routing under the ordered response callback, then spawn
+the user callback. Their callback futures must therefore be `'static`, but they may safely wait
+for later connection or session traffic. A response interceptor that retains and routes the
+response later cannot retroactively order that setup before already-processed messages. Perform
+synchronous bookkeeping in the surrounding request handler when it must complete before every
+later message.
 
 Construct `Lines` and `ByteStreams` with `Lines::new(outgoing, incoming)` and
 `ByteStreams::new(outgoing, incoming)`; their stream fields are no longer public.

--- a/md/migration_v2.0.md
+++ b/md/migration_v2.0.md
@@ -272,11 +272,12 @@ supported, so move request customization into `build_session_from` before the bu
 
 When the session response is routed during its original dispatch, `on_session_start` and
 `on_proxy_session_start` install session routing under the ordered response callback, then spawn
-the user callback. Their callback futures must therefore be `'static`, but they may safely wait
-for later connection or session traffic. A response interceptor that retains and routes the
-response later cannot retroactively order that setup before already-processed messages. Perform
-synchronous bookkeeping in the surrounding request handler when it must complete before every
-later message.
+the user callback. No user callback code runs under that ordering guarantee. The callback itself
+must be `'static`, but its returned future does not need an additional `'static` bound and may
+safely wait for later connection or session traffic. A response interceptor that retains and
+routes the response later cannot retroactively order that setup before already-processed messages.
+Register application state needed for routing before calling these helpers. Bookkeeping that
+requires the returned session or session ID runs concurrently with later traffic.
 
 Construct `Lines` and `ByteStreams` with `Lines::new(outgoing, incoming)` and
 `ByteStreams::new(outgoing, incoming)`; their stream fields are no longer public.
@@ -307,8 +308,10 @@ are included in the SDK 2.0 migration rather than treated as stable-v1 wire chan
 ## `SentRequest::map` accepts arbitrary output
 
 `SentRequest::map` can now consume a typed response into any output type; the mapped value no
-longer needs to implement `JsonRpcResponse`. The mapper may also be a one-shot closure. This is
-additive, so existing mapping code does not need to change.
+longer needs to implement `JsonRpcResponse`. This includes mapped values carrying non-`'static`
+lifetimes when they are consumed with `block_task`; callback-style consumption still requires
+`'static` because it is spawned onto the connection. The mapper may also be a one-shot closure.
+This is additive, so existing mapping code does not need to change.
 
 ## `AcpAgent` has its own process configuration
 

--- a/src/agent-client-protocol-cookbook/src/lib.rs
+++ b/src/agent-client-protocol-cookbook/src/lib.rs
@@ -605,13 +605,11 @@ pub mod per_session_mcp_server {
     //!             connection.build_session_from(request)
     //!                 .with_mcp_server(mcp_server)?
     //!                 .on_proxy_session_start(responder, async move |session_id| {
-    //!                     // This callback runs after the session-id has been sent to the
-    //!                     // client but before any further messages from the client or agent
-    //!                     // related to this session have been processed.
+    //!                     // Session proxying is installed before this callback is spawned.
     //!                     //
-    //!                     // You can use this to store the `session_id` before processing
-    //!                     // future messages, or to send a first prompt to the agent before
-    //!                     // the client has a chance to do so.
+    //!                     // Use this for follow-up work that may wait for later connection
+    //!                     // traffic. Perform synchronous bookkeeping in the request handler
+    //!                     // itself when it must precede every later message.
     //!                     tracing::info!(%session_id, "Session started");
     //!                     Ok(())
     //!                 })
@@ -634,10 +632,11 @@ pub mod per_session_mcp_server {
     //! the message handler. This is ideal for proxies that just need to inject
     //! tools and track sessions.
     //!
-    //! # Alternative: blocking with `start_session_proxy`
+    //! # Alternative: spawning `start_session_proxy`
     //!
-    //! If you need the simpler blocking API (e.g., in a client context where
-    //! blocking is safe), use [`block_task`] + [`start_session_proxy`]:
+    //! If you need the linear [`start_session_proxy`] API, move it into a
+    //! spawned task. Awaiting it directly in the request handler would block
+    //! the dispatch loop that must receive the agent's response:
     //!
     //! ```
     //! # use agent_client_protocol::mcp_server::McpServer;
@@ -654,13 +653,17 @@ pub mod per_session_mcp_server {
     //!                 }, agent_client_protocol::tool_fn!())
     //!                 .build();
     //!
-    //!             let session_id = connection.build_session_from(request)
-    //!                 .with_mcp_server(mcp_server)?
-    //!                 .block_task()
-    //!                 .start_session_proxy(responder)
-    //!                 .await?;
+    //!             let task_connection = connection.clone();
+    //!             connection.spawn(async move {
+    //!                 let session_id = task_connection.build_session_from(request)
+    //!                     .with_mcp_server(mcp_server)?
+    //!                     .block_task()
+    //!                     .start_session_proxy(responder)
+    //!                     .await?;
     //!
-    //!             tracing::info!(%session_id, "Session started");
+    //!                 tracing::info!(%session_id, "Session started");
+    //!                 Ok(())
+    //!             })?;
     //!             Ok(())
     //!         }, agent_client_protocol::on_receive_request!())
     //!         .connect_to(transport)

--- a/src/agent-client-protocol/CHANGELOG.md
+++ b/src/agent-client-protocol/CHANGELOG.md
@@ -58,6 +58,12 @@
 
 **Fixed**
 
+- Honor `on_receiving_result` ordering when callback consumption is selected before a response
+  arrives, without stalling unconsumed, blocking, or delayed response routes. Session-start
+  helpers now install their routing state under that ordering barrier for responses routed during
+  their original dispatch, and run user session work in a spawned task.
+- Emit at most one response for an individual request when a handler responds and then returns an
+  error, matching the existing per-entry completion behavior for batches.
 - Preserve JSON-RPC batch framing across component adapters, protocol routing, and tracing
   bridges. Invalid call entries no longer abort relays, fully filtered response batches are not
   serialized as empty arrays, and malformed response-only input is ignored rather than answered.

--- a/src/agent-client-protocol/src/concepts/callbacks.rs
+++ b/src/agent-client-protocol/src/concepts/callbacks.rs
@@ -84,8 +84,11 @@
 //! # }
 //! ```
 //!
-//! You must send exactly one response per request. If your callback returns
-//! without responding, an error response is sent automatically.
+//! Send at most one response per request. If a handler responds and then
+//! returns an error, the first response wins and the duplicate completion is
+//! ignored. Dropping a responder from a batch produces an automatic Internal
+//! Error so sibling responses are not stranded; dropping the responder for an
+//! individual request sends no response.
 //!
 //! # Multiple Handlers
 //!

--- a/src/agent-client-protocol/src/concepts/ordering.rs
+++ b/src/agent-client-protocol/src/concepts/ordering.rs
@@ -23,7 +23,11 @@
 //! This includes:
 //! - [`on_receive_request`] and [`on_receive_notification`]
 //! - [`on_receiving_result`] and [`on_receiving_ok_result`]
-//! - [`on_session_start`] and [`on_proxy_session_start`]
+//!
+//! Session-start helpers are two-phase: [`on_session_start`] and
+//! [`on_proxy_session_start`] perform their session setup under this ordering
+//! guarantee, then spawn the user callback so it can consume later session
+//! traffic.
 //!
 //! This means:
 //! - No other messages are processed while your callback runs
@@ -108,6 +112,10 @@
 //! the next message. Use this when you need to ensure no other messages
 //! are processed until you've handled the response.
 //!
+//! Register the callback before the response arrives to select this ordered
+//! mode. A response that was already routed, or that an interceptor retains
+//! and routes after its original dispatch, cannot retroactively hold the loop.
+//!
 //! # Escaping the Loop: `spawn`
 //!
 //! Use [`spawn`] to run work outside the dispatch loop:
@@ -156,6 +164,7 @@
 //! |---------|--------------|----------|
 //! | `on_*` callback | Yes | Quick decisions, need ordering |
 //! | `on_receiving_result` | Yes | Need to process response before next message |
+//! | `on_session_start` / `on_proxy_session_start` | Setup only | Install session routing, then run session work concurrently |
 //! | `block_task()` | No | In spawned tasks, need response value |
 //! | `spawn(...)` | No | Long-running work, don't need ordering |
 //! | `block_task().run_until(...)` | No | Session-scoped work |

--- a/src/agent-client-protocol/src/concepts/ordering.rs
+++ b/src/agent-client-protocol/src/concepts/ordering.rs
@@ -25,11 +25,12 @@
 //! - [`on_receiving_result`] and [`on_receiving_ok_result`]
 //!
 //! Session-start helpers are two-phase: [`on_session_start`] and
-//! [`on_proxy_session_start`] perform their session setup under this ordering
-//! guarantee, then spawn the user callback so it can consume later session
-//! traffic.
+//! [`on_proxy_session_start`] perform framework-owned session setup under this
+//! ordering guarantee, then invoke the user callback in a spawned task so it
+//! can consume later session traffic. No user callback code runs under the
+//! session-setup ordering guarantee.
 //!
-//! This means:
+//! For callbacks that run inside the dispatch loop, this means:
 //! - No other messages are processed while your callback runs
 //! - You can safely do setup before "releasing" control back to the loop
 //! - Messages are processed in the order they arrive

--- a/src/agent-client-protocol/src/concepts/sessions.rs
+++ b/src/agent-client-protocol/src/concepts/sessions.rs
@@ -123,8 +123,12 @@
 //! # }
 //! ```
 //!
-//! This follows the same ordering guarantees as other `on_*` methods - see
-//! [Ordering](super::ordering) for details.
+//! When the session response is routed during its original dispatch, session
+//! setup completes before later messages are dispatched. The callback itself
+//! runs in a spawned task, so it can wait for session traffic. A response
+//! interceptor that retains and routes the response later cannot retroactively
+//! order setup before messages already processed. See [Ordering](super::ordering)
+//! for details.
 //!
 //! # Next Steps
 //!

--- a/src/agent-client-protocol/src/concepts/sessions.rs
+++ b/src/agent-client-protocol/src/concepts/sessions.rs
@@ -124,8 +124,9 @@
 //! ```
 //!
 //! When the session response is routed during its original dispatch, session
-//! setup completes before later messages are dispatched. The callback itself
-//! runs in a spawned task, so it can wait for session traffic. A response
+//! routing is installed before later messages are dispatched. The callback is
+//! invoked in a spawned task, so no user callback code has that ordering
+//! guarantee and the callback can wait for session traffic. A response
 //! interceptor that retains and routes the response later cannot retroactively
 //! order setup before messages already processed. See [Ordering](super::ordering)
 //! for details.

--- a/src/agent-client-protocol/src/jsonrpc.rs
+++ b/src/agent-client-protocol/src/jsonrpc.rs
@@ -1839,9 +1839,10 @@ pub(crate) struct ResponsePayload {
     /// response processing is complete, allowing the dispatch loop to continue
     /// to the next message.
     ///
-    /// This is `None` for error paths where the response is sent directly
-    /// (e.g., when the outgoing channel is broken) rather than through the
-    /// normal dispatch loop flow.
+    /// This is present only when callback-style consumption was selected before
+    /// the response was routed during its original dispatch. Local error paths,
+    /// blocking consumers, and responses routed later do not hold the dispatch
+    /// loop.
     pub(crate) ack_tx: Option<oneshot::Sender<()>>,
 }
 
@@ -1854,11 +1855,27 @@ impl std::fmt::Debug for ResponsePayload {
     }
 }
 
+#[derive(Clone, Debug, Default)]
+struct ResponseOrdering {
+    ordered: Arc<AtomicBool>,
+}
+
+impl ResponseOrdering {
+    fn mark_ordered(&self) {
+        self.ordered.store(true, Ordering::Release);
+    }
+
+    fn is_ordered(&self) -> bool {
+        self.ordered.load(Ordering::Acquire)
+    }
+}
+
 struct PendingReply {
     method: String,
     role_id: RoleId,
     sender: oneshot::Sender<ResponsePayload>,
     cancellation_disarm: SentRequestCancellationDisarm,
+    ordering: ResponseOrdering,
 }
 
 impl PendingReply {
@@ -2387,20 +2404,24 @@ pub fn is_cancel_request_notification<N: JsonRpcNotification>(notification: &N) 
 /// Messages send to be serialized over the transport.
 #[derive(Clone)]
 enum ResponseDestination {
-    Individual,
+    Individual(IndividualResponseSlot),
     Batch(BatchResponseSlot),
 }
 
 impl std::fmt::Debug for ResponseDestination {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Individual => formatter.write_str("Individual"),
+            Self::Individual(slot) => formatter.debug_tuple("Individual").field(slot).finish(),
             Self::Batch(slot) => formatter.debug_tuple("Batch").field(slot).finish(),
         }
     }
 }
 
 impl ResponseDestination {
+    fn individual() -> Self {
+        Self::Individual(IndividualResponseSlot::default())
+    }
+
     fn batch(slot_count: usize) -> (impl Iterator<Item = Self>, BatchDispatchCompletion) {
         let state = Arc::new(Mutex::new(BatchResponseState {
             remaining: slot_count,
@@ -2427,14 +2448,14 @@ impl ResponseDestination {
 
     fn complete(self, response: RawJsonRpcMessage) -> Option<TransportFrame> {
         match self {
-            Self::Individual => Some(TransportFrame::Single(response)),
+            Self::Individual(slot) => slot.complete(response),
             Self::Batch(slot) => slot.complete(response).map(batch_response_frame),
         }
     }
 
     fn abandon(self, fallback: RawJsonRpcMessage) -> Option<TransportFrame> {
         match self {
-            Self::Individual => None,
+            Self::Individual(_) => None,
             Self::Batch(slot) => slot.abandon(fallback).map(batch_response_frame),
         }
     }
@@ -2459,9 +2480,25 @@ impl ResponseDestination {
 
     fn finish_handler_attempt(self) -> Option<TransportFrame> {
         match self {
-            Self::Individual => None,
+            Self::Individual(_) => None,
             Self::Batch(slot) => slot.finish_handler_attempt().map(batch_response_frame),
         }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct IndividualResponseSlot {
+    completed: Arc<AtomicBool>,
+}
+
+impl IndividualResponseSlot {
+    fn complete(self, response: RawJsonRpcMessage) -> Option<TransportFrame> {
+        if self.completed.swap(true, Ordering::AcqRel) {
+            tracing::warn!("Ignoring duplicate completion of JSON-RPC request");
+            return None;
+        }
+
+        Some(TransportFrame::Single(response))
     }
 }
 
@@ -2665,6 +2702,8 @@ struct ResponseReplyTarget {
     id: RequestId,
     method: String,
     sender: Arc<Mutex<Option<oneshot::Sender<ResponsePayload>>>>,
+    ordering: ResponseOrdering,
+    dispatch: ResponseDispatch,
 }
 
 impl ResponseReplyTarget {
@@ -2683,19 +2722,52 @@ impl ResponseReplyTarget {
             return;
         };
 
-        if sender
-            .send(ResponsePayload {
-                result,
-                ack_tx: None,
-            })
-            .is_err()
-        {
+        let ack_tx = self.dispatch.acknowledgment(&self.ordering);
+        if sender.send(ResponsePayload { result, ack_tx }).is_err() {
             tracing::debug!(
                 method = %self.method,
                 id = ?self.id,
                 "dropped response because local receiver was gone"
             );
         }
+    }
+}
+
+#[derive(Clone, Default)]
+struct ResponseDispatch {
+    state: Arc<Mutex<ResponseDispatchState>>,
+}
+
+#[derive(Default)]
+struct ResponseDispatchState {
+    complete: bool,
+    ack_rx: Option<oneshot::Receiver<()>>,
+}
+
+impl ResponseDispatch {
+    fn acknowledgment(&self, ordering: &ResponseOrdering) -> Option<oneshot::Sender<()>> {
+        if !ordering.is_ordered() {
+            return None;
+        }
+
+        let mut state = self.state.lock().expect("response dispatch mutex poisoned");
+        if state.complete {
+            return None;
+        }
+
+        let (ack_tx, ack_rx) = oneshot::channel();
+        let previous_ack = state.ack_rx.replace(ack_rx);
+        debug_assert!(
+            previous_ack.is_none(),
+            "a response dispatch can only be routed once"
+        );
+        Some(ack_tx)
+    }
+
+    fn complete(&self) -> Option<oneshot::Receiver<()>> {
+        let mut state = self.state.lock().expect("response dispatch mutex poisoned");
+        state.complete = true;
+        state.ack_rx.take()
     }
 }
 
@@ -3312,6 +3384,7 @@ impl<Counterpart: Role> ConnectionTo<Counterpart> {
         let method = request.method().to_string();
         let id = RequestId::Str(uuid::Uuid::new_v4().to_string());
         let (response_tx, response_rx) = oneshot::channel();
+        let response_ordering = ResponseOrdering::default();
         let role_id = peer.role_id();
         let remote_style = self.counterpart.remote_style(peer);
         let cancellation =
@@ -3328,6 +3401,7 @@ impl<Counterpart: Role> ConnectionTo<Counterpart> {
                 self.task_tx.clone(),
                 response_rx,
                 cancellation,
+                response_ordering,
             )
             .map(move |json| <Req::Response>::from_value(&method, json));
         }
@@ -3343,6 +3417,7 @@ impl<Counterpart: Role> ConnectionTo<Counterpart> {
                     role_id,
                     sender: response_tx,
                     cancellation_disarm: cancellation.disarm_handle(),
+                    ordering: response_ordering.clone(),
                 };
 
                 if self
@@ -3395,6 +3470,7 @@ impl<Counterpart: Role> ConnectionTo<Counterpart> {
             self.task_tx.clone(),
             response_rx,
             cancellation,
+            response_ordering,
         )
         .map(move |json| <Req::Response>::from_value(&method, json))
     }
@@ -3895,17 +3971,21 @@ impl ResponseRouter<serde_json::Value> {
     /// When [`route_with_result`](Self::route_with_result) is called, the response is sent through the oneshot
     /// channel to the code that originally sent the request. If that receiver was
     /// dropped, the response is discarded because there is no local awaiter left.
-    pub(crate) fn new(
+    fn new(
         method: String,
         id: RequestId,
         role_id: RoleId,
         sender: oneshot::Sender<ResponsePayload>,
         cancellation_disarm: SentRequestCancellationDisarm,
+        ordering: ResponseOrdering,
+        dispatch: ResponseDispatch,
     ) -> Self {
         let reply_target = ResponseReplyTarget {
             id: id.clone(),
             method: method.clone(),
             sender: Arc::new(Mutex::new(Some(sender))),
+            ordering,
+            dispatch,
         };
         let send_target = reply_target.clone();
         // A response for the request reached this router, so the request is
@@ -4603,6 +4683,7 @@ pub struct SentRequest<T> {
     response_rx: oneshot::Receiver<ResponsePayload>,
     to_result: Box<dyn FnOnce(serde_json::Value) -> Result<T, crate::Error> + Send>,
     cancellation: SentRequestCancellation,
+    response_ordering: ResponseOrdering,
     /// Cancellation markers of other (incoming) requests whose cancellation
     /// should be forwarded to this request. See
     /// [`forward_cancellation_from`](Self::forward_cancellation_from).
@@ -4757,6 +4838,7 @@ impl SentRequest<serde_json::Value> {
         task_tx: mpsc::UnboundedSender<Task>,
         response_rx: oneshot::Receiver<ResponsePayload>,
         cancellation: SentRequestCancellation,
+        response_ordering: ResponseOrdering,
     ) -> Self {
         Self {
             id,
@@ -4765,6 +4847,7 @@ impl SentRequest<serde_json::Value> {
             task_tx,
             to_result: Box::new(Ok),
             cancellation,
+            response_ordering,
             cancellation_sources: Vec::new(),
         }
     }
@@ -4879,6 +4962,7 @@ impl<T: 'static> SentRequest<T> {
             task_tx: self.task_tx,
             to_result: Box::new(move |value| map_fn((self.to_result)(value)?)),
             cancellation: self.cancellation,
+            response_ordering: self.response_ordering,
             cancellation_sources: self.cancellation_sources,
         }
     }
@@ -4980,6 +5064,7 @@ impl<T: 'static> SentRequest<T> {
     where
         F: Future<Output = Result<(), crate::Error>> + 'static + Send,
     {
+        self.response_ordering.mark_ordered();
         let task_tx = self.task_tx.clone();
         let method = self.method;
         let response_rx = self.response_rx;
@@ -5240,6 +5325,11 @@ impl<T: 'static> SentRequest<T> {
     /// The callback runs as a spawned task, but the dispatch loop waits for it to complete
     /// before processing the next message. This gives you ordering guarantees: no other
     /// messages will be processed while your callback runs.
+    ///
+    /// Call this before the response arrives to select ordered consumption. If
+    /// the response was already routed, or an interceptor routes a retained
+    /// [`ResponseRouter`] after its original dispatch, the callback still runs
+    /// but cannot retroactively block messages that were already released.
     ///
     /// This differs from [`block_task`](Self::block_task), which signals completion immediately
     /// upon receiving the response (before your code processes it).

--- a/src/agent-client-protocol/src/jsonrpc.rs
+++ b/src/agent-client-protocol/src/jsonrpc.rs
@@ -4933,7 +4933,7 @@ impl<T> SentRequest<T> {
     }
 }
 
-impl<T: 'static> SentRequest<T> {
+impl<T> SentRequest<T> {
     /// The id of the outgoing request.
     #[must_use]
     pub fn id(&self) -> &RequestId {
@@ -4950,11 +4950,17 @@ impl<T: 'static> SentRequest<T> {
     ///
     /// The mapped type does not need to implement [`JsonRpcResponse`]. The
     /// mapper runs at most once and may consume captured state. JSON-RPC error
-    /// responses bypass the mapper.
+    /// responses bypass the mapper. The mapped type may carry a non-`'static`
+    /// lifetime when it is consumed with [`block_task`](Self::block_task);
+    /// callback-style consumption still requires a `'static` mapped type
+    /// because its work is spawned onto the connection.
     pub fn map<U>(
         self,
         map_fn: impl FnOnce(T) -> Result<U, crate::Error> + 'static + Send,
-    ) -> SentRequest<U> {
+    ) -> SentRequest<U>
+    where
+        T: 'static,
+    {
         SentRequest {
             id: self.id,
             method: self.method,
@@ -5062,6 +5068,7 @@ impl<T: 'static> SentRequest<T> {
         handle: impl FnOnce(Result<Result<T, crate::Error>, crate::Error>) -> F + 'static + Send,
     ) -> Result<(), crate::Error>
     where
+        T: 'static,
         F: Future<Output = Result<(), crate::Error>> + 'static + Send,
     {
         self.response_ordering.mark_ordered();
@@ -5356,6 +5363,7 @@ impl<T: 'static> SentRequest<T> {
         task: impl FnOnce(Result<T, crate::Error>) -> F + 'static + Send,
     ) -> Result<(), crate::Error>
     where
+        T: 'static,
         F: Future<Output = Result<(), crate::Error>> + 'static + Send,
     {
         self.consume_with(move |response| match response {

--- a/src/agent-client-protocol/src/jsonrpc/dynamic_handler.rs
+++ b/src/agent-client-protocol/src/jsonrpc/dynamic_handler.rs
@@ -37,6 +37,8 @@ impl<Counterpart: Role, H: HandleDispatchFrom<Counterpart>> DynHandleDispatchFro
 pub(crate) enum DynamicHandlerMessage<Counterpart: Role> {
     AddDynamicHandler(Uuid, Box<dyn DynHandleDispatchFrom<Counterpart>>),
     RemoveDynamicHandler(Uuid),
+    /// Marks the end of the registrations queued by an ordered response callback.
+    Barrier,
 }
 
 impl<Counterpart: Role> std::fmt::Debug for DynamicHandlerMessage<Counterpart> {
@@ -50,6 +52,7 @@ impl<Counterpart: Role> std::fmt::Debug for DynamicHandlerMessage<Counterpart> {
             Self::RemoveDynamicHandler(arg0) => {
                 f.debug_tuple("RemoveDynamicHandler").field(arg0).finish()
             }
+            Self::Barrier => f.write_str("Barrier"),
         }
     }
 }

--- a/src/agent-client-protocol/src/jsonrpc/incoming_actor.rs
+++ b/src/agent-client-protocol/src/jsonrpc/incoming_actor.rs
@@ -4,6 +4,7 @@ use futures::channel::mpsc;
 use futures::stream;
 use futures_concurrency::stream::StreamExt as _;
 use rustc_hash::FxHashMap;
+use std::collections::VecDeque;
 use uuid::Uuid;
 
 use crate::Dispatch;
@@ -20,6 +21,7 @@ use crate::jsonrpc::RawJsonRpcParams;
 use crate::jsonrpc::RequestReplyTarget;
 use crate::jsonrpc::Responder;
 use crate::jsonrpc::ResponseDestination;
+use crate::jsonrpc::ResponseDispatch;
 use crate::jsonrpc::ResponseRouter;
 use crate::jsonrpc::TransportBatchEntry;
 use crate::jsonrpc::TransportFrame;
@@ -88,7 +90,16 @@ pub(super) async fn incoming_protocol_actor<Counterpart: Role>(
     let request_cancellations = super::RequestCancellationRegistry::new();
     let mut on_close = Some(on_close);
 
-    while let Some(message_result) = my_rx.next().await {
+    let mut queued_transport_messages = VecDeque::new();
+    loop {
+        let message_result = if let Some(message) = queued_transport_messages.pop_front() {
+            message
+        } else {
+            let Some(message) = my_rx.next().await else {
+                break;
+            };
+            message
+        };
         tracing::trace!(message = ?message_result, actor = "incoming_protocol_actor");
         match message_result {
             IncomingProtocolMsg::TransportClosed => {
@@ -106,48 +117,15 @@ pub(super) async fn incoming_protocol_actor<Counterpart: Role>(
                 callback_result?;
             }
 
-            IncomingProtocolMsg::DynamicHandler(message) => match message {
-                DynamicHandlerMessage::AddDynamicHandler(uuid, mut handler) => {
-                    // Before adding the new handler, give it a chance to process
-                    // any pending messages.
-                    let mut new_pending_messages = vec![];
-                    for pending_message in pending_messages {
-                        tracing::trace!(method = pending_message.method(), handler = ?handler.dyn_describe_chain(), "Retrying message");
-                        let reply_target = pending_message.handler_error_target();
-                        let handler_attempt = reply_target.as_ref().and_then(|target| {
-                            target.begin_handler_attempt(&connection.message_tx)
-                        });
-                        let method = pending_message.method().to_string();
-                        match handler
-                            .dyn_handle_dispatch_from(pending_message, connection.clone())
-                            .await
-                        {
-                            Ok(Handled::Yes) => {
-                                tracing::trace!("Message handled");
-                            }
-                            Ok(Handled::No {
-                                message: m,
-                                retry: _,
-                            }) => {
-                                tracing::trace!(method = m.method(), handler = ?handler.dyn_describe_chain(), "Message not handled");
-                                new_pending_messages.push(m);
-                            }
-                            Err(err) => {
-                                tracing::warn!(?err, handler = ?handler.dyn_describe_chain(), "Dynamic handler errored on pending message");
-                                handle_handler_error(connection, reply_target, method, err)?;
-                            }
-                        }
-                        drop(handler_attempt);
-                    }
-                    pending_messages = new_pending_messages;
-
-                    // Add handler so it will be used for future incoming messages.
-                    dynamic_handlers.insert(uuid, handler);
-                }
-                DynamicHandlerMessage::RemoveDynamicHandler(uuid) => {
-                    dynamic_handlers.remove(&uuid);
-                }
-            },
+            IncomingProtocolMsg::DynamicHandler(message) => {
+                handle_dynamic_handler_message(
+                    message,
+                    connection,
+                    &mut dynamic_handlers,
+                    &mut pending_messages,
+                )
+                .await?;
+            }
 
             IncomingProtocolMsg::Transport(frame) => {
                 let (entries, batch_completion) = frame_entries(frame);
@@ -237,7 +215,8 @@ pub(super) async fn incoming_protocol_actor<Counterpart: Role>(
                             if let Some(pending_reply) = pending_replies.remove(&id) {
                                 let result = protocol_compat
                                     .incoming_response(&pending_reply.method, result);
-                                let dispatch = dispatch_from_response(id, pending_reply, result);
+                                let (dispatch, response_dispatch) =
+                                    dispatch_from_response(id, pending_reply, result);
                                 dispatch_dispatch(
                                     counterpart.clone(),
                                     connection,
@@ -248,6 +227,44 @@ pub(super) async fn incoming_protocol_actor<Counterpart: Role>(
                                     &request_cancellations,
                                 )
                                 .await?;
+                                if let Some(ack_rx) = response_dispatch.complete() {
+                                    let _ = ack_rx.await;
+
+                                    // Ordered callbacks may synchronously queue dynamic handlers
+                                    // (notably session routing) before acknowledging the response.
+                                    // Put a marker behind those registrations, then install every
+                                    // preceding handler before dispatching the next transport entry.
+                                    connection
+                                        .dynamic_handler_tx
+                                        .unbounded_send(DynamicHandlerMessage::Barrier)
+                                        .map_err(crate::util::internal_error)?;
+
+                                    loop {
+                                        let Some(message) = my_rx.next().await else {
+                                            return Err(crate::util::internal_error(
+                                                "dynamic-handler stream closed before its barrier",
+                                            ));
+                                        };
+                                        match message {
+                                            IncomingProtocolMsg::DynamicHandler(
+                                                DynamicHandlerMessage::Barrier,
+                                            ) => break,
+                                            IncomingProtocolMsg::DynamicHandler(message) => {
+                                                handle_dynamic_handler_message(
+                                                    message,
+                                                    connection,
+                                                    &mut dynamic_handlers,
+                                                    &mut pending_messages,
+                                                )
+                                                .await?;
+                                            }
+                                            message @ (IncomingProtocolMsg::Transport(_)
+                                            | IncomingProtocolMsg::TransportClosed) => {
+                                                queued_transport_messages.push_back(message);
+                                            }
+                                        }
+                                    }
+                                }
                             } else {
                                 tracing::warn!(
                                     ?id,
@@ -282,6 +299,58 @@ pub(super) async fn incoming_protocol_actor<Counterpart: Role>(
     Ok(())
 }
 
+async fn handle_dynamic_handler_message<Counterpart: Role>(
+    message: DynamicHandlerMessage<Counterpart>,
+    connection: &ConnectionTo<Counterpart>,
+    dynamic_handlers: &mut FxHashMap<Uuid, Box<dyn DynHandleDispatchFrom<Counterpart>>>,
+    pending_messages: &mut Vec<Dispatch>,
+) -> Result<(), crate::Error> {
+    match message {
+        DynamicHandlerMessage::AddDynamicHandler(uuid, mut handler) => {
+            // Before adding the new handler, give it a chance to process
+            // any pending messages.
+            let mut new_pending_messages = vec![];
+            for pending_message in std::mem::take(pending_messages) {
+                tracing::trace!(method = pending_message.method(), handler = ?handler.dyn_describe_chain(), "Retrying message");
+                let reply_target = pending_message.handler_error_target();
+                let handler_attempt = reply_target
+                    .as_ref()
+                    .and_then(|target| target.begin_handler_attempt(&connection.message_tx));
+                let method = pending_message.method().to_string();
+                match handler
+                    .dyn_handle_dispatch_from(pending_message, connection.clone())
+                    .await
+                {
+                    Ok(Handled::Yes) => {
+                        tracing::trace!("Message handled");
+                    }
+                    Ok(Handled::No {
+                        message: m,
+                        retry: _,
+                    }) => {
+                        tracing::trace!(method = m.method(), handler = ?handler.dyn_describe_chain(), "Message not handled");
+                        new_pending_messages.push(m);
+                    }
+                    Err(err) => {
+                        tracing::warn!(?err, handler = ?handler.dyn_describe_chain(), "Dynamic handler errored on pending message");
+                        handle_handler_error(connection, reply_target, method, err)?;
+                    }
+                }
+                drop(handler_attempt);
+            }
+            *pending_messages = new_pending_messages;
+
+            // Add handler so it will be used for future incoming messages.
+            dynamic_handlers.insert(uuid, handler);
+        }
+        DynamicHandlerMessage::RemoveDynamicHandler(uuid) => {
+            dynamic_handlers.remove(&uuid);
+        }
+        DynamicHandlerMessage::Barrier => {}
+    }
+    Ok(())
+}
+
 #[derive(Debug)]
 enum IncomingProtocolMsg<Counterpart: Role> {
     Transport(TransportFrame),
@@ -301,7 +370,7 @@ fn frame_entries(
     let entries: Vec<Result<RawJsonRpcMessage, crate::Error>> = match frame {
         TransportFrame::Single(message) => {
             let destination = matches!(&message, RawJsonRpcMessage::Request(_))
-                .then_some(ResponseDestination::Individual);
+                .then(ResponseDestination::individual);
             return (vec![(Ok(message), destination)], None);
         }
         TransportFrame::Malformed { raw, error } => {
@@ -309,7 +378,7 @@ fn frame_entries(
                 return (Vec::new(), None);
             }
             return (
-                vec![(Err(error), Some(ResponseDestination::Individual))],
+                vec![(Err(error), Some(ResponseDestination::individual()))],
                 None,
             );
         }
@@ -400,13 +469,15 @@ fn dispatch_from_response(
     id: RequestId,
     pending_reply: PendingReply,
     result: Result<serde_json::Value, crate::Error>,
-) -> Dispatch {
+) -> (Dispatch, ResponseDispatch) {
     let PendingReply {
         method,
         role_id,
         sender,
         cancellation_disarm,
+        ordering,
     } = pending_reply;
+    let response_dispatch = ResponseDispatch::default();
 
     // Create a Dispatch::Response with a ResponseRouter that routes to the oneshot
     let router = ResponseRouter::new(
@@ -415,8 +486,10 @@ fn dispatch_from_response(
         role_id,
         sender,
         cancellation_disarm,
+        ordering,
+        response_dispatch.clone(),
     );
-    Dispatch::Response(result, router)
+    (Dispatch::Response(result, router), response_dispatch)
 }
 
 #[tracing::instrument(

--- a/src/agent-client-protocol/src/session.rs
+++ b/src/agent-client-protocol/src/session.rs
@@ -209,18 +209,19 @@ where
     ///
     /// # Ordering
     ///
-    /// Session runners and routing setup are started before the dispatch loop
-    /// processes the next message when the session response is routed during
-    /// its original dispatch. The user callback then runs in a spawned task,
-    /// so it may wait for later session traffic without deadlocking the
-    /// connection. A response interceptor that retains the response and routes
-    /// it later cannot retroactively order session setup before messages the
-    /// dispatch loop has already processed.
+    /// Session runners are scheduled and routing setup is installed before the
+    /// dispatch loop processes the next message when the session response is
+    /// routed during its original dispatch. No user callback code runs under
+    /// that ordering guarantee: the callback is invoked in a spawned task, so
+    /// it may wait for later session traffic without deadlocking the connection.
+    /// A response interceptor that retains the response and routes it later
+    /// cannot retroactively order session setup before messages the dispatch
+    /// loop has already processed.
     pub fn on_session_start<F, Fut>(self, op: F) -> Result<(), crate::Error>
     where
         R: 'static,
         F: FnOnce(ActiveSession<'static, Counterpart>) -> Fut + Send + 'static,
-        Fut: Future<Output = Result<(), crate::Error>> + Send + 'static,
+        Fut: Future<Output = Result<(), crate::Error>> + Send,
     {
         let Self {
             connection,
@@ -242,7 +243,7 @@ where
                     let active_session =
                         connection.attach_session(response, dynamic_handler_registrations)?;
 
-                    connection.spawn(op(active_session))
+                    connection.spawn(async move { op(active_session).await })
                 }
             })
     }
@@ -289,10 +290,11 @@ where
     ///
     /// # Ordering
     ///
-    /// The client response, proxy routing, and session runners are set up before
-    /// the dispatch loop processes the next message when the session response
-    /// is routed during its original dispatch. The user callback then runs in a
-    /// spawned task, so it may wait for later connection traffic. A response
+    /// The client response and proxy routing are completed, and session runners
+    /// are scheduled, before the dispatch loop processes the next message when
+    /// the session response is routed during its original dispatch. No user
+    /// callback code runs under that ordering guarantee: the callback is invoked
+    /// in a spawned task, so it may wait for later connection traffic. A response
     /// interceptor that retains the response and routes it later cannot
     /// retroactively order this setup before messages the loop already processed.
     pub fn on_proxy_session_start<F, Fut>(
@@ -302,7 +304,7 @@ where
     ) -> Result<(), crate::Error>
     where
         F: FnOnce(SessionId) -> Fut + Send + 'static,
-        Fut: Future<Output = Result<(), crate::Error>> + Send + 'static,
+        Fut: Future<Output = Result<(), crate::Error>> + Send,
         Counterpart: HasPeer<Client>,
         R: 'static,
     {
@@ -337,7 +339,7 @@ where
                     .into_iter()
                     .for_each(DynamicHandlerGuard::detach);
 
-                connection.spawn(op(session_id))
+                connection.spawn(async move { op(session_id).await })
             }
         })
     }

--- a/src/agent-client-protocol/src/session.rs
+++ b/src/agent-client-protocol/src/session.rs
@@ -179,9 +179,9 @@ where
     /// without blocking the current task. The session handshake and closure execution
     /// happen in a spawned background task.
     ///
-    /// The closure receives an `ActiveSession<'static, _>` and should return
-    /// `Result<(), Error>`. If the closure returns an error, it will propagate
-    /// to the connection's error handling.
+    /// The closure receives an `ActiveSession<'static, _>` and runs in a
+    /// spawned task. If it returns an error, the error propagates to the
+    /// connection's task handling.
     ///
     /// # Example
     ///
@@ -209,13 +209,18 @@ where
     ///
     /// # Ordering
     ///
-    /// This callback blocks the dispatch loop until the session starts and your
-    /// callback completes. See the [`ordering`](crate::concepts::ordering) module for details.
+    /// Session runners and routing setup are started before the dispatch loop
+    /// processes the next message when the session response is routed during
+    /// its original dispatch. The user callback then runs in a spawned task,
+    /// so it may wait for later session traffic without deadlocking the
+    /// connection. A response interceptor that retains the response and routes
+    /// it later cannot retroactively order session setup before messages the
+    /// dispatch loop has already processed.
     pub fn on_session_start<F, Fut>(self, op: F) -> Result<(), crate::Error>
     where
         R: 'static,
         F: FnOnce(ActiveSession<'static, Counterpart>) -> Fut + Send + 'static,
-        Fut: Future<Output = Result<(), crate::Error>> + Send,
+        Fut: Future<Output = Result<(), crate::Error>> + Send + 'static,
     {
         let Self {
             connection,
@@ -237,7 +242,7 @@ where
                     let active_session =
                         connection.attach_session(response, dynamic_handler_registrations)?;
 
-                    op(active_session).await
+                    connection.spawn(op(active_session))
                 }
             })
     }
@@ -284,8 +289,12 @@ where
     ///
     /// # Ordering
     ///
-    /// This callback blocks the dispatch loop until the session starts and your
-    /// callback completes. See the [`ordering`](crate::concepts::ordering) module for details.
+    /// The client response, proxy routing, and session runners are set up before
+    /// the dispatch loop processes the next message when the session response
+    /// is routed during its original dispatch. The user callback then runs in a
+    /// spawned task, so it may wait for later connection traffic. A response
+    /// interceptor that retains the response and routes it later cannot
+    /// retroactively order this setup before messages the loop already processed.
     pub fn on_proxy_session_start<F, Fut>(
         self,
         responder: Responder<NewSessionResponse>,
@@ -293,7 +302,7 @@ where
     ) -> Result<(), crate::Error>
     where
         F: FnOnce(SessionId) -> Fut + Send + 'static,
-        Fut: Future<Output = Result<(), crate::Error>> + Send,
+        Fut: Future<Output = Result<(), crate::Error>> + Send + 'static,
         Counterpart: HasPeer<Client>,
         R: 'static,
     {
@@ -328,7 +337,7 @@ where
                     .into_iter()
                     .for_each(DynamicHandlerGuard::detach);
 
-                op(session_id).await
+                connection.spawn(op(session_id))
             }
         })
     }

--- a/src/agent-client-protocol/tests/jsonrpc_advanced.rs
+++ b/src/agent-client-protocol/tests/jsonrpc_advanced.rs
@@ -6,11 +6,14 @@
 //! - Out-of-order response handling
 
 use agent_client_protocol::{
-    ConnectionTo, JsonRpcMessage, JsonRpcRequest, JsonRpcResponse, Responder, SentRequest,
-    role::UntypedRole,
+    Channel, ConnectionTo, Dispatch, HandleDispatchFrom, Handled, JsonRpcMessage,
+    JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, RawJsonRpcMessage, Responder,
+    SentRequest, TransportBatch, TransportFrame, role::UntypedRole,
 };
-use futures::{AsyncRead, AsyncWrite};
+use futures::channel::{mpsc, oneshot};
+use futures::{AsyncRead, AsyncWrite, StreamExt as _};
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 /// Test helper to block and wait for a JSON-RPC response.
@@ -155,6 +158,73 @@ impl JsonRpcResponse for SlowResponse {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AfterResponseNotification {
+    value: u32,
+}
+
+impl JsonRpcMessage for AfterResponseNotification {
+    fn matches_method(method: &str) -> bool {
+        method == "after_response"
+    }
+
+    fn method(&self) -> &'static str {
+        "after_response"
+    }
+
+    fn to_untyped_message(
+        &self,
+    ) -> Result<agent_client_protocol::UntypedMessage, agent_client_protocol::Error> {
+        agent_client_protocol::UntypedMessage::new(self.method(), self)
+    }
+
+    fn parse_message(
+        method: &str,
+        params: &impl serde::Serialize,
+    ) -> Result<Self, agent_client_protocol::Error> {
+        if !Self::matches_method(method) {
+            return Err(agent_client_protocol::Error::method_not_found());
+        }
+        agent_client_protocol::util::json_cast(params)
+    }
+}
+
+impl JsonRpcNotification for AfterResponseNotification {}
+
+struct AfterResponseCollector {
+    notification_tx: mpsc::UnboundedSender<u32>,
+}
+
+impl HandleDispatchFrom<UntypedRole> for AfterResponseCollector {
+    async fn handle_dispatch_from(
+        &mut self,
+        message: Dispatch,
+        _connection: ConnectionTo<UntypedRole>,
+    ) -> Result<Handled<Dispatch>, agent_client_protocol::Error> {
+        if let Dispatch::Notification(notification) = &message
+            && AfterResponseNotification::matches_method(&notification.method)
+        {
+            let notification = AfterResponseNotification::parse_message(
+                &notification.method,
+                &notification.params,
+            )?;
+            self.notification_tx
+                .unbounded_send(notification.value)
+                .map_err(agent_client_protocol::Error::into_internal_error)?;
+            return Ok(Handled::Yes);
+        }
+
+        Ok(Handled::No {
+            message,
+            retry: false,
+        })
+    }
+
+    fn describe_chain(&self) -> impl std::fmt::Debug {
+        "AfterResponseCollector"
+    }
+}
+
 // ============================================================================
 // Test 1: Bidirectional communication
 // ============================================================================
@@ -213,6 +283,192 @@ async fn test_bidirectional_communication() {
             assert!(result.is_ok(), "Test failed: {result:?}");
         })
         .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn callback_consumes_response_before_following_message_is_dispatched() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let (callback_started_tx, callback_started_rx) = oneshot::channel();
+            let (release_callback_tx, release_callback_rx) = oneshot::channel();
+            let (notification_tx, mut notification_rx) = mpsc::unbounded();
+
+            let server = UntypedRole.builder().on_receive_request(
+                async |request: PingRequest,
+                       responder: Responder<PongResponse>,
+                       connection: ConnectionTo<UntypedRole>| {
+                    responder.respond(PongResponse {
+                        value: request.value + 1,
+                    })?;
+                    connection.send_notification(AfterResponseNotification {
+                        value: request.value,
+                    })
+                },
+                agent_client_protocol::on_receive_request!(),
+            );
+            let client = UntypedRole.builder().on_receive_notification(
+                async move |notification: AfterResponseNotification,
+                            _connection: ConnectionTo<UntypedRole>| {
+                    notification_tx
+                        .unbounded_send(notification.value)
+                        .map_err(agent_client_protocol::Error::into_internal_error)
+                },
+                agent_client_protocol::on_receive_notification!(),
+            );
+
+            let result = client
+                .connect_with(server, async move |connection| {
+                    connection
+                        .send_request(PingRequest { value: 41 })
+                        .on_receiving_result(async move |response| {
+                            assert_eq!(response?.value, 42);
+                            callback_started_tx
+                                .send(())
+                                .map_err(|()| agent_client_protocol::Error::internal_error())?;
+                            release_callback_rx
+                                .await
+                                .map_err(|_| agent_client_protocol::Error::internal_error())
+                        })?;
+
+                    callback_started_rx
+                        .await
+                        .map_err(|_| agent_client_protocol::Error::internal_error())?;
+                    assert!(
+                        tokio::time::timeout(Duration::from_millis(100), notification_rx.next())
+                            .await
+                            .is_err(),
+                        "the next message was dispatched before the response callback completed"
+                    );
+
+                    release_callback_tx
+                        .send(())
+                        .map_err(|()| agent_client_protocol::Error::internal_error())?;
+                    let notification =
+                        tokio::time::timeout(Duration::from_secs(10), notification_rx.next())
+                            .await
+                            .map_err(agent_client_protocol::Error::into_internal_error)?
+                            .ok_or_else(agent_client_protocol::Error::internal_error)?;
+                    assert_eq!(notification, 41);
+                    Ok(())
+                })
+                .await;
+
+            assert!(result.is_ok(), "Test failed: {result:?}");
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn unconsumed_response_does_not_block_following_message() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let (notification_tx, mut notification_rx) = mpsc::unbounded();
+            let server = UntypedRole.builder().on_receive_request(
+                async |request: PingRequest,
+                       responder: Responder<PongResponse>,
+                       connection: ConnectionTo<UntypedRole>| {
+                    responder.respond(PongResponse {
+                        value: request.value + 1,
+                    })?;
+                    connection.send_notification(AfterResponseNotification {
+                        value: request.value,
+                    })
+                },
+                agent_client_protocol::on_receive_request!(),
+            );
+            let client = UntypedRole.builder().on_receive_notification(
+                async move |notification: AfterResponseNotification,
+                            _connection: ConnectionTo<UntypedRole>| {
+                    notification_tx
+                        .unbounded_send(notification.value)
+                        .map_err(agent_client_protocol::Error::into_internal_error)
+                },
+                agent_client_protocol::on_receive_notification!(),
+            );
+
+            let result = client
+                .connect_with(server, async move |connection| {
+                    let response = connection.send_request(PingRequest { value: 7 });
+                    let notification =
+                        tokio::time::timeout(Duration::from_secs(10), notification_rx.next())
+                            .await
+                            .map_err(agent_client_protocol::Error::into_internal_error)?
+                            .ok_or_else(agent_client_protocol::Error::internal_error)?;
+                    assert_eq!(notification, 7);
+                    assert_eq!(response.block_task().await?.value, 8);
+                    Ok(())
+                })
+                .await;
+
+            assert!(result.is_ok(), "Test failed: {result:?}");
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn ordered_callback_installs_dynamic_handler_before_later_batch_entry() {
+    let (transport, mut peer) = Channel::duplex();
+    let (notification_tx, mut notification_rx) = mpsc::unbounded();
+
+    let client = UntypedRole
+        .builder()
+        .connect_with(transport, async move |connection| {
+            connection
+                .send_request(PingRequest { value: 41 })
+                .on_receiving_result({
+                    let connection = connection.clone();
+                    async move |response| {
+                        assert_eq!(response?.value, 42);
+                        connection
+                            .add_dynamic_handler(AfterResponseCollector { notification_tx })?
+                            .detach();
+                        Ok(())
+                    }
+                })?;
+
+            let notification = notification_rx
+                .next()
+                .await
+                .ok_or_else(agent_client_protocol::Error::internal_error)?;
+            assert_eq!(notification, 41);
+            Ok(())
+        });
+
+    let peer = async move {
+        let Some(TransportFrame::Single(RawJsonRpcMessage::Request(request))) =
+            peer.rx.next().await
+        else {
+            panic!("expected a ping request");
+        };
+        assert_eq!(request.method.as_ref(), "ping");
+
+        let response = RawJsonRpcMessage::response(
+            request.id,
+            Ok(serde_json::to_value(PongResponse { value: 42 })
+                .expect("ping response should serialize")),
+        );
+        let notification = RawJsonRpcMessage::notification(
+            "after_response".into(),
+            serde_json::to_value(AfterResponseNotification { value: 41 })
+                .expect("notification should serialize"),
+        )
+        .expect("notification should form valid JSON-RPC parameters");
+        let batch = TransportBatch::from_messages([response, notification])
+            .expect("test batch should be non-empty");
+        peer.tx
+            .unbounded_send(TransportFrame::Batch(batch))
+            .expect("client should accept the response batch");
+
+        while peer.rx.next().await.is_some() {}
+        Ok::<(), agent_client_protocol::Error>(())
+    };
+
+    tokio::time::timeout(Duration::from_secs(10), async {
+        futures::try_join!(client, peer)
+    })
+    .await
+    .expect("dynamic handler was not installed before the later batch entry")
+    .expect("connection failed");
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/src/agent-client-protocol/tests/jsonrpc_advanced.rs
+++ b/src/agent-client-protocol/tests/jsonrpc_advanced.rs
@@ -13,7 +13,7 @@ use agent_client_protocol::{
 use futures::channel::{mpsc, oneshot};
 use futures::{AsyncRead, AsyncWrite, StreamExt as _};
 use serde::{Deserialize, Serialize};
-use std::time::Duration;
+use std::{marker::PhantomData, time::Duration};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 /// Test helper to block and wait for a JSON-RPC response.
@@ -102,6 +102,25 @@ impl JsonRpcResponse for PongResponse {
     ) -> Result<Self, agent_client_protocol::Error> {
         agent_client_protocol::util::json_cast(&value)
     }
+}
+
+#[derive(Debug)]
+struct LifetimeTaggedResponse<'a> {
+    value: u32,
+    _scope: PhantomData<&'a ()>,
+}
+
+#[allow(clippy::elidable_lifetime_names)]
+fn map_response_with_scope(
+    request: SentRequest<PongResponse>,
+    _scope: &(),
+) -> SentRequest<LifetimeTaggedResponse<'_>> {
+    request.map(|response| {
+        Ok(LifetimeTaggedResponse {
+            value: response.value,
+            _scope: PhantomData,
+        })
+    })
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -523,6 +542,21 @@ async fn test_map_response_to_application_types() {
                             .await?;
 
                         assert_eq!(*non_send_response, 21_u32);
+
+                        let scope = ();
+                        let scoped_response = map_response_with_scope(
+                            cx.send_request(PingRequest { value: 30 }),
+                            &scope,
+                        );
+                        assert_eq!(scoped_response.method(), "ping");
+                        assert!(matches!(
+                            scoped_response.id(),
+                            agent_client_protocol::schema::v1::RequestId::Str(id)
+                                if !id.is_empty()
+                        ));
+                        let scoped_response = scoped_response.block_task().await?;
+
+                        assert_eq!(scoped_response.value, 31_u32);
                         Ok(())
                     },
                 )

--- a/src/agent-client-protocol/tests/jsonrpc_batch.rs
+++ b/src/agent-client-protocol/tests/jsonrpc_batch.rs
@@ -980,6 +980,54 @@ async fn duplicate_completion_after_batch_flush_is_ignored() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn duplicate_completion_of_individual_request_is_ignored() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let (notification_tx, _notification_rx) = mpsc::unbounded();
+            let (mut peer_writer, mut peer_reader, server_task) = start_server(notification_tx);
+
+            write_json_line(
+                &mut peer_writer,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": 27,
+                    "method": "test/echo",
+                    "params": { "message": "respond then error" }
+                }),
+            )
+            .await;
+            write_json_line(
+                &mut peer_writer,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": 28,
+                    "method": "test/echo",
+                    "params": { "message": "after duplicate completion" }
+                }),
+            )
+            .await;
+
+            let first = read_json_line(&mut peer_reader).await;
+            assert_eq!(first["id"], json!(27));
+            assert_eq!(first["result"], json!({ "result": "first response wins" }));
+
+            let barrier = read_json_line(&mut peer_reader).await;
+            assert_eq!(
+                barrier["id"],
+                json!(28),
+                "a duplicate handler-error response must not precede the next request"
+            );
+            assert_eq!(
+                barrier["result"],
+                json!({ "result": "echo: after duplicate completion" })
+            );
+
+            finish_server(peer_writer, server_task).await;
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn overlapping_batches_may_reuse_ids_without_cross_contamination() {
     tokio::task::LocalSet::new()
         .run_until(async {

--- a/src/agent-client-protocol/tests/session_ordering.rs
+++ b/src/agent-client-protocol/tests/session_ordering.rs
@@ -1,0 +1,141 @@
+use std::time::Duration;
+
+use agent_client_protocol::{
+    Agent, Channel, Client, ConnectionTo, RawJsonRpcMessage, Responder, SessionMessage,
+    TransportBatch, TransportFrame,
+    schema::v1::{
+        ContentBlock, ContentChunk, NewSessionRequest, NewSessionResponse, PromptRequest,
+        PromptResponse, SessionId, SessionNotification, SessionUpdate, StopReason, TextContent,
+    },
+};
+use futures::{StreamExt as _, channel::oneshot};
+
+const TIMEOUT: Duration = Duration::from_secs(10);
+
+#[tokio::test(flavor = "current_thread")]
+async fn on_session_start_callback_can_consume_later_session_messages() {
+    let session_id = SessionId::new("ordered-session");
+    let new_session_id = session_id.clone();
+    let prompt_session_id = session_id.clone();
+
+    let agent = Agent
+        .builder()
+        .on_receive_request(
+            async move |_request: NewSessionRequest,
+                        responder: Responder<NewSessionResponse>,
+                        _connection: ConnectionTo<Client>| {
+                responder.respond(NewSessionResponse::new(new_session_id.clone()))
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .on_receive_request(
+            async move |request: PromptRequest,
+                        responder: Responder<PromptResponse>,
+                        connection: ConnectionTo<Client>| {
+                assert_eq!(request.session_id, prompt_session_id);
+                connection.send_notification(SessionNotification::new(
+                    request.session_id,
+                    SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::Text(
+                        TextContent::new("ordered response"),
+                    ))),
+                ))?;
+                responder.respond(PromptResponse::new(StopReason::EndTurn))
+            },
+            agent_client_protocol::on_receive_request!(),
+        );
+
+    let (result_tx, result_rx) = oneshot::channel();
+    let client = Client
+        .builder()
+        .connect_with(agent, async move |connection| {
+            connection
+                .build_session_cwd()?
+                .on_session_start(async move |mut session| {
+                    session.send_prompt("test ordering")?;
+                    let text = session.read_to_string().await?;
+                    result_tx
+                        .send(text)
+                        .map_err(|_| agent_client_protocol::Error::internal_error())
+                })?;
+
+            let text = result_rx
+                .await
+                .map_err(|_| agent_client_protocol::Error::internal_error())?;
+            assert_eq!(text, "ordered response");
+            Ok(())
+        });
+
+    tokio::time::timeout(TIMEOUT, client)
+        .await
+        .expect("session callback deadlocked the incoming dispatch loop")
+        .expect("session connection failed");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn on_session_start_installs_routing_before_later_batch_entry() {
+    let session_id = SessionId::new("same-batch-session");
+    let response_session_id = session_id.clone();
+    let notification_session_id = session_id.clone();
+    let (transport, mut peer) = Channel::duplex();
+    let (result_tx, result_rx) = oneshot::channel();
+
+    let client = Client
+        .builder()
+        .connect_with(transport, async move |connection| {
+            connection
+                .build_session_cwd()?
+                .on_session_start(async move |mut session| {
+                    let update = session.read_update().await?;
+                    assert!(matches!(update, SessionMessage::SessionMessage(_)));
+                    result_tx
+                        .send(())
+                        .map_err(|()| agent_client_protocol::Error::internal_error())
+                })?;
+
+            result_rx
+                .await
+                .map_err(|_| agent_client_protocol::Error::internal_error())?;
+            Ok(())
+        });
+
+    let peer = async move {
+        let Some(TransportFrame::Single(RawJsonRpcMessage::Request(request))) =
+            peer.rx.next().await
+        else {
+            panic!("expected a session/new request");
+        };
+        assert_eq!(request.method.as_ref(), "session/new");
+
+        let response = RawJsonRpcMessage::response(
+            request.id,
+            Ok(
+                serde_json::to_value(NewSessionResponse::new(response_session_id))
+                    .expect("session response should serialize"),
+            ),
+        );
+        let notification = RawJsonRpcMessage::notification(
+            "session/update".into(),
+            serde_json::to_value(SessionNotification::new(
+                notification_session_id,
+                SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::Text(
+                    TextContent::new("same batch"),
+                ))),
+            ))
+            .expect("session notification should serialize"),
+        )
+        .expect("session notification should form valid JSON-RPC parameters");
+        let batch = TransportBatch::from_messages([response, notification])
+            .expect("test batch should be non-empty");
+        peer.tx
+            .unbounded_send(TransportFrame::Batch(batch))
+            .expect("client should accept the response batch");
+
+        while peer.rx.next().await.is_some() {}
+        Ok::<(), agent_client_protocol::Error>(())
+    };
+
+    tokio::time::timeout(TIMEOUT, async { futures::try_join!(client, peer) })
+        .await
+        .expect("same-batch session update was not routed")
+        .expect("session connection failed");
+}

--- a/src/agent-client-protocol/tests/session_ordering.rs
+++ b/src/agent-client-protocol/tests/session_ordering.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
 use agent_client_protocol::{
-    Agent, Channel, Client, ConnectionTo, RawJsonRpcMessage, Responder, SessionMessage,
-    TransportBatch, TransportFrame,
+    ActiveSession, Agent, Channel, Client, Conductor, ConnectionTo, RawJsonRpcMessage, Responder,
+    SessionMessage, TransportBatch, TransportFrame,
     schema::v1::{
         ContentBlock, ContentChunk, NewSessionRequest, NewSessionResponse, PromptRequest,
         PromptResponse, SessionId, SessionNotification, SessionUpdate, StopReason, TextContent,
@@ -11,6 +11,61 @@ use agent_client_protocol::{
 use futures::{StreamExt as _, channel::oneshot};
 
 const TIMEOUT: Duration = Duration::from_secs(10);
+
+// Compile-time regressions for the callback future bounds on the two non-blocking
+// session helpers. The callbacks themselves are `'static`, but their future
+// types deliberately carry an arbitrary shorter lifetime.
+#[allow(dead_code)]
+mod callback_future_lifetimes {
+    use std::{
+        future::Future,
+        marker::PhantomData,
+        pin::Pin,
+        task::{Context, Poll},
+    };
+
+    use super::*;
+
+    struct LifetimeTaggedFuture<'a>(PhantomData<&'a ()>);
+
+    impl Future for LifetimeTaggedFuture<'_> {
+        type Output = Result<(), agent_client_protocol::Error>;
+
+        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    fn session_callback<'a>()
+    -> impl FnOnce(ActiveSession<'static, Agent>) -> LifetimeTaggedFuture<'a> + Send + 'static {
+        |_session| LifetimeTaggedFuture(PhantomData)
+    }
+
+    fn proxy_session_callback<'a>()
+    -> impl FnOnce(SessionId) -> LifetimeTaggedFuture<'a> + Send + 'static {
+        |_session_id| LifetimeTaggedFuture(PhantomData)
+    }
+
+    fn on_session_start_accepts_non_static_callback_future<'a>(
+        connection: &ConnectionTo<Agent>,
+        _scope: &'a str,
+    ) -> Result<(), agent_client_protocol::Error> {
+        connection
+            .build_session_cwd()?
+            .on_session_start(session_callback::<'a>())
+    }
+
+    fn on_proxy_session_start_accepts_non_static_callback_future<'a>(
+        connection: &ConnectionTo<Conductor>,
+        request: NewSessionRequest,
+        responder: Responder<NewSessionResponse>,
+        _scope: &'a str,
+    ) -> Result<(), agent_client_protocol::Error> {
+        connection
+            .build_session_from(request)
+            .on_proxy_session_start(responder, proxy_session_callback::<'a>())
+    }
+}
 
 #[tokio::test(flavor = "current_thread")]
 async fn on_session_start_callback_can_consume_later_session_messages() {


### PR DESCRIPTION
Honor ordered response callbacks without stalling unconsumed or delayed routes, install callback-queued handlers before later frames, and suppress duplicate individual responses.

Install session routing under the ordered response barrier, then invoke user session work in connection-owned spawned tasks so it can wait for later traffic without deadlocking. Preserve non-`'static` session callback future types and document that only framework-owned setup is ordered.

Allow mapped `SentRequest` values carrying non-`'static` lifetimes to be inspected and consumed with `block_task`; spawned callback consumers still require `'static`.

BREAKING CHANGE: `on_session_start` and `on_proxy_session_start` now invoke user callbacks in spawned connection tasks after ordered framework setup. User callback work is no longer completed before later messages are dispatched.
