### PR TITLE
refactor(acp)!: remove obsolete public helpers

### DIFF
--- a/md/migration_v2.0.md
+++ b/md/migration_v2.0.md
@@ -243,6 +243,16 @@ separately.
 
 ## Low-level helpers have a narrower surface
 
+`NullHandler::new` was removed. Construct the unit struct as `NullHandler` or use
+`NullHandler::default()`.
+
+`MatchDispatch::from_handled` was removed because it exposed an internal composition state. Start
+a standalone match with `MatchDispatch::new`, or continue a peer-aware chain with
+`MatchDispatchFrom`.
+
+`Channel::copy` is now an implementation detail. Connect channels through `ConnectTo`, or use
+`Channel::bridge_with_inspection` when building an inspecting relay.
+
 `DynConnectTo::type_name` now returns `&'static str` without allocating. Call `.to_owned()` when
 an owned type name is required.
 

--- a/src/agent-client-protocol/CHANGELOG.md
+++ b/src/agent-client-protocol/CHANGELOG.md
@@ -46,6 +46,9 @@
   guide].
 - **Breaking:** Narrow low-level helpers by borrowing `DynConnectTo` type names, hiding transport
   fields and session/stream internals, and removing `util::both`. See the [2.0 migration guide].
+- **Breaking:** Remove the obsolete `NullHandler::new` and `MatchDispatch::from_handled`
+  constructors, and make `Channel::copy` an implementation detail. See the
+  [2.0 migration guide].
 - **Breaking:** Replace the MCP wire-schema configuration accepted by `AcpAgent` with the SDK-local
   `AcpAgentConfig`; use `config()` and `into_config()`, and represent JSON environment variables as
   an object. See the [2.0 migration guide].

--- a/src/agent-client-protocol/src/jsonrpc.rs
+++ b/src/agent-client-protocol/src/jsonrpc.rs
@@ -5657,7 +5657,7 @@ impl Channel {
     /// # Errors
     ///
     /// Returns an error if the receiving endpoint closes before the input.
-    pub async fn copy(mut self) -> Result<(), crate::Error> {
+    pub(crate) async fn copy(mut self) -> Result<(), crate::Error> {
         while let Some(frame) = self.rx.next().await {
             self.tx
                 .unbounded_send(frame)

--- a/src/agent-client-protocol/src/jsonrpc/handlers.rs
+++ b/src/agent-client-protocol/src/jsonrpc/handlers.rs
@@ -11,17 +11,9 @@ use std::ops::AsyncFnMut;
 #[derive(Debug)]
 pub struct NullHandler;
 
-impl NullHandler {
-    /// Creates a new null handler.
-    #[must_use]
-    pub fn new() -> Self {
-        Self
-    }
-}
-
 impl Default for NullHandler {
     fn default() -> Self {
-        Self::new()
+        Self
     }
 }
 

--- a/src/agent-client-protocol/src/util/typed.rs
+++ b/src/agent-client-protocol/src/util/typed.rs
@@ -86,14 +86,6 @@ impl MatchDispatch {
         }
     }
 
-    /// Create a pattern matcher from an existing `Handled` state.
-    ///
-    /// This is useful when composing with [`MatchDispatchFrom`] which applies
-    /// peer transforms before delegating to `MatchDispatch` for parsing.
-    pub fn from_handled(state: Result<Handled<Dispatch>, crate::Error>) -> Self {
-        Self { state }
-    }
-
     /// Try to handle the message as a request of type `Req`.
     ///
     /// If the message can be parsed as `Req`, the handler `op` is called with the parsed


### PR DESCRIPTION
- keep the frame-copy loop internal to the core crate
- remove the unused handled-state matcher constructor
- remove the redundant constructor for the null unit handler
- document direct migration alternatives for all three changes

These helpers expose implementation details or duplicate simpler public construction paths. Removing them before 2.0 keeps the supported API focused without changing runtime behavior.

BREAKING CHANGE: `Channel::copy` is no longer public, and `MatchDispatch::from_handled` and `NullHandler::new` are removed. The migration guide documents the supported replacements.