### PR TITLE
fix(acp): box handler chain links to bound dispatch stack use

### DIFF
--- a/src/agent-client-protocol/src/jsonrpc/handlers.rs
+++ b/src/agent-client-protocol/src/jsonrpc/handlers.rs
@@ -500,6 +500,21 @@ impl<H1, H2> ChainedHandler<H1, H2> {
     }
 }
 
+/// Heap-allocates a handler's dispatch future; `inline(never)` keeps its
+/// construction out of the caller's poll frame.
+#[inline(never)]
+fn boxed_dispatch<Counterpart, H>(
+    handler: &mut H,
+    message: Dispatch,
+    connection: ConnectionTo<Counterpart>,
+) -> crate::BoxFuture<'_, Result<Handled<Dispatch>, crate::Error>>
+where
+    Counterpart: Role,
+    H: HandleDispatchFrom<Counterpart>,
+{
+    Box::pin(handler.handle_dispatch_from(message, connection))
+}
+
 impl<Counterpart: Role, H1, H2> HandleDispatchFrom<Counterpart> for ChainedHandler<H1, H2>
 where
     H1: HandleDispatchFrom<Counterpart>,
@@ -518,20 +533,14 @@ where
         message: Dispatch,
         connection: ConnectionTo<Counterpart>,
     ) -> Result<Handled<Dispatch>, crate::Error> {
-        match self
-            .handler1
-            .handle_dispatch_from(message, connection.clone())
-            .await?
-        {
+        // Box each link so deep chains don't build one giant nested poll
+        // frame per handler and overflow small (e.g. GCD 512 KiB) stacks.
+        match boxed_dispatch(&mut self.handler1, message, connection.clone()).await? {
             Handled::Yes => Ok(Handled::Yes),
             Handled::No {
                 message,
                 retry: retry1,
-            } => match self
-                .handler2
-                .handle_dispatch_from(message, connection)
-                .await?
-            {
+            } => match boxed_dispatch(&mut self.handler2, message, connection).await? {
                 Handled::Yes => Ok(Handled::Yes),
                 Handled::No {
                     message,

--- a/src/agent-client-protocol/src/jsonrpc/handlers.rs
+++ b/src/agent-client-protocol/src/jsonrpc/handlers.rs
@@ -499,6 +499,21 @@ impl<H1, H2> ChainedHandler<H1, H2> {
     }
 }
 
+/// Heap-allocates a handler's dispatch future; `inline(never)` keeps its
+/// construction out of the caller's poll frame.
+#[inline(never)]
+fn boxed_dispatch<Counterpart, H>(
+    handler: &mut H,
+    message: Dispatch,
+    connection: ConnectionTo<Counterpart>,
+) -> crate::BoxFuture<'_, Result<Handled<Dispatch>, crate::Error>>
+where
+    Counterpart: Role,
+    H: HandleDispatchFrom<Counterpart>,
+{
+    Box::pin(handler.handle_dispatch_from(message, connection))
+}
+
 impl<Counterpart: Role, H1, H2> HandleDispatchFrom<Counterpart> for ChainedHandler<H1, H2>
 where
     H1: HandleDispatchFrom<Counterpart>,
@@ -517,20 +532,14 @@ where
         message: Dispatch,
         connection: ConnectionTo<Counterpart>,
     ) -> Result<Handled<Dispatch>, crate::Error> {
-        match self
-            .handler1
-            .handle_dispatch_from(message, connection.clone())
-            .await?
-        {
+        // Box each link so deep chains don't build one giant nested poll
+        // frame per handler and overflow small (e.g. GCD 512 KiB) stacks.
+        match boxed_dispatch(&mut self.handler1, message, connection.clone()).await? {
             Handled::Yes => Ok(Handled::Yes),
             Handled::No {
                 message,
                 retry: retry1,
-            } => match self
-                .handler2
-                .handle_dispatch_from(message, connection)
-                .await?
-            {
+            } => match boxed_dispatch(&mut self.handler2, message, connection).await? {
                 Handled::Yes => Ok(Handled::Yes),
                 Handled::No {
                     message,

--- a/src/agent-client-protocol/tests/jsonrpc_deep_chain_stack.rs
+++ b/src/agent-client-protocol/tests/jsonrpc_deep_chain_stack.rs
@@ -1,0 +1,206 @@
+//! Regression test for stack overflow with deeply chained handlers.
+//!
+//! Consumers like Zed register 10-20 typed handlers on a single connection,
+//! producing a tower of nested `ChainedHandler` futures. In unoptimized
+//! (debug) builds, polling that tower used to consume a large stack frame per
+//! chain link, overflowing threads with small fixed stacks — notably macOS
+//! GCD dispatch threads, which have 512 KiB and ignore `RUST_MIN_STACK`.
+//! See zed-industries/zed#61840.
+//!
+//! This test drives a realistically deep handler chain on a thread restricted
+//! to 512 KiB of stack, in the spirit of that environment. It aborts the
+//! process (stack overflow) if dispatch frames regress.
+
+use agent_client_protocol::role::UntypedRole;
+use agent_client_protocol::{
+    ConnectionTo, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, Responder,
+    SentRequest,
+};
+use serde::{Deserialize, Serialize};
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+/// The stack size of a macOS GCD (libdispatch) worker thread, the smallest
+/// stack the dispatch loop is known to run on in the wild.
+const GCD_STACK_SIZE: usize = 512 * 1024;
+
+/// Test helper to block and wait for a JSON-RPC response.
+async fn recv<T: JsonRpcResponse + Send>(
+    response: SentRequest<T>,
+) -> Result<T, agent_client_protocol::Error> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    response.on_receiving_result(async move |result| {
+        tx.send(result)
+            .map_err(|_| agent_client_protocol::Error::internal_error())
+    })?;
+    rx.await
+        .map_err(|_| agent_client_protocol::Error::internal_error())?
+}
+
+macro_rules! test_message {
+    ($name:ident, $method:literal) => {
+        #[derive(Debug, Clone, Serialize, Deserialize)]
+        struct $name {
+            message: String,
+        }
+
+        impl JsonRpcMessage for $name {
+            fn matches_method(method: &str) -> bool {
+                method == $method
+            }
+
+            fn method(&self) -> &'static str {
+                $method
+            }
+
+            fn to_untyped_message(
+                &self,
+            ) -> Result<agent_client_protocol::UntypedMessage, agent_client_protocol::Error> {
+                agent_client_protocol::UntypedMessage::new(self.method(), self)
+            }
+
+            fn parse_message(
+                method: &str,
+                params: &impl serde::Serialize,
+            ) -> Result<Self, agent_client_protocol::Error> {
+                if !Self::matches_method(method) {
+                    return Err(agent_client_protocol::Error::method_not_found());
+                }
+                agent_client_protocol::util::json_cast(params)
+            }
+        }
+    };
+}
+
+test_message!(PingRequest, "ping");
+test_message!(NopRequest, "nop");
+test_message!(NopNotification, "nop_notification");
+
+impl JsonRpcRequest for PingRequest {
+    type Response = PongResponse;
+}
+
+impl JsonRpcRequest for NopRequest {
+    type Response = PongResponse;
+}
+
+impl JsonRpcNotification for NopNotification {}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PongResponse {
+    echo: String,
+}
+
+impl JsonRpcResponse for PongResponse {
+    fn into_json(self, _method: &str) -> Result<serde_json::Value, agent_client_protocol::Error> {
+        serde_json::to_value(self).map_err(agent_client_protocol::Error::into_internal_error)
+    }
+
+    fn from_value(
+        _method: &str,
+        value: serde_json::Value,
+    ) -> Result<Self, agent_client_protocol::Error> {
+        agent_client_protocol::util::json_cast(&value)
+    }
+}
+
+/// Registers `PingRequest` first (innermost link, so a "ping" traverses the
+/// entire chain before it is claimed), then a pile of handlers for messages
+/// that are never sent — mirroring a consumer that registers a callback per
+/// protocol method.
+macro_rules! deep_chain_server {
+    ($($_idx:literal),*) => {
+        UntypedRole
+            .builder()
+            .on_receive_request(
+                async |request: PingRequest,
+                       responder: Responder<PongResponse>,
+                       _connection: ConnectionTo<UntypedRole>| {
+                    responder.respond(PongResponse {
+                        echo: format!("pong: {}", request.message),
+                    })
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            $(
+                .on_receive_request(
+                    async |request: NopRequest,
+                           responder: Responder<PongResponse>,
+                           _connection: ConnectionTo<UntypedRole>| {
+                        let _ = $_idx;
+                        responder.respond(PongResponse {
+                            echo: request.message,
+                        })
+                    },
+                    agent_client_protocol::on_receive_request!(),
+                )
+                .on_receive_notification(
+                    async |_notification: NopNotification, _cx: ConnectionTo<UntypedRole>| {
+                        Ok(())
+                    },
+                    agent_client_protocol::on_receive_notification!(),
+                )
+            )*
+    };
+}
+
+#[test]
+fn deep_handler_chain_within_small_stack() {
+    let (client_io, server_io) = tokio::io::duplex(1024);
+
+    // The server side runs its whole dispatch loop on a thread with the same
+    // fixed stack budget as a macOS GCD worker.
+    let server = std::thread::Builder::new()
+        .name("small-stack-dispatch".to_string())
+        .stack_size(GCD_STACK_SIZE)
+        .spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("failed to build server runtime");
+            let local = tokio::task::LocalSet::new();
+            local.block_on(&runtime, async move {
+                let (server_reader, server_writer) = tokio::io::split(server_io);
+                let transport = agent_client_protocol::ByteStreams::new(
+                    server_writer.compat_write(),
+                    server_reader.compat(),
+                );
+                // 16 request + 16 notification handlers plus the ping handler:
+                // deeper than a full ACP client/agent registration. Before
+                // the chain links were boxed, this many handlers did not
+                // even compile (layout query depth overflow), and half as
+                // many overflowed the stack below at runtime.
+                let server =
+                    deep_chain_server!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+                server.connect_to(transport).await
+            })
+        })
+        .expect("failed to spawn small-stack thread");
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build client runtime");
+    let local = tokio::task::LocalSet::new();
+    let result = local.block_on(&runtime, async move {
+        let (client_reader, client_writer) = tokio::io::split(client_io);
+        let transport = agent_client_protocol::ByteStreams::new(
+            client_writer.compat_write(),
+            client_reader.compat(),
+        );
+        UntypedRole
+            .builder()
+            .connect_with(transport, async |cx| {
+                let response = recv(cx.send_request(PingRequest {
+                    message: "hello".to_string(),
+                }))
+                .await?;
+                assert_eq!(response.echo, "pong: hello");
+                Ok(())
+            })
+            .await
+    });
+    assert!(result.is_ok(), "client failed: {result:?}");
+
+    let server_result = server.join().expect("server thread panicked");
+    assert!(server_result.is_ok(), "server failed: {server_result:?}");
+}


### PR DESCRIPTION
## Problem

Consumers that register many typed handlers on one connection build a tower of nested `ChainedHandler` futures. Because each link's future was inlined into its parent's, dispatching a message polled the whole tower as one deep, recursively-inlined future. In **unoptimized (debug) builds** every nesting level cost a large stack frame (~14 KiB), so a realistic chain of 10–20 handlers overflowed threads with small fixed stacks.

This is the crash reported in zed-industries/zed#61840: Zed registers ~10–20 typed handlers, dispatch happens on a macOS Grand Central Dispatch worker thread with a **fixed 512 KiB stack** (which ignores `RUST_MIN_STACK`), and restoring an ACP thread crash-loops with SIGILL / EXC_BAD_ACCESS on the stack guard when a `RequestPermissionRequest` arrives. The only downstream workaround so far has been `--config 'profile.dev.package.<crate>.opt-level=1'`, which every consumer would otherwise have to discover for themselves.

A second symptom of the same root cause: sufficiently deep chains (33+ handlers) **failed to compile** at all, with `error: queries overflow the depth limit!` while computing the layout of the `incoming_protocol_actor` async body.

## Fix

Box each link of the handler chain. `ChainedHandler::handle_dispatch_from` now dispatches each sub-handler through a small `#[inline(never)] boxed_dispatch` helper returning `crate::BoxFuture`, so a link's future state lives on the heap rather than inline in its ancestors' poll frames, and the temporary isn't staged in the caller's frame either. The chain-traversal semantics (handler1 then handler2, retry OR-ing) are unchanged.

This is **always on** rather than behind a feature: cargo features must be additive, one allocation per link per message is negligible next to serde parsing, and this path already boxes every user callback future (`to_future_hack` → `BoxFuture`) — so it's a patch-level fix with **no public API change**.

## Measurements

`RUSTC_BOOTSTRAP=1 cargo rustc -- -Zprint-type-sizes` on a test crate with a 17-handler chain (debug), where the generics are monomorphized:

| async body | before | after |
|---|---|---|
| `incoming_protocol_actor` | 13,504 B | 4,272 B |
| `dispatch_dispatch` | 11,520 B | 2,288 B |
| `ChainedHandler::handle_dispatch_from` | 10,296 B | 1,064 B |

These sizes are now **independent of chain depth** (identical at 17 and 33 handlers).

Runtime, on a `std::thread::Builder::new().stack_size(512 * 1024)` thread in a debug build:

| chain depth | before | after |
|---|---|---|
| 17 handlers | overflows 512 KiB | fits |
| 33 handlers | does not compile | fits in **256 KiB** |
| 129 handlers | does not compile | fits in **512 KiB** |

## Regression test

`tests/jsonrpc_deep_chain_stack.rs` registers a 33-handler chain (deeper than a full ACP client/agent registration) and dispatches a request through the whole chain on a 512 KiB thread. Before this change it aborts the process with `thread 'small-stack-dispatch' has overflowed its stack`; after, it passes.

## Downstream (Zed)

The fix is unconditional, so Zed needs no code or feature change — it takes effect on the next `agent-client-protocol` bump (Zed currently pins `=2.0.0`). For local verification ahead of a release:

```toml
[patch.crates-io]
agent-client-protocol = { git = "https://github.com/pnkfelix/acp-rust-sdk", branch = "fix/box-handler-chain-stack-depth" }
```

after which the `opt-level=1` dev-profile workaround for the affected crates should be removable.