### PR TITLE
fix(acp): flush rejected protocol connections

### DIFF
--- a/src/agent-client-protocol/CHANGELOG.md
+++ b/src/agent-client-protocol/CHANGELOG.md
@@ -81,6 +81,8 @@
   original error or sending protocol traffic in response to a response.
 - Let the version-selecting agent router ignore response-only frames before `initialize` and
   preserve response-only entries beside a valid batched initialization.
+- Let the version-selecting agent router finish flushing an initialization rejection when the
+  peer sends malformed trailing input before closing the transport.
 - Release abandoned v2 and v1 probe implementations before continuing a negotiated v1 fallback.
 - Preserve `MatchDispatchFrom` retry state across chained matchers.
 

--- a/src/agent-client-protocol/src/jsonrpc.rs
+++ b/src/agent-client-protocol/src/jsonrpc.rs
@@ -139,14 +139,6 @@ impl TransportBatchEntry {
         }
     }
 
-    #[cfg(any(feature = "unstable_protocol_v2", test))]
-    fn into_result(self) -> Result<RawJsonRpcMessage, crate::Error> {
-        match self {
-            Self::Message(message) => Ok(message),
-            Self::Malformed { error, .. } => Err(error),
-        }
-    }
-
     fn message_ref(&self) -> Option<&RawJsonRpcMessage> {
         match self {
             Self::Message(message) => Some(message),
@@ -221,13 +213,6 @@ impl TransportBatch {
         &self,
     ) -> impl Iterator<Item = Result<&RawJsonRpcMessage, &crate::Error>> {
         self.entries().map(TransportBatchEntry::as_result)
-    }
-
-    #[cfg(any(feature = "unstable_protocol_v2", test))]
-    pub(crate) fn into_results(
-        self,
-    ) -> impl Iterator<Item = Result<RawJsonRpcMessage, crate::Error>> {
-        self.into_entries().map(TransportBatchEntry::into_result)
     }
 
     fn messages(&self) -> impl Iterator<Item = &RawJsonRpcMessage> {

--- a/src/agent-client-protocol/src/role/acp.rs
+++ b/src/agent-client-protocol/src/role/acp.rs
@@ -697,20 +697,11 @@ async fn reject_initialize(
     drop(tx);
 
     let drain_incoming = async move {
-        while let Some(frame) = rx.next().await {
-            match frame {
-                TransportFrame::Single(_) => {}
-                TransportFrame::Malformed { error, .. } => {
-                    return Err(error);
-                }
-                TransportFrame::Batch(batch) => {
-                    for entry in batch.into_results() {
-                        entry?;
-                    }
-                }
-            }
-        }
-        Ok(())
+        // Later input has no protocol meaning once initialization is rejected.
+        // Keep draining it only so the transport can flush the queued rejection;
+        // treating a malformed trailing frame as fatal would cancel that flush.
+        while rx.next().await.is_some() {}
+        Ok::<_, crate::Error>(())
     };
 
     let ((), ()) = futures::try_join!(future, drain_incoming)?;

--- a/src/agent-client-protocol/tests/protocol_v2.rs
+++ b/src/agent-client-protocol/tests/protocol_v2.rs
@@ -1457,6 +1457,60 @@ async fn protocol_router_rejection_flushes_over_byte_streams() -> Result<(), Err
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn protocol_router_rejection_flushes_with_trailing_malformed_input() -> Result<(), Error> {
+    use tokio::io::{AsyncWriteExt as _, BufReader};
+
+    let agent = Agent
+        .protocol_router()
+        .with_v2(Agent.v2().on_receive_request(
+            async |_initialize: v2::InitializeRequest, responder, _cx| {
+                responder.respond_with_internal_error("v2 implementation should not run")
+            },
+            agent_client_protocol::on_receive_request!(),
+        ));
+
+    let (mut client_writer, server_reader) = tokio::io::duplex(4096);
+    // Keep the outbound pipe full until the malformed input is already queued.
+    let (server_writer, client_reader) = tokio::io::duplex(1);
+    let server_transport = ByteStreams::new(server_writer.compat_write(), server_reader.compat());
+    let agent_task = tokio::spawn(agent.connect_to(server_transport));
+    let mut client_reader = BufReader::new(client_reader);
+
+    write_wire_json(
+        &mut client_writer,
+        &serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": json_value(v1_initialize_request(ProtocolVersion::V1))?,
+        }),
+    )
+    .await?;
+    client_writer
+        .write_all(b"{not json\n")
+        .await
+        .map_err(Error::into_internal_error)?;
+    client_writer
+        .shutdown()
+        .await
+        .map_err(Error::into_internal_error)?;
+
+    let response = read_wire_json(&mut client_reader).await?;
+    assert_eq!(response["id"], 1);
+    assert!(
+        response["error"]["data"]
+            .as_str()
+            .is_some_and(|data| data.contains("supports ACP protocol version 2")),
+        "{response:?}"
+    );
+
+    agent_task
+        .await
+        .map_err(agent_client_protocol::util::internal_error)??;
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn protocol_router_ignores_retained_response_batch_before_initialize() -> Result<(), Error> {
     use tokio::io::{AsyncWriteExt as _, BufReader};
 


### PR DESCRIPTION
- keep draining input after an unsupported protocol initialization so the queued rejection can flush under backpressure
- ignore trailing malformed frames once the connection has already been rejected
- remove dead private batch conversion helpers and add a byte-stream regression test