### PR TITLE
feat(jsonrpc): add tracked response receipts

### DIFF
--- a/src/agent-client-protocol/src/jsonrpc.rs
+++ b/src/agent-client-protocol/src/jsonrpc.rs
@@ -2692,6 +2692,120 @@ pub fn is_cancel_request_notification<N: JsonRpcNotification>(notification: &N) 
     }
 }
 
+/// Resolves when a tracked JSON-RPC response frame is accepted by the outgoing
+/// transport-frame queue.
+///
+/// This receipt does not indicate that any bytes were written to the transport.
+/// For a response in a batch, it resolves only after every response in the batch
+/// is ready and the aggregate batch frame is accepted by the queue. It resolves
+/// with an error if enqueueing fails or the outgoing actor tears down first.
+///
+/// # Batch handler deadlocks
+///
+/// A batch cannot be enqueued until all of its handlers return. Do not await a
+/// receipt from inside a batch handler. Return from the handler first, or spawn
+/// receipt-dependent side effects so the handler can return immediately.
+#[must_use = "a response receipt must be awaited to observe enqueue completion"]
+pub struct ResponseReceipt {
+    receiver: oneshot::Receiver<Result<(), crate::Error>>,
+}
+
+impl std::fmt::Debug for ResponseReceipt {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ResponseReceipt")
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::future::Future for ResponseReceipt {
+    type Output = Result<(), crate::Error>;
+
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        context: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        match std::pin::Pin::new(&mut self.receiver).poll(context) {
+            std::task::Poll::Ready(Ok(result)) => std::task::Poll::Ready(result),
+            std::task::Poll::Ready(Err(_)) => {
+                std::task::Poll::Ready(Err(response_receipt_teardown_error()))
+            }
+            std::task::Poll::Pending => std::task::Poll::Pending,
+        }
+    }
+}
+
+struct ResponseReceiptSender {
+    state: Arc<ResponseReceiptState>,
+}
+
+impl std::fmt::Debug for ResponseReceiptSender {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ResponseReceiptSender")
+            .finish_non_exhaustive()
+    }
+}
+
+struct ResponseReceiptState {
+    sender: Mutex<Option<oneshot::Sender<Result<(), crate::Error>>>>,
+}
+
+impl ResponseReceiptSender {
+    fn channel() -> (Self, ResponseReceipt) {
+        let (sender, receiver) = oneshot::channel();
+        (
+            Self {
+                state: Arc::new(ResponseReceiptState {
+                    sender: Mutex::new(Some(sender)),
+                }),
+            },
+            ResponseReceipt { receiver },
+        )
+    }
+
+    fn resolve(self, result: Result<(), crate::Error>) {
+        self.state.resolve(result);
+    }
+}
+
+impl ResponseReceiptState {
+    fn resolve(&self, result: Result<(), crate::Error>) {
+        if let Some(sender) = self
+            .sender
+            .lock()
+            .expect("response receipt mutex poisoned")
+            .take()
+        {
+            drop(sender.send(result));
+        }
+    }
+}
+
+impl Drop for ResponseReceiptState {
+    fn drop(&mut self) {
+        if let Some(sender) = self
+            .sender
+            .get_mut()
+            .expect("response receipt mutex poisoned")
+            .take()
+        {
+            drop(sender.send(Err(response_receipt_teardown_error())));
+        }
+    }
+}
+
+fn response_receipt_teardown_error() -> crate::Error {
+    crate::util::internal_error(
+        "outgoing JSON-RPC actor stopped before the response frame was enqueued",
+    )
+}
+
+struct CompletedResponseFrame {
+    frame: TransportFrame,
+    receipts: Vec<ResponseReceiptSender>,
+}
+
 /// Messages send to be serialized over the transport.
 #[derive(Clone)]
 enum ResponseDestination {
@@ -2719,6 +2833,7 @@ impl ResponseDestination {
             responses: (0..slot_count).map(|_| None).collect(),
             abandoned: (0..slot_count).map(|_| None).collect(),
             active_handler_attempts: (0..slot_count).map(|_| 0).collect(),
+            receipts: (0..slot_count).map(|_| None).collect(),
             dispatch_complete: false,
             emitted: false,
         }));
@@ -2737,14 +2852,18 @@ impl ResponseDestination {
         )
     }
 
-    fn complete(self, response: RawJsonRpcMessage) -> Option<TransportFrame> {
+    fn complete(
+        self,
+        response: RawJsonRpcMessage,
+        receipt: Option<ResponseReceiptSender>,
+    ) -> Option<CompletedResponseFrame> {
         match self {
-            Self::Individual(slot) => slot.complete(response),
-            Self::Batch(slot) => slot.complete(response).map(batch_response_frame),
+            Self::Individual(slot) => slot.complete(response, receipt),
+            Self::Batch(slot) => slot.complete(response, receipt).map(batch_response_frame),
         }
     }
 
-    fn abandon(self, fallback: RawJsonRpcMessage) -> Option<TransportFrame> {
+    fn abandon(self, fallback: RawJsonRpcMessage) -> Option<CompletedResponseFrame> {
         match self {
             Self::Individual(_) => None,
             Self::Batch(slot) => slot.abandon(fallback).map(batch_response_frame),
@@ -2769,7 +2888,7 @@ impl ResponseDestination {
         })
     }
 
-    fn finish_handler_attempt(self) -> Option<TransportFrame> {
+    fn finish_handler_attempt(self) -> Option<CompletedResponseFrame> {
         match self {
             Self::Individual(_) => None,
             Self::Batch(slot) => slot.finish_handler_attempt().map(batch_response_frame),
@@ -2783,21 +2902,33 @@ struct IndividualResponseSlot {
 }
 
 impl IndividualResponseSlot {
-    fn complete(self, response: RawJsonRpcMessage) -> Option<TransportFrame> {
+    fn complete(
+        self,
+        response: RawJsonRpcMessage,
+        receipt: Option<ResponseReceiptSender>,
+    ) -> Option<CompletedResponseFrame> {
         if self.completed.swap(true, Ordering::AcqRel) {
             tracing::warn!("Ignoring duplicate completion of JSON-RPC request");
             return None;
         }
 
-        Some(TransportFrame::Single(response))
+        Some(CompletedResponseFrame {
+            frame: TransportFrame::Single(response),
+            receipts: receipt.into_iter().collect(),
+        })
     }
 }
 
-fn batch_response_frame(responses: Vec<RawJsonRpcMessage>) -> TransportFrame {
-    TransportFrame::Batch(
-        TransportBatch::from_messages(responses)
-            .expect("a completed JSON-RPC response batch is non-empty"),
-    )
+fn batch_response_frame(
+    (responses, receipts): (Vec<RawJsonRpcMessage>, Vec<ResponseReceiptSender>),
+) -> CompletedResponseFrame {
+    CompletedResponseFrame {
+        frame: TransportFrame::Batch(
+            TransportBatch::from_messages(responses)
+                .expect("a completed JSON-RPC response batch is non-empty"),
+        ),
+        receipts,
+    }
 }
 
 #[derive(Clone)]
@@ -2814,7 +2945,7 @@ impl std::fmt::Debug for BatchDispatchCompletion {
 }
 
 impl BatchDispatchCompletion {
-    fn complete(self) -> Option<TransportFrame> {
+    fn complete(self) -> Option<CompletedResponseFrame> {
         let mut state = self
             .state
             .lock()
@@ -2841,23 +2972,25 @@ fn promote_abandoned_response(state: &mut BatchResponseState, index: usize) {
     }
 }
 
-fn take_completed_batch(state: &mut BatchResponseState) -> Option<Vec<RawJsonRpcMessage>> {
+fn take_completed_batch(
+    state: &mut BatchResponseState,
+) -> Option<(Vec<RawJsonRpcMessage>, Vec<ResponseReceiptSender>)> {
     if !state.dispatch_complete || state.remaining != 0 || state.emitted {
         return None;
     }
 
     state.emitted = true;
-    Some(
-        state
-            .responses
-            .iter_mut()
-            .map(|response| {
-                response
-                    .take()
-                    .expect("completed JSON-RPC batch has every response slot")
-            })
-            .collect(),
-    )
+    let responses = state
+        .responses
+        .iter_mut()
+        .map(|response| {
+            response
+                .take()
+                .expect("completed JSON-RPC batch has every response slot")
+        })
+        .collect();
+    let receipts = state.receipts.iter_mut().filter_map(Option::take).collect();
+    Some((responses, receipts))
 }
 
 #[derive(Clone)]
@@ -2884,7 +3017,9 @@ impl BatchResponseSlot {
         state.active_handler_attempts[self.index] += 1;
     }
 
-    fn finish_handler_attempt(self) -> Option<Vec<RawJsonRpcMessage>> {
+    fn finish_handler_attempt(
+        self,
+    ) -> Option<(Vec<RawJsonRpcMessage>, Vec<ResponseReceiptSender>)> {
         let mut state = self
             .state
             .lock()
@@ -2898,7 +3033,11 @@ impl BatchResponseSlot {
         take_completed_batch(&mut state)
     }
 
-    fn complete(self, response: RawJsonRpcMessage) -> Option<Vec<RawJsonRpcMessage>> {
+    fn complete(
+        self,
+        response: RawJsonRpcMessage,
+        receipt: Option<ResponseReceiptSender>,
+    ) -> Option<(Vec<RawJsonRpcMessage>, Vec<ResponseReceiptSender>)> {
         let mut state = self
             .state
             .lock()
@@ -2924,11 +3063,15 @@ impl BatchResponseSlot {
 
         state.abandoned[self.index] = None;
         state.responses[self.index] = Some(response);
+        state.receipts[self.index] = receipt;
         state.remaining -= 1;
         take_completed_batch(&mut state)
     }
 
-    fn abandon(self, fallback: RawJsonRpcMessage) -> Option<Vec<RawJsonRpcMessage>> {
+    fn abandon(
+        self,
+        fallback: RawJsonRpcMessage,
+    ) -> Option<(Vec<RawJsonRpcMessage>, Vec<ResponseReceiptSender>)> {
         let mut state = self
             .state
             .lock()
@@ -2959,6 +3102,7 @@ struct BatchResponseState {
     responses: Vec<Option<RawJsonRpcMessage>>,
     abandoned: Vec<Option<RawJsonRpcMessage>>,
     active_handler_attempts: Vec<usize>,
+    receipts: Vec<Option<ResponseReceiptSender>>,
     dispatch_complete: bool,
     emitted: bool,
 }
@@ -3138,6 +3282,8 @@ enum OutgoingMessage {
         response: Result<serde_json::Value, crate::Error>,
 
         destination: ResponseDestination,
+
+        receipt: Option<ResponseReceiptSender>,
     },
 
     /// Send an Error Response that cannot be correlated to a request ID.
@@ -4452,7 +4598,13 @@ pub struct Responder<T: JsonRpcResponse = serde_json::Value> {
     ///
     /// For incoming requests: serializes to JSON and sends over the wire.
     /// For incoming responses: sends to the waiting oneshot channel.
-    send_fn: Box<dyn FnOnce(Result<T, crate::Error>) -> Result<(), crate::Error> + Send>,
+    send_fn: Box<
+        dyn FnOnce(
+                Result<T, crate::Error>,
+                Option<ResponseReceiptSender>,
+            ) -> Result<(), crate::Error>
+            + Send,
+    >,
 
     /// Completes an abandoned batch slot unless an explicit response disarms it.
     drop_guard: ResponderDropGuard,
@@ -4533,17 +4685,20 @@ impl Responder<serde_json::Value> {
             id,
             cancellation,
             destination,
-            send_fn: Box::new(move |response: Result<serde_json::Value, crate::Error>| {
-                send_raw_message(
-                    &message_tx,
-                    OutgoingMessage::Response {
-                        id: id_clone,
-                        method: method_clone,
-                        response,
-                        destination: send_destination,
-                    },
-                )
-            }),
+            send_fn: Box::new(
+                move |response: Result<serde_json::Value, crate::Error>, receipt| {
+                    send_raw_message(
+                        &message_tx,
+                        OutgoingMessage::Response {
+                            id: id_clone,
+                            method: method_clone,
+                            response,
+                            destination: send_destination,
+                            receipt,
+                        },
+                    )
+                },
+            ),
             drop_guard,
         }
     }
@@ -4619,9 +4774,9 @@ impl<T: JsonRpcResponse> Responder<T> {
             id: self.id,
             cancellation: self.cancellation,
             destination: self.destination,
-            send_fn: Box::new(move |input: Result<U, crate::Error>| {
+            send_fn: Box::new(move |input: Result<U, crate::Error>, receipt| {
                 let t_value = wrap_fn(&method, input);
-                (self.send_fn)(t_value)
+                (self.send_fn)(t_value, receipt)
             }),
             drop_guard: self.drop_guard,
         }
@@ -4634,7 +4789,47 @@ impl<T: JsonRpcResponse> Responder<T> {
     ) -> Result<(), crate::Error> {
         tracing::debug!(id = ?self.id, "respond called");
         self.drop_guard.disarm();
-        (self.send_fn)(response)
+        (self.send_fn)(response, None)
+    }
+
+    /// Respond to the JSON-RPC request with either a value (`Ok`) or an error (`Err`)
+    /// and return a receipt for enqueue completion.
+    ///
+    /// The receipt resolves successfully when the response's single
+    /// [`TransportFrame`], or its aggregate batch frame, is accepted by the
+    /// outgoing transport-frame queue. It does not wait for bytes to be written.
+    /// It resolves with an error if enqueueing fails or the outgoing actor tears
+    /// down first.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error immediately if the response cannot enter the outgoing
+    /// protocol queue. After this method returns a receipt, enqueue or actor
+    /// teardown failures are reported by awaiting that receipt.
+    ///
+    /// # Batch handler deadlocks
+    ///
+    /// A batch frame cannot be enqueued until all batch handlers return. Do not
+    /// await the receipt inside a batch handler. Return first, or spawn any side
+    /// effect that awaits the receipt so the handler can return immediately.
+    pub fn respond_with_result_tracked(
+        mut self,
+        response: Result<T, crate::Error>,
+    ) -> Result<ResponseReceipt, crate::Error> {
+        tracing::debug!(id = ?self.id, "tracked respond called");
+        let (sender, receipt) = ResponseReceiptSender::channel();
+        self.drop_guard.disarm();
+        (self.send_fn)(response, Some(sender))?;
+        Ok(receipt)
+    }
+
+    /// Respond to the JSON-RPC request with a value and return a receipt for
+    /// enqueue completion.
+    ///
+    /// See [`respond_with_result_tracked`](Self::respond_with_result_tracked) for
+    /// receipt semantics and the batch-handler deadlock warning.
+    pub fn respond_tracked(self, response: T) -> Result<ResponseReceipt, crate::Error> {
+        self.respond_with_result_tracked(Ok(response))
     }
 
     /// Respond to the JSON-RPC request with a value.

--- a/src/agent-client-protocol/src/jsonrpc/incoming_actor.rs
+++ b/src/agent-client-protocol/src/jsonrpc/incoming_actor.rs
@@ -647,6 +647,7 @@ fn handle_handler_error<Counterpart: Role>(
                 method: reply_target.method,
                 response: Err(error),
                 destination: reply_target.destination,
+                receipt: None,
             },
         ),
         Some(HandlerErrorTarget::Response(reply_target)) => {

--- a/src/agent-client-protocol/src/jsonrpc/outgoing_actor.rs
+++ b/src/agent-client-protocol/src/jsonrpc/outgoing_actor.rs
@@ -1,9 +1,14 @@
 // Types re-exported from crate root
+use std::sync::{Arc, Weak};
+
 use futures::StreamExt as _;
 use futures::channel::mpsc;
 
 use crate::jsonrpc::protocol_compat::ProtocolCompat;
-use crate::jsonrpc::{OutgoingMessage, PendingReplies, RawJsonRpcMessage, TransportFrame};
+use crate::jsonrpc::{
+    CompletedResponseFrame, OutgoingMessage, PendingReplies, RawJsonRpcMessage,
+    ResponseReceiptSender, ResponseReceiptState, TransportFrame, response_receipt_teardown_error,
+};
 use crate::schema::v1::RequestId;
 
 pub type OutgoingMessageTx = mpsc::UnboundedSender<OutgoingMessage>;
@@ -15,6 +20,47 @@ pub(crate) fn send_raw_message(
     tracing::debug!(?message, ?tx, "send_raw_message");
     tx.unbounded_send(message)
         .map_err(crate::util::internal_error)
+}
+
+#[derive(Default)]
+struct ResponseReceiptRegistry {
+    pending: Vec<Weak<ResponseReceiptState>>,
+}
+
+impl ResponseReceiptRegistry {
+    fn register(&mut self, sender: &ResponseReceiptSender) {
+        self.pending.retain(|state| state.strong_count() != 0);
+        self.pending.push(Arc::downgrade(&sender.state));
+    }
+}
+
+impl Drop for ResponseReceiptRegistry {
+    fn drop(&mut self) {
+        for state in self.pending.drain(..).filter_map(|state| state.upgrade()) {
+            state.resolve(Err(response_receipt_teardown_error()));
+        }
+    }
+}
+
+fn enqueue_completed_response(
+    transport_tx: &mpsc::UnboundedSender<TransportFrame>,
+    completed: CompletedResponseFrame,
+) -> Result<(), crate::Error> {
+    match transport_tx.unbounded_send(completed.frame) {
+        Ok(()) => {
+            for receipt in completed.receipts {
+                receipt.resolve(Ok(()));
+            }
+            Ok(())
+        }
+        Err(error) => {
+            let error = crate::Error::into_internal_error(error);
+            for receipt in completed.receipts {
+                receipt.resolve(Err(error.clone()));
+            }
+            Err(error)
+        }
+    }
 }
 
 /// Outgoing protocol actor: Converts application-level OutgoingMessage to protocol-level RawJsonRpcMessage.
@@ -31,12 +77,13 @@ pub(super) async fn outgoing_protocol_actor(
     protocol_compat: ProtocolCompat,
 ) -> Result<(), crate::Error> {
     let mut drain_waiters = Vec::new();
+    let mut receipt_registry = ResponseReceiptRegistry::default();
 
     while let Some(message) = outgoing_rx.next().await {
         tracing::debug!(?message, "outgoing_protocol_actor");
 
         // Create the message to be sent over the transport
-        let (json_rpc_message, destination) = match message {
+        let (json_rpc_message, destination, receipt) = match message {
             OutgoingMessage::CloseAfterDraining { done } => {
                 // Reject later sends while preserving every message that was
                 // already accepted into this receiver's buffer.
@@ -46,17 +93,13 @@ pub(super) async fn outgoing_protocol_actor(
             }
             OutgoingMessage::BatchDispatchComplete { completion } => {
                 if let Some(frame) = completion.complete() {
-                    transport_tx
-                        .unbounded_send(frame)
-                        .map_err(crate::Error::into_internal_error)?;
+                    enqueue_completed_response(&transport_tx, frame)?;
                 }
                 continue;
             }
             OutgoingMessage::BatchHandlerAttemptComplete { destination } => {
                 if let Some(frame) = destination.finish_handler_attempt() {
-                    transport_tx
-                        .unbounded_send(frame)
-                        .map_err(crate::Error::into_internal_error)?;
+                    enqueue_completed_response(&transport_tx, frame)?;
                 }
                 continue;
             }
@@ -79,9 +122,7 @@ pub(super) async fn outgoing_protocol_actor(
                 );
                 let fallback = RawJsonRpcMessage::response(id, fallback);
                 if let Some(frame) = destination.abandon(fallback) {
-                    transport_tx
-                        .unbounded_send(frame)
-                        .map_err(crate::Error::into_internal_error)?;
+                    enqueue_completed_response(&transport_tx, frame)?;
                 }
                 continue;
             }
@@ -180,14 +221,23 @@ pub(super) async fn outgoing_protocol_actor(
                 method,
                 response,
                 destination,
+                receipt,
             } => match protocol_compat.outgoing_response_to(&id, &method, response) {
                 Ok(value) => {
                     tracing::debug!(?id, "Sending success response");
-                    (RawJsonRpcMessage::response(id, Ok(value)), destination)
+                    (
+                        RawJsonRpcMessage::response(id, Ok(value)),
+                        destination,
+                        receipt,
+                    )
                 }
                 Err(error) => {
                     tracing::warn!(?id, %method, ?error, "Sending error response");
-                    (RawJsonRpcMessage::response(id, Err(error)), destination)
+                    (
+                        RawJsonRpcMessage::response(id, Err(error)),
+                        destination,
+                        receipt,
+                    )
                 }
             },
             OutgoingMessage::UncorrelatedErrorResponse { error, destination } => {
@@ -196,14 +246,16 @@ pub(super) async fn outgoing_protocol_actor(
                 (
                     RawJsonRpcMessage::response(RequestId::Null, Err(error)),
                     destination,
+                    None,
                 )
             }
         };
 
-        if let Some(frame) = destination.complete(json_rpc_message) {
-            transport_tx
-                .unbounded_send(frame)
-                .map_err(crate::Error::into_internal_error)?;
+        if let Some(receipt) = receipt.as_ref() {
+            receipt_registry.register(receipt);
+        }
+        if let Some(frame) = destination.complete(json_rpc_message, receipt) {
+            enqueue_completed_response(&transport_tx, frame)?;
         }
     }
 
@@ -215,4 +267,48 @@ pub(super) async fn outgoing_protocol_actor(
         let _ = done.send(());
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::executor::block_on;
+    use futures::future::join;
+
+    use super::*;
+
+    #[test]
+    fn actor_teardown_fails_every_registered_response_receipt() {
+        let (first_sender, first_receipt) = ResponseReceiptSender::channel();
+        let (second_sender, second_receipt) = ResponseReceiptSender::channel();
+        let mut registry = ResponseReceiptRegistry::default();
+        registry.register(&first_sender);
+        registry.register(&second_sender);
+
+        drop(registry);
+
+        let (first_result, second_result) = block_on(join(first_receipt, second_receipt));
+        assert!(first_result.is_err());
+        assert!(second_result.is_err());
+        drop((first_sender, second_sender));
+    }
+
+    #[test]
+    fn response_transport_queue_failure_fails_every_receipt() {
+        let (transport_tx, transport_rx) = mpsc::unbounded();
+        drop(transport_rx);
+        let (first_sender, first_receipt) = ResponseReceiptSender::channel();
+        let (second_sender, second_receipt) = ResponseReceiptSender::channel();
+        let completed = CompletedResponseFrame {
+            frame: TransportFrame::Single(RawJsonRpcMessage::response(
+                RequestId::Null,
+                Ok(serde_json::Value::Null),
+            )),
+            receipts: vec![first_sender, second_sender],
+        };
+
+        assert!(enqueue_completed_response(&transport_tx, completed).is_err());
+        let (first_result, second_result) = block_on(join(first_receipt, second_receipt));
+        assert!(first_result.is_err());
+        assert!(second_result.is_err());
+    }
 }

--- a/src/agent-client-protocol/src/lib.rs
+++ b/src/agent-client-protocol/src/lib.rs
@@ -125,8 +125,8 @@ pub use jsonrpc::{
     HandleConnectionClose, HandleDispatchFrom, Handled, INCOMING_TRANSPORT_CLOSED_REASON,
     IntoHandled, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, Lines,
     NullClose, NullHandler, RawConnectionContext, RawJsonRpcMessage, RawJsonRpcParams, Responder,
-    ResponseRouter, SentRequest, TransportBatch, TransportBatchEntry, TransportFrame,
-    UntypedMessage, is_incoming_transport_closed,
+    ResponseReceipt, ResponseRouter, SentRequest, TransportBatch, TransportBatchEntry,
+    TransportFrame, UntypedMessage, is_incoming_transport_closed,
     run::{ChainRun, NullRun, RunWithConnectionTo},
 };
 pub use jsonrpc::{RequestCancellation, is_cancel_request_notification};

--- a/src/agent-client-protocol/tests/jsonrpc_batch.rs
+++ b/src/agent-client-protocol/tests/jsonrpc_batch.rs
@@ -17,7 +17,8 @@ use std::{
 use agent_client_protocol::{
     Agent, ByteStreams, Channel, ConnectTo, ConnectionTo, Dispatch, Error, HandleDispatchFrom,
     Handled, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse,
-    RawJsonRpcMessage, Responder, TransportBatch, TransportBatchEntry, TransportFrame,
+    RawJsonRpcMessage, Responder, ResponseReceipt, TransportBatch, TransportBatchEntry,
+    TransportFrame,
     role::{Role, UntypedRole},
     schema::ProtocolVersion,
     schema::v1,
@@ -237,6 +238,79 @@ async fn next_deferred_response(
         .expect("deferred responder channel closed unexpectedly")
 }
 
+async fn next_response_receipt(
+    rx: &mut mpsc::UnboundedReceiver<(String, ResponseReceipt)>,
+) -> (String, ResponseReceipt) {
+    tokio::time::timeout(TIMEOUT, rx.next())
+        .await
+        .expect("timed out waiting for response receipt")
+        .expect("response receipt channel closed unexpectedly")
+}
+
+fn start_tracked_server(
+    responder_tx: mpsc::UnboundedSender<(String, Responder<TestResponse>)>,
+    receipt_tx: mpsc::UnboundedSender<(String, ResponseReceipt)>,
+) -> (
+    DuplexStream,
+    BufReader<DuplexStream>,
+    JoinHandle<Result<(), agent_client_protocol::Error>>,
+) {
+    let (peer_writer, sdk_reader) = tokio::io::duplex(8192);
+    let (sdk_writer, peer_reader) = tokio::io::duplex(8192);
+    let transport = ByteStreams::new(sdk_writer.compat_write(), sdk_reader.compat());
+
+    let server = UntypedRole.builder().on_receive_request(
+        async move |request: TestRequest,
+                    responder: Responder<TestResponse>,
+                    connection: ConnectionTo<UntypedRole>| {
+            let message = request.message;
+            if message == "drop responder" {
+                drop(responder);
+                return Ok(());
+            }
+            if message.starts_with("deferred") {
+                return responder_tx
+                    .unbounded_send((message, responder))
+                    .map_err(agent_client_protocol::Error::into_internal_error);
+            }
+            if message == "tracked then notification" {
+                let receipt = responder.respond_tracked(TestResponse {
+                    result: "tracked response".into(),
+                })?;
+                let notification_connection = connection.clone();
+                connection.spawn(async move {
+                    receipt.await?;
+                    notification_connection.send_notification(TestNotification {
+                        message: "after tracked response".into(),
+                    })
+                })?;
+                return Ok(());
+            }
+            if message == "untracked" {
+                return responder.respond(TestResponse {
+                    result: "untracked response".into(),
+                });
+            }
+
+            let response = if message == "tracked error" {
+                Err(agent_client_protocol::Error::internal_error().data("tracked error"))
+            } else {
+                Ok(TestResponse {
+                    result: format!("echo: {message}"),
+                })
+            };
+            let receipt = responder.respond_with_result_tracked(response)?;
+            receipt_tx
+                .unbounded_send((message, receipt))
+                .map_err(agent_client_protocol::Error::into_internal_error)
+        },
+        agent_client_protocol::on_receive_request!(),
+    );
+
+    let server_task = tokio::task::spawn_local(server.connect_to(transport));
+    (peer_writer, BufReader::new(peer_reader), server_task)
+}
+
 fn start_deferred_server(
     responder_tx: mpsc::UnboundedSender<(String, Responder<TestResponse>)>,
 ) -> (
@@ -279,6 +353,199 @@ async fn finish_server(
         .expect("server did not stop after incoming EOF")
         .expect("server task panicked")
         .expect("server connection failed");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn tracked_individual_response_orders_notification_and_leaves_untracked_unchanged() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let (responder_tx, _responder_rx) = mpsc::unbounded();
+            let (receipt_tx, _receipt_rx) = mpsc::unbounded();
+            let (mut peer_writer, mut peer_reader, server_task) =
+                start_tracked_server(responder_tx, receipt_tx);
+
+            write_json_line(
+                &mut peer_writer,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "test/echo",
+                    "params": { "message": "tracked then notification" }
+                }),
+            )
+            .await;
+
+            let response = read_json_line(&mut peer_reader).await;
+            assert_eq!(response["id"], json!(1));
+            assert_eq!(response["result"], json!({ "result": "tracked response" }));
+            let notification = read_json_line(&mut peer_reader).await;
+            assert_eq!(notification["method"], json!("test/notify"));
+            assert_eq!(
+                notification["params"],
+                json!({ "message": "after tracked response" })
+            );
+
+            write_json_line(
+                &mut peer_writer,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "test/echo",
+                    "params": { "message": "untracked" }
+                }),
+            )
+            .await;
+            let untracked = read_json_line(&mut peer_reader).await;
+            assert_eq!(untracked["id"], json!(2));
+            assert_eq!(
+                untracked["result"],
+                json!({ "result": "untracked response" })
+            );
+
+            finish_server(peer_writer, server_task).await;
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn tracked_error_response_receipt_resolves_when_frame_is_enqueued() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let (responder_tx, _responder_rx) = mpsc::unbounded();
+            let (receipt_tx, mut receipt_rx) = mpsc::unbounded();
+            let (mut peer_writer, mut peer_reader, server_task) =
+                start_tracked_server(responder_tx, receipt_tx);
+
+            write_json_line(
+                &mut peer_writer,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "test/echo",
+                    "params": { "message": "tracked error" }
+                }),
+            )
+            .await;
+
+            let (message, receipt) = next_response_receipt(&mut receipt_rx).await;
+            assert_eq!(message, "tracked error");
+            receipt
+                .await
+                .expect("error response frame should be enqueued");
+            let response = read_json_line(&mut peer_reader).await;
+            assert_eq!(response["id"], json!(3));
+            assert_eq!(response["error"]["code"], json!(-32603));
+            assert_eq!(response["error"]["data"], json!("tracked error"));
+
+            finish_server(peer_writer, server_task).await;
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn tracked_batch_receipts_resolve_together_after_aggregate_is_ready() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let (responder_tx, mut responder_rx) = mpsc::unbounded();
+            let (receipt_tx, mut receipt_rx) = mpsc::unbounded();
+            let (mut peer_writer, mut peer_reader, server_task) =
+                start_tracked_server(responder_tx, receipt_tx);
+
+            write_json_line(
+                &mut peer_writer,
+                &json!([
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 4,
+                        "method": "test/echo",
+                        "params": { "message": "immediate tracked" }
+                    },
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 5,
+                        "method": "test/echo",
+                        "params": { "message": "deferred tracked" }
+                    }
+                ]),
+            )
+            .await;
+
+            let (message, mut first_receipt) = next_response_receipt(&mut receipt_rx).await;
+            assert_eq!(message, "immediate tracked");
+            let (message, responder) = next_deferred_response(&mut responder_rx).await;
+            assert_eq!(message, "deferred tracked");
+            assert!(
+                tokio::time::timeout(Duration::from_millis(25), &mut first_receipt)
+                    .await
+                    .is_err(),
+                "a batch receipt resolved before its sibling response was ready"
+            );
+
+            let second_receipt = responder
+                .respond_tracked(TestResponse {
+                    result: "echo: deferred tracked".into(),
+                })
+                .expect("deferred tracked response should be accepted");
+            let (first_result, second_result) = join(first_receipt, second_receipt).await;
+            first_result.expect("first batch receipt should resolve");
+            second_result.expect("second batch receipt should resolve");
+
+            let response = read_json_line(&mut peer_reader).await;
+            let responses = response
+                .as_array()
+                .expect("tracked batch should emit one aggregate array");
+            assert_eq!(responses.len(), 2);
+
+            finish_server(peer_writer, server_task).await;
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn tracked_batch_receipt_resolves_when_sibling_responder_is_abandoned() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let (responder_tx, _responder_rx) = mpsc::unbounded();
+            let (receipt_tx, mut receipt_rx) = mpsc::unbounded();
+            let (mut peer_writer, mut peer_reader, server_task) =
+                start_tracked_server(responder_tx, receipt_tx);
+
+            write_json_line(
+                &mut peer_writer,
+                &json!([
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 6,
+                        "method": "test/echo",
+                        "params": { "message": "tracked sibling" }
+                    },
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 7,
+                        "method": "test/echo",
+                        "params": { "message": "drop responder" }
+                    }
+                ]),
+            )
+            .await;
+
+            let (message, receipt) = next_response_receipt(&mut receipt_rx).await;
+            assert_eq!(message, "tracked sibling");
+            receipt
+                .await
+                .expect("tracked sibling should resolve with abandoned fallback batch");
+            let response = read_json_line(&mut peer_reader).await;
+            let responses = response
+                .as_array()
+                .expect("abandoned sibling should still emit one aggregate array");
+            assert_eq!(responses.len(), 2);
+            assert!(responses.iter().any(|response| {
+                response["id"] == json!(7) && response["error"]["code"] == json!(-32603)
+            }));
+
+            finish_server(peer_writer, server_task).await;
+        })
+        .await;
 }
 
 #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## Summary

Adds optional responder APIs that return a receipt for the outgoing JSON-RPC response:

- `Responder::respond_tracked`
- `Responder::respond_with_result_tracked`
- `ResponseReceipt`

Awaiting the receipt confirms that the response frame has been queued for transport. For a batched request, the receipt waits until the complete batch response is assembled and queued, not merely until one response entry is ready.

The existing responder APIs keep their current behavior. Callers only pay for tracking when they use the new methods.

This gives handlers an ordering point for follow-up work that must happen after the response, such as emitting a notification that refers to a newly accepted resource.

## Related

- Session injection RFD: https://github.com/agentclientprotocol/agent-client-protocol/pull/1261
- First consumer: https://github.com/agentclientprotocol/rust-sdk/pull/339
