### PR TITLE
docs(acp): clarify response and session ordering

### DIFF
--- a/md/migration_v2.0.md
+++ b/md/migration_v2.0.md
@@ -7,6 +7,22 @@ explicit, and gives `AcpAgent` an SDK-owned process-launch configuration instead
 wire-schema type. It also replaces the SDK-local MCP-over-ACP wire extension with the shared
 schema's opt-in native transport.
 
+## Compatible crate versions
+
+Most published workspace crates move to the 2.x version family together. The rmcp integration
+moves to 3.x because both `agent-client-protocol` and `rmcp` are public dependencies in its API:
+
+| Crate | Version compatible with `agent-client-protocol` 2.x |
+| --- | --- |
+| `agent-client-protocol` | 2.x |
+| `agent-client-protocol-derive` | 2.x |
+| `agent-client-protocol-conductor` | 2.x |
+| `agent-client-protocol-cookbook` | 2.x |
+| `agent-client-protocol-http` | 2.x |
+| `agent-client-protocol-polyfill` | 2.x |
+| `agent-client-protocol-trace-viewer` | 2.x |
+| `agent-client-protocol-rmcp` | 3.x |
+
 ## Notifications cannot receive error responses
 
 The SDK no longer exposes `ConnectionTo::send_error_notification`, and
@@ -111,6 +127,29 @@ Its methods have therefore been renamed:
 If a catch-all response handler returns `Err`, that error is now routed to the local
 `SentRequest` awaiter. It is never serialized as a response to the peer's response. This replaces
 the misleading generic failure that previously appeared when the real interceptor error was lost.
+
+## Response callbacks enforce ordered dispatch
+
+The 1.x documentation said that `on_receiving_result` and `on_receiving_ok_result` callbacks held
+the dispatch loop until completion, but the implementation did not enforce that ordering. In 2.0,
+registering either callback before a peer response is routed during its original dispatch selects
+ordered consumption: registration returns immediately, then the loop waits for response handling
+to finish before processing the next message.
+
+This is a behavioral change. An ordered response callback must not await a later response,
+notification, or other inbound traffic on the same connection, because the loop cannot dispatch
+that traffic until the callback returns. Spawn that follow-up work and return from the callback,
+or use `block_task` from a task that already runs outside the dispatch loop, such as the foreground
+future passed to `connect_with`.
+
+The barrier is not retroactive. A pending-request failure delivered without an incoming response
+(such as EOF), a response that was already routed, or a retained `ResponseRouter` routed after its
+original dispatch runs without holding the loop.
+
+Session-start helpers apply this barrier only to framework-owned runner and routing installation,
+then spawn the user callback. This preserves the actual 1.x scheduling behavior for user session
+work while correcting the old documentation that claimed the user callback itself blocked
+dispatch.
 
 ## Request IDs remain typed
 
@@ -265,10 +304,10 @@ Pass a finite limit instead of `None` to bound concurrency.
 `ConnectionTo::build_session`, `build_session_cwd`, or `build_session_from` instead. Use
 `SessionBuilder::on_session_start` to start without blocking the calling task, or call
 `block_task()` followed by `run_until` or `start_session` outside message handlers. Proxy handlers
-must use `on_proxy_session_start`; only call `block_task().start_session_proxy(...)` from an
-already-spawned task. Directly attaching an already-returned `NewSessionResponse` is no longer
-supported, so move request customization into `build_session_from` before the builder sends
-`session/new`.
+must use `on_proxy_session_start`; only call `block_task().start_session_proxy(...)` from a task
+already outside the dispatch loop, such as a `connect_with` foreground future or a spawned task.
+Directly attaching an already-returned `NewSessionResponse` is no longer supported, so move
+request customization into `build_session_from` before the builder sends `session/new`.
 
 When the session response is routed during its original dispatch, `on_session_start` and
 `on_proxy_session_start` install session routing under the ordered response callback, then spawn
@@ -277,7 +316,9 @@ must be `'static`, but its returned future does not need an additional `'static`
 safely wait for later connection or session traffic. A response interceptor that retains and
 routes the response later cannot retroactively order that setup before already-processed messages.
 Register application state needed for routing before calling these helpers. Bookkeeping that
-requires the returned session or session ID runs concurrently with later traffic.
+requires the returned session or session ID runs concurrently with later traffic. If handlers
+must observe ID-keyed bookkeeping first, install a gate or placeholder before calling the helper,
+have those handlers await it, and populate it from the callback.
 
 Construct `Lines` and `ByteStreams` with `Lines::new(outgoing, incoming)` and
 `ByteStreams::new(outgoing, incoming)`; their stream fields are no longer public.

--- a/src/agent-client-protocol-cookbook/src/lib.rs
+++ b/src/agent-client-protocol-cookbook/src/lib.rs
@@ -191,9 +191,10 @@ pub mod connecting_as_client {
     //!
     //! # Note on `block_task`
     //!
-    //! Using [`block_task`] is safe inside `connect_with` because the closure runs
-    //! as a spawned task, not on the event loop. The event loop continues processing
-    //! messages (including the response you're waiting for) while your task blocks.
+    //! Using [`block_task`] is safe inside `connect_with` because its foreground
+    //! future runs alongside, rather than inside, the dispatch loop. The loop
+    //! continues processing messages (including the response you're waiting for)
+    //! while the foreground future waits.
     //!
     //! [`connect_with`]: agent_client_protocol::Builder::connect_with
     //! [`block_task`]: agent_client_protocol::SentRequest::block_task
@@ -365,10 +366,11 @@ pub mod reusable_components {
     //! # Important: Don't block the event loop
     //!
     //! Message handlers run on the event loop. Blocking in a handler prevents the
-    //! connection from processing new messages. For expensive work:
+    //! connection from processing new messages:
     //!
     //! - Use [`ConnectionTo::spawn`] to offload work to a background task
-    //! - Use [`on_receiving_result`] to schedule work when a response arrives
+    //! - Use [`on_receiving_result`] for bounded, ordered response handling; if it
+    //!   must await later traffic, spawn that work from the callback and return
     //!
     //! [`ConnectTo`]: agent_client_protocol::ConnectTo
     //! [`ConnectionTo::spawn`]: agent_client_protocol::ConnectionTo::spawn
@@ -549,9 +551,9 @@ pub mod global_mcp_server {
     //! handler. It:
     //!
     //! 1. Intercepts session setup requests and adds a schema-native
-    //!    `McpServer::Acp` declaration with a unique server ID to each request's
-    //!    `mcp_servers` list (`session/new`, `session/load`, `session/resume`, and
-    //!    feature-gated `session/fork`)
+    //!    `McpServer::Acp` declaration with one connection-scoped server ID,
+    //!    reused in each request's `mcp_servers` list (`session/new`,
+    //!    `session/load`, `session/resume`, and feature-gated `session/fork`)
     //! 2. Passes the modified request through to the next handler
     //! 3. Handles `mcp/connect`, `mcp/message`, and `mcp/disconnect` for that server ID
     //!
@@ -571,7 +573,7 @@ pub mod per_session_mcp_server {
     //! # When to use
     //!
     //! - Tools need access to the session's working directory
-    //! - You want to track active sessions or maintain per-session state
+    //! - You want eventual active-session tracking that does not need to precede later traffic
     //! - Tools need to customize behavior based on session parameters
     //!
     //! # Basic pattern with `on_proxy_session_start`
@@ -608,8 +610,9 @@ pub mod per_session_mcp_server {
     //!                     // Session proxying is installed before this callback is spawned.
     //!                     //
     //!                     // Use this for follow-up work that may wait for later connection
-    //!                     // traffic. Perform synchronous bookkeeping in the request handler
-    //!                     // itself when it must precede every later message.
+    //!                     // traffic. Register ID-independent state in the request handler.
+    //!                     // For ID-keyed state, preinstall a gate that later handlers await,
+    //!                     // then populate it here.
     //!                     tracing::info!(%session_id, "Session started");
     //!                     Ok(())
     //!                 })
@@ -629,8 +632,12 @@ pub mod per_session_mcp_server {
     //! 4. Runs your callback with the `SessionId`
     //!
     //! The callback runs after the session is established but doesn't block
-    //! the message handler. This is ideal for proxies that just need to inject
-    //! tools and track sessions.
+    //! the message handler. It is suitable for follow-up work and eventual
+    //! session tracking. Because it runs concurrently with later traffic, it
+    //! does not guarantee that bookkeeping keyed by `SessionId` completes
+    //! first. Register ID-independent state before calling the helper. For
+    //! ID-keyed state, preinstall a gate or placeholder that later handlers
+    //! await, then populate it from the callback.
     //!
     //! # Alternative: spawning `start_session_proxy`
     //!

--- a/src/agent-client-protocol/CHANGELOG.md
+++ b/src/agent-client-protocol/CHANGELOG.md
@@ -51,6 +51,12 @@
   an object. See the [2.0 migration guide].
 - **Breaking:** Remove the deprecated `zed_claude_code` and `zed_codex` constructors and the
   `google_gemini` convenience constructor from `AcpAgent`. See the [2.0 migration guide].
+- **Breaking:** Enforce ordered dispatch for `on_receiving_result` and
+  `on_receiving_ok_result` callbacks selected before a peer response is routed during its original
+  dispatch. Registration still returns immediately, but the callback now delays later messages
+  and must not await later traffic on the same connection. Session-start helpers use the barrier
+  only for framework-owned setup, then run user work concurrently; the old documentation claiming
+  that session user callbacks blocked dispatch was inaccurate. See the [2.0 migration guide].
 - Update `agent-client-protocol-schema` to 1.5.0. The stable v1 schema remains compatible; the
   opt-in draft v2 API gains semantic newtypes, revised diff and terminal types, and generic
   fallible conversion helpers. See the
@@ -58,10 +64,9 @@
 
 **Fixed**
 
-- Honor `on_receiving_result` ordering when callback consumption is selected before a response
-  arrives, without stalling unconsumed, blocking, or delayed response routes. Session-start
-  helpers now install their routing state under that ordering barrier for responses routed during
-  their original dispatch, and run user session work in a spawned task.
+- Install framework-owned session and proxy routing before later messages when a session response
+  is routed during its original dispatch. User session work remains concurrent so it can consume
+  later traffic without deadlocking.
 - Emit at most one response for an individual request when a handler responds and then returns an
   error, matching the existing per-entry completion behavior for batches.
 - Preserve JSON-RPC batch framing across component adapters, protocol routing, and tracing

--- a/src/agent-client-protocol/src/concepts/cancellation.rs
+++ b/src/agent-client-protocol/src/concepts/cancellation.rs
@@ -77,9 +77,10 @@
 //! request work instead.
 //!
 //! Cancellation markers are only updated when the connection can process the
-//! incoming `$/cancel_request` notification. Long-running handlers should
-//! return quickly and move work into [`ConnectionTo::spawn`], [`SentRequest`]
-//! callbacks, or another task; see the [ordering](super::ordering) chapter.
+//! incoming `$/cancel_request` notification. Long-running handlers and ordered
+//! [`SentRequest`] callbacks should return quickly and move work into
+//! [`ConnectionTo::spawn`] or another task; see the
+//! [ordering](super::ordering) chapter.
 //!
 //! # Proxies
 //!

--- a/src/agent-client-protocol/src/concepts/ordering.rs
+++ b/src/agent-client-protocol/src/concepts/ordering.rs
@@ -14,15 +14,18 @@
 //! before processing the next message.** This gives you sequential ordering
 //! guarantees within a single connection.
 //!
-//! # `on_*` Methods Block the Loop
+//! # Ordered Callbacks Hold the Loop
 //!
-//! Methods whose names begin with `on_` register callbacks that run inside
-//! the dispatch loop. When your callback is invoked, the loop is blocked
-//! until your callback completes.
+//! Request and notification callbacks registered with [`on_receive_request`]
+//! and [`on_receive_notification`] run inside the dispatch loop. The loop is
+//! blocked until the callback completes.
 //!
-//! This includes:
-//! - [`on_receive_request`] and [`on_receive_notification`]
-//! - [`on_receiving_result`] and [`on_receiving_ok_result`]
+//! Registering [`on_receiving_result`] or [`on_receiving_ok_result`] returns
+//! immediately. If registration happens before a peer response is routed
+//! during its original dispatch, response handling then holds an ordering
+//! barrier until the callback completes. A pending-request failure delivered
+//! without an incoming response, or a response routed later, does not carry
+//! that barrier.
 //!
 //! Session-start helpers are two-phase: [`on_session_start`] and
 //! [`on_proxy_session_start`] perform framework-owned session setup under this
@@ -30,15 +33,15 @@
 //! can consume later session traffic. No user callback code runs under the
 //! session-setup ordering guarantee.
 //!
-//! For callbacks that run inside the dispatch loop, this means:
+//! While a callback holds the dispatch loop, this means:
 //! - No other messages are processed while your callback runs
 //! - You can safely do setup before "releasing" control back to the loop
 //! - Messages are processed in the order they arrive
 //!
 //! # Deadlock Risk
 //!
-//! Because `on_*` callbacks block the dispatch loop, it's easy to create
-//! deadlocks. The most common pattern:
+//! Because callbacks can hold the dispatch loop, it's easy to create deadlocks.
+//! The most common pattern:
 //!
 //! ```ignore
 //! // DEADLOCK: This blocks the loop waiting for a response,
@@ -58,9 +61,10 @@
 //!
 //! When you send a request, you get a [`SentRequest`] with two ways to handle it:
 //!
-//! ## `block_task()` - Acks immediately, you process later
+//! ## `block_task()` - Does not hold dispatch while you process
 //!
-//! Use this in spawned tasks where you need to wait for the response:
+//! Use this from a task that already runs outside the dispatch loop, such as a
+//! foreground `connect_with` future or a spawned task:
 //!
 //! ```
 //! # use agent_client_protocol::{Client, Agent, ConnectTo};
@@ -87,7 +91,7 @@
 //! The dispatch loop continues immediately after delivering the response.
 //! Your code receives the response and can take as long as it wants.
 //!
-//! ## `on_receiving_result()` - Your callback blocks the loop
+//! ## `on_receiving_result()` - A peer response callback can hold the loop
 //!
 //! Use this when you need ordering guarantees:
 //!
@@ -98,7 +102,7 @@
 //! # Client.builder().connect_with(transport, async |cx| {
 //! cx.send_request(MyRequest {})
 //!     .on_receiving_result(async |result| {
-//!         // Dispatch loop is blocked until this completes
+//!         // A timely peer response holds dispatch until this completes
 //!         let response = result?;
 //!         // Do something with response...
 //!         Ok(())
@@ -109,13 +113,16 @@
 //! # }
 //! ```
 //!
-//! The dispatch loop waits for your callback to complete before processing
-//! the next message. Use this when you need to ensure no other messages
-//! are processed until you've handled the response.
+//! Register the callback before a peer response is routed to select this
+//! ordered mode. The dispatch loop then waits for your callback before
+//! processing the next message. A pending-request failure delivered without
+//! an incoming response (such as EOF), a response that was already routed, or
+//! one that an interceptor retains and routes after its original dispatch does
+//! not carry the barrier.
 //!
-//! Register the callback before the response arrives to select this ordered
-//! mode. A response that was already routed, or that an interceptor retains
-//! and routes after its original dispatch, cannot retroactively hold the loop.
+//! An ordered callback must not wait for later inbound traffic on the same
+//! connection. Spawn that follow-up work and return from the callback so the
+//! loop can continue.
 //!
 //! # Escaping the Loop: `spawn`
 //!
@@ -135,10 +142,13 @@
 //! }, on_receive_request!());
 //! ```
 //!
-//! # `run_until` Methods
+//! # Blocking Session Methods
 //!
-//! Methods named `run_until` (like on session builders) run in a spawned task,
-//! so awaiting them won't cause deadlocks:
+//! `SessionBuilder::run_until` does not spawn its caller. It waits for the
+//! session response on the current task, so call it only when that task already
+//! runs outside the dispatch loop—for example, from the foreground future
+//! passed to `connect_with` or from a task created with [`spawn`]. Awaiting it
+//! from a message handler deadlocks just like awaiting `block_task()` there.
 //!
 //! ```
 //! # use agent_client_protocol::{Client, Agent, ConnectTo};
@@ -147,7 +157,7 @@
 //! cx.build_session_cwd()?
 //!     .block_task()
 //!     .run_until(async |mut session| {
-//!         // Safe to await here - we're in a spawned task
+//!         // Safe: connect_with's foreground future runs outside the dispatch loop
 //!         session.send_prompt("Hello")?;
 //!         let response = session.read_to_string().await?;
 //!         Ok(())
@@ -163,12 +173,12 @@
 //!
 //! | Pattern | Blocks Loop? | Use When |
 //! |---------|--------------|----------|
-//! | `on_*` callback | Yes | Quick decisions, need ordering |
-//! | `on_receiving_result` | Yes | Need to process response before next message |
+//! | `on_receive_*` callback | Yes | Handle one incoming message |
+//! | `on_receiving_*` callback | For a timely peer response | Bounded response work that needs ordering |
 //! | `on_session_start` / `on_proxy_session_start` | Setup only | Install session routing, then run session work concurrently |
-//! | `block_task()` | No | In spawned tasks, need response value |
+//! | `block_task()` | If awaited in a handler | Wait for a response from outside the dispatch loop |
 //! | `spawn(...)` | No | Long-running work, don't need ordering |
-//! | `block_task().run_until(...)` | No | Session-scoped work |
+//! | `block_task().run_until(...)` | If called in a handler | Session-scoped work from outside the dispatch loop |
 //!
 //! # Next Steps
 //!

--- a/src/agent-client-protocol/src/jsonrpc.rs
+++ b/src/agent-client-protocol/src/jsonrpc.rs
@@ -3312,13 +3312,13 @@ impl<Counterpart: Role> ConnectionTo<Counterpart> {
 
     /// Send an outgoing request and return a [`SentRequest`] for handling the reply.
     ///
-    /// The returned [`SentRequest`] provides methods for receiving the response without
-    /// blocking the event loop:
+    /// The returned [`SentRequest`] makes the response-consumption mode explicit:
     ///
-    /// * [`on_receiving_result`](SentRequest::on_receiving_result) - Schedule
-    ///   a callback to run when the response arrives (doesn't block the event loop)
-    /// * [`block_task`](SentRequest::block_task) - Block the current task until the response
-    ///   arrives (only safe in spawned tasks, not in handlers)
+    /// * [`on_receiving_result`](SentRequest::on_receiving_result) - Register a callback and
+    ///   return immediately. If registered before the response is routed during its original
+    ///   dispatch, the loop waits for the callback to complete.
+    /// * [`block_task`](SentRequest::block_task) - Wait on the current task until the response
+    ///   arrives. This is only safe when that task already runs outside the dispatch loop.
     ///
     /// # Anti-Footgun Design
     ///
@@ -3337,7 +3337,7 @@ impl<Counterpart: Role> ConnectionTo<Counterpart> {
     /// ```no_run
     /// # use agent_client_protocol_test::*;
     /// # async fn example(cx: agent_client_protocol::ConnectionTo<agent_client_protocol::UntypedRole>) -> Result<(), agent_client_protocol::Error> {
-    /// // ✅ Option 1: Schedule callback (safe in handlers)
+    /// // ✅ Option 1: Register an ordered callback (safe in handlers)
     /// cx.send_request(MyRequest {})
     ///     .on_receiving_result(async |result| {
     ///         // Handle the response
@@ -4578,19 +4578,21 @@ impl JsonRpcNotification for UntypedMessage {}
 
 /// Represents a pending response of type `R` from an outgoing request.
 ///
-/// Returned by [`ConnectionTo::send_request`], this type provides methods for handling
-/// the response without blocking the event loop. The API is intentionally designed to make
-/// it difficult to accidentally block.
+/// Returned by [`ConnectionTo::send_request`], this type provides explicit response-consumption
+/// modes. The API is intentionally designed to make it difficult to accidentally wait for a
+/// response inside the dispatch loop.
 ///
 /// # Anti-Footgun Design
 ///
 /// You cannot directly `.await` a `SentRequest`. Instead, you must choose how to handle
 /// the response:
 ///
-/// ## Option 1: Schedule a Callback (Safe in Handlers)
+/// ## Option 1: Register an Ordered Callback (Safe in Handlers)
 ///
-/// Use [`on_receiving_result`](Self::on_receiving_result) to schedule a task
-/// that runs when the response arrives. This doesn't block the event loop:
+/// Calling [`on_receiving_result`](Self::on_receiving_result) registers the callback and returns
+/// immediately. When ordered consumption is selected before the response is routed during its
+/// original dispatch, the loop waits for the callback to complete before processing the next
+/// message:
 ///
 /// ```no_run
 /// # use agent_client_protocol_test::*;
@@ -4612,10 +4614,11 @@ impl JsonRpcNotification for UntypedMessage {}
 /// # }
 /// ```
 ///
-/// ## Option 2: Block in a Spawned Task (Safe Only in `spawn`)
+/// ## Option 2: Wait Outside the Dispatch Loop
 ///
-/// Use [`block_task`](Self::block_task) to block until the response arrives, but **only**
-/// in a spawned task (never in a handler):
+/// Use [`block_task`](Self::block_task) only when the current task already runs outside the
+/// dispatch loop—for example, in the foreground future passed to `connect_with` or in a task
+/// created with [`ConnectionTo::spawn`]. Never await it in a handler:
 ///
 /// ```no_run
 /// # use agent_client_protocol_test::*;
@@ -5120,11 +5123,12 @@ impl<T> SentRequest<T> {
 
     /// Block the current task until the response is received.
     ///
-    /// **Warning:** This method blocks the current async task. It is **only safe** to use
-    /// in spawned tasks created with [`ConnectionTo::spawn`]. Using it directly in a
+    /// **Warning:** This method blocks the current async task. It is safe only when that task
+    /// already runs outside the dispatch loop, such as the foreground future passed to
+    /// `connect_with` or a task created with [`ConnectionTo::spawn`]. Using it directly in a
     /// handler callback will deadlock the connection.
     ///
-    /// # Safe Usage (in spawned tasks)
+    /// # Safe Usage (outside the dispatch loop)
     ///
     /// ```no_run
     /// # use agent_client_protocol_test::*;
@@ -5175,7 +5179,7 @@ impl<T> SentRequest<T> {
     /// # When to Use
     ///
     /// Use this method when:
-    /// - You're in a spawned task (via [`ConnectionTo::spawn`])
+    /// - Your current task already runs outside the dispatch loop
     /// - You need the response value to proceed with your logic
     /// - Linear control flow is more natural than callbacks
     ///
@@ -5193,8 +5197,8 @@ impl<T> SentRequest<T> {
                 result: Ok(json_value),
                 ack_tx,
             }) => {
-                // Ack immediately - we're in a spawned task, so the dispatch loop
-                // can continue while we process the value.
+                // Blocking consumers ack before converting or returning the
+                // value, so dispatch can continue while the caller processes it.
                 if let Some(tx) = ack_tx {
                     let _ = tx.send(());
                 }
@@ -5259,9 +5263,12 @@ impl<T> SentRequest<T> {
     ///
     /// # Ordering
     ///
-    /// Like [`on_receiving_result`](Self::on_receiving_result), the callback blocks the
-    /// dispatch loop until it completes. See the [`ordering`](crate::concepts::ordering) module
-    /// for details.
+    /// Like [`on_receiving_result`](Self::on_receiving_result), response handling holds the
+    /// dispatch loop through callback completion when ordered consumption is selected before a
+    /// peer response is routed during its original dispatch. Pending-request failures delivered
+    /// without an incoming response and delayed routes do not carry that barrier. The callback
+    /// must not await later inbound traffic on the same connection. See the
+    /// [`ordering`](crate::concepts::ordering) module for details.
     ///
     /// # When to Use
     ///
@@ -5287,10 +5294,12 @@ impl<T> SentRequest<T> {
         })
     }
 
-    /// Schedule an async task to run when the response is received.
+    /// Register an async callback to run when the response is received.
     ///
-    /// This is the recommended way to handle responses in handler callbacks, as it doesn't
-    /// block the event loop. The task will be spawned automatically when the response arrives.
+    /// This is the recommended way to select response handling from inside a handler because
+    /// registration returns immediately. The response-consumption task waits concurrently for
+    /// the response; once the response is dispatched, the ordered callback may hold the dispatch
+    /// loop until it completes.
     ///
     /// # Example: Handle response in callback
     ///
@@ -5319,7 +5328,7 @@ impl<T> SentRequest<T> {
     ///             }
     ///         })?;
     ///
-    ///     // Handler continues immediately without waiting
+    ///     // Handler continues immediately after registering the callback
     ///     responder.respond(MyResponse { status: "processing".into() })
     /// }, agent_client_protocol::on_receive_request!())
     /// # .connect_to(agent_client_protocol_test::MockTransport).await?;
@@ -5329,17 +5338,22 @@ impl<T> SentRequest<T> {
     ///
     /// # Ordering
     ///
-    /// The callback runs as a spawned task, but the dispatch loop waits for it to complete
-    /// before processing the next message. This gives you ordering guarantees: no other
-    /// messages will be processed while your callback runs.
+    /// When ordered consumption is selected before a peer response is routed during its original
+    /// dispatch, the callback runs in a connection-managed task and the dispatch loop waits for
+    /// it to complete before processing the next message.
     ///
-    /// Call this before the response arrives to select ordered consumption. If
-    /// the response was already routed, or an interceptor routes a retained
-    /// [`ResponseRouter`] after its original dispatch, the callback still runs
-    /// but cannot retroactively block messages that were already released.
+    /// The barrier does not apply when the pending request is failed without an incoming response,
+    /// such as on EOF. If the response was already routed, or an interceptor routes a retained
+    /// [`ResponseRouter`] after its original dispatch, the callback still runs but cannot
+    /// retroactively block messages that were already released.
     ///
-    /// This differs from [`block_task`](Self::block_task), which signals completion immediately
-    /// upon receiving the response (before your code processes it).
+    /// While the barrier is held, the callback must not await a later response, notification, or
+    /// other inbound traffic on the same connection: that traffic cannot be dispatched until the
+    /// callback completes. Spawn follow-up work with [`ConnectionTo::spawn`] and return, or use
+    /// [`block_task`](Self::block_task) from a task already outside the dispatch loop.
+    ///
+    /// This differs from [`block_task`](Self::block_task), which does not select ordered
+    /// consumption: dispatch remains free while the caller processes the delivered response.
     ///
     /// See the [`ordering`](crate::concepts::ordering) module for details on ordering guarantees
     /// and how to avoid deadlocks.
@@ -5352,11 +5366,12 @@ impl<T> SentRequest<T> {
     /// # When to Use
     ///
     /// Use this method when:
-    /// - You're in a handler callback (not a spawned task)
-    /// - You want ordering guarantees (no other messages processed during your callback)
-    /// - You need to do async work before "releasing" control back to the dispatch loop
+    /// - You need to register response handling from a handler callback
+    /// - You want a peer response callback to complete before later messages are dispatched
+    /// - The callback performs bounded work that does not depend on later inbound traffic
     ///
-    /// For spawned tasks where you don't need ordering guarantees, consider [`block_task`](Self::block_task).
+    /// When already outside the dispatch loop and you do not need ordering guarantees, consider
+    /// [`block_task`](Self::block_task).
     #[track_caller]
     pub fn on_receiving_result<F>(
         self,

--- a/src/agent-client-protocol/src/session.rs
+++ b/src/agent-client-protocol/src/session.rs
@@ -261,8 +261,11 @@ where
     /// immediately without blocking the current task. The session handshake, client
     /// response, and proxy setup all happen in a spawned background task.
     ///
-    /// The closure receives the `SessionId` once the session is established, allowing
-    /// you to perform any custom work with that ID (e.g., tracking, logging).
+    /// The closure receives the `SessionId` once the session is established. Use it for logging
+    /// or eventual tracking; it runs concurrently with later connection traffic. Register
+    /// ID-independent state that later handlers must observe before calling this helper. For
+    /// ID-keyed bookkeeping, install a gate or placeholder first, make later handlers await it,
+    /// and populate it from the closure.
     ///
     /// # Example
     ///
@@ -290,13 +293,13 @@ where
     ///
     /// # Ordering
     ///
-    /// The client response and proxy routing are completed, and session runners
-    /// are scheduled, before the dispatch loop processes the next message when
-    /// the session response is routed during its original dispatch. No user
-    /// callback code runs under that ordering guarantee: the callback is invoked
-    /// in a spawned task, so it may wait for later connection traffic. A response
-    /// interceptor that retains the response and routes it later cannot
-    /// retroactively order this setup before messages the loop already processed.
+    /// The client response is queued, proxy routing is installed, and session runners are
+    /// scheduled before the dispatch loop processes the next message when the session response
+    /// is routed during its original dispatch. This is a local ordering guarantee, not a
+    /// guarantee that the response reaches the client before later wire traffic. No user callback
+    /// code runs under the barrier: the callback is invoked in a spawned task, so it may wait for
+    /// later connection traffic. A response interceptor that retains the response and routes it
+    /// later cannot retroactively order this setup before messages the loop already processed.
     pub fn on_proxy_session_start<F, Fut>(
         self,
         responder: Responder<NewSessionResponse>,


### PR DESCRIPTION
- distinguish non-blocking callback registration from the conditional response-dispatch barrier
- document when `on_receiving_*` callbacks can deadlock and when `block_task`/session blocking methods are safe
- correct the 2.0 release notes: 1.x documented session callback ordering but never enforced it; 2.0 orders framework setup while user session work remains concurrent
- add the companion-crate compatibility matrix for the 2.0 release
- clarify connection-scoped MCP server IDs and actionable SessionId-keyed bookkeeping guidance

A timely peer response now carries an ordering barrier when callback consumption was selected first. Failures delivered without an incoming response and delayed routes do not. The previous docs blurred registration, callback execution, and session helper behavior, which obscured both deadlock risks and the actual compatibility change.

This is the documentation follow-up to #282. PR #283 is the separate obsolete-helper cleanup and is already green.