### PR TITLE
feat(acp): add stable session restore builders

### DIFF
--- a/md/migration_v2.0.md
+++ b/md/migration_v2.0.md
@@ -317,15 +317,20 @@ stream
 Pass a finite limit instead of `None` to bound concurrency.
 
 `ConnectionTo::attach_session` is no longer public. Create sessions through
-`ConnectionTo::build_session`, `build_session_cwd`, or `build_session_from` instead. Use
-`SessionBuilder::on_session_start` to start without blocking the calling task, or call
-`block_task()` followed by `run_until` or `start_session` outside message handlers. Proxy handlers
-must use `on_proxy_session_start`; only call `block_task().start_session_proxy(...)` from a task
-already outside the dispatch loop, such as a `connect_with` foreground future or a spawned task.
-Directly attaching an already-returned `NewSessionResponse` is no longer supported, so move
+`ConnectionTo::build_session`, `build_session_cwd`, or `build_session_from` instead. Restore
+stable-v1 sessions through `load_session`, `load_session_from`, `resume_session`, or
+`resume_session_from`; blocking `start_session` returns a `RestoredSession` containing the
+`ActiveSession` and exact load or resume response, while `on_session_start` delivers that value to
+its callback. Both builder families expose `on_session_start` for non-blocking use and
+`block_task().start_session()` for tasks already outside the dispatch loop. Restore routing is
+acknowledged before the request is published so `session/load` replay cannot overtake local setup.
+For new sessions, `SessionBuilder::run_until` is also available after `block_task()`. Proxy
+handlers must use `on_proxy_session_start`; only call `block_task().start_session_proxy(...)` from
+a task already outside the dispatch loop, such as a `connect_with` foreground future or a spawned
+task. Directly attaching an already-returned `NewSessionResponse` is no longer supported, so move
 request customization into `build_session_from` before the builder sends `session/new`.
 
-When the session response is routed during its original dispatch, `on_session_start` and
+For new sessions, when the response is routed during its original dispatch, `on_session_start` and
 `on_proxy_session_start` install session routing under the ordered response callback, then spawn
 the user callback. No user callback code runs under that ordering guarantee. The callback itself
 must be `'static`, but its returned future does not need an additional `'static` bound and may

--- a/src/agent-client-protocol-cookbook/src/lib.rs
+++ b/src/agent-client-protocol-cookbook/src/lib.rs
@@ -316,6 +316,13 @@ pub mod connecting_as_client {
     //! With the core SDK's `unstable_mcp_over_acp` feature, the session builder
     //! also supports adding MCP servers with [`with_mcp_server`].
     //!
+    //! Existing stable-v1 sessions can be reopened with [`load_session`] to
+    //! replay history or [`resume_session`] to continue without replay. Their
+    //! blocking `start_session` returns a [`RestoredSession`] containing the
+    //! active session and complete operation response; `on_session_start`
+    //! delivers the same value to its callback. Use either restore operation
+    //! only after initialization advertises its matching capability.
+    //!
     //! # Handling Permission Requests
     //!
     //! Agents may send [`RequestPermissionRequest`] to ask for user approval
@@ -349,7 +356,10 @@ pub mod connecting_as_client {
     //! [`connect_with`]: agent_client_protocol::Builder::connect_with
     //! [`block_task`]: agent_client_protocol::SentRequest::block_task
     //! [`build_session`]: agent_client_protocol::ConnectionTo::build_session
+    //! [`load_session`]: agent_client_protocol::ConnectionTo::load_session
+    //! [`resume_session`]: agent_client_protocol::ConnectionTo::resume_session
     //! [`SessionBuilder`]: agent_client_protocol::SessionBuilder
+    //! [`RestoredSession`]: agent_client_protocol::RestoredSession
     //! [`send_prompt`]: agent_client_protocol::ActiveSession::send_prompt
     //! [`read_update`]: agent_client_protocol::ActiveSession::read_update
     //! [`read_to_string`]: agent_client_protocol::ActiveSession::read_to_string

--- a/src/agent-client-protocol/CHANGELOG.md
+++ b/src/agent-client-protocol/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- Add stable-v1 `load_session*` and `resume_session*` builders that produce a
+  `RestoredSession` containing an `ActiveSession` and the exact operation
+  response. Session routing is active before either restore request is
+  published, preserving required `session/load` replay, and provisional routing
+  is removed after failed restores or dropped in-flight blocking starts.
+  ([#323](https://github.com/agentclientprotocol/rust-sdk/issues/323))
 - *(unstable-v2)* Add runnable draft-v2 agent and one-shot client examples. The
   agent implements the complete baseline session lifecycle; the client handles
   permissions, projects chunk and snapshot updates by message ID, and waits for

--- a/src/agent-client-protocol/src/concepts/sessions.rs
+++ b/src/agent-client-protocol/src/concepts/sessions.rs
@@ -52,6 +52,45 @@
 //! # }
 //! ```
 //!
+//! # Restoring a Session
+//!
+//! Stable protocol v1 direct clients can turn `session/load` and
+//! `session/resume` into a [`RestoredSession`](crate::RestoredSession) without
+//! manually installing session handlers. It contains both the [`ActiveSession`]
+//! and the complete operation-specific response:
+//!
+//! ```no_run
+//! # use agent_client_protocol::{Client, ConnectTo};
+//! # async fn example(transport: impl ConnectTo<Client>) -> Result<(), agent_client_protocol::Error> {
+//! # Client.builder().connect_with(transport, async |cx| {
+//! let restored = cx
+//!     .load_session("session-1", "/path/to/project")
+//!     .block_task()
+//!     .start_session()
+//!     .await?;
+//! let (mut session, load_response) = restored.into_parts();
+//! println!("load response: {load_response:?}");
+//! session.send_prompt("Continue where we left off")?;
+//! # Ok(())
+//! # }).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Use `load_session` only when the agent advertises the top-level
+//! `loadSession` capability. Use `resume_session` to continue without replay
+//! when the agent advertises `sessionCapabilities.resume`.
+//! The matching `load_session_from` and `resume_session_from` helpers preserve
+//! requests assembled elsewhere. Non-blocking callers can use
+//! `on_session_start` instead of `block_task().start_session()`.
+//!
+//! For `session/load`, the SDK acknowledges its local route before publishing
+//! the request, so history updates sent before the load response remain queued
+//! on the returned session. An error removes the provisional route before
+//! later traffic is dispatched. Dropping an in-flight blocking start
+//! immediately deactivates the provisional route and triggers the standard
+//! [`SentRequest`](crate::SentRequest) drop-time cancellation behavior.
+//!
 //! # Sending Prompts
 //!
 //! Inside `run_until`, you get an [`ActiveSession`] that lets you interact

--- a/src/agent-client-protocol/src/jsonrpc.rs
+++ b/src/agent-client-protocol/src/jsonrpc.rs
@@ -2092,10 +2092,11 @@ pub(crate) struct ResponsePayload {
     /// response processing is complete, allowing the dispatch loop to continue
     /// to the next message.
     ///
-    /// This is present only when callback-style consumption was selected before
-    /// the response was routed during its original dispatch. Local error paths,
-    /// blocking consumers, and responses routed later do not hold the dispatch
-    /// loop.
+    /// This is present when ordered response consumption was selected before
+    /// the response was routed during its original dispatch. Public callback
+    /// consumption and framework-owned ordered blocking transforms can hold
+    /// the dispatch loop; ordinary blocking consumers, local error paths, and
+    /// responses routed later do not.
     pub(crate) ack_tx: Option<oneshot::Sender<()>>,
 }
 
@@ -2109,7 +2110,6 @@ struct RequestReadiness {
 }
 
 impl RequestReadiness {
-    #[cfg(feature = "unstable_protocol_v2")]
     fn new(future: impl Future<Output = Result<(), crate::Error>> + Send + 'static) -> Self {
         Self {
             future: future.boxed(),
@@ -4046,6 +4046,34 @@ impl<Counterpart: Role> ConnectionTo<Counterpart> {
         self.send_request_to_with_options(peer, request, true, None, None)
     }
 
+    /// Send an ordered request after `before_send` completes successfully.
+    ///
+    /// The ordering marker and readiness prerequisite are both registered
+    /// before the request enters the outgoing queue. This is used by framework
+    /// setup paths that must acknowledge local routing before the peer can
+    /// observe the request.
+    pub(crate) fn send_ordered_request_to_after<
+        Peer: Role,
+        Req: JsonRpcRequest,
+        BeforeSend: Future<Output = Result<(), crate::Error>> + Send + 'static,
+    >(
+        &self,
+        peer: Peer,
+        request: Req,
+        before_send: BeforeSend,
+    ) -> SentRequest<Req::Response>
+    where
+        Counterpart: HasPeer<Peer>,
+    {
+        self.send_request_to_with_options(
+            peer,
+            request,
+            true,
+            Some(RequestReadiness::new(before_send)),
+            None,
+        )
+    }
+
     fn send_request_to_with_options<Peer: Role, Req: JsonRpcRequest>(
         &self,
         peer: Peer,
@@ -4284,7 +4312,6 @@ impl<Counterpart: Role> ConnectionTo<Counterpart> {
 
     /// Wait until every dynamic-handler update queued before this call has
     /// been applied by the incoming protocol actor.
-    #[cfg(feature = "unstable_protocol_v2")]
     pub(crate) fn dynamic_handler_barrier(&self) -> BoxFuture<'static, Result<(), crate::Error>> {
         let (acknowledgment_tx, acknowledgment_rx) = oneshot::channel();
         if let Err(error) =
@@ -5974,6 +6001,48 @@ impl<T> SentRequest<T> {
         }
     }
 
+    /// Block the current task and transform the typed result before releasing
+    /// the ordered-response barrier.
+    ///
+    /// Framework lifecycle code uses this when success transfers local state
+    /// to the returned value while an error must drop that state before later
+    /// messages from the same transport frame are dispatched. The synchronous
+    /// transform must not wait for additional connection traffic.
+    pub(crate) async fn block_task_with_ordered_result<U>(
+        self,
+        transform: impl FnOnce(Result<T, crate::Error>) -> Result<U, crate::Error>,
+    ) -> Result<U, crate::Error> {
+        let response = await_response_forwarding_cancellation(
+            self.response_rx,
+            &self.cancellation,
+            &self.cancellation_sources,
+        )
+        .await;
+
+        let (result, ack_tx) = match response {
+            Ok(ResponsePayload { result, ack_tx }) => {
+                let typed_result = match result {
+                    Ok(json_value) => (self.to_result)(json_value),
+                    Err(error) => Err(error),
+                };
+                (typed_result, ack_tx)
+            }
+            Err(error) => (
+                Err(crate::util::internal_error(format!(
+                    "response to `{}` never received: {error}",
+                    self.method
+                ))),
+                None,
+            ),
+        };
+
+        let outcome = transform(result);
+        if let Some(acknowledgment) = ack_tx {
+            let _ = acknowledgment.send(());
+        }
+        outcome
+    }
+
     /// Schedule an async task to run when a successful response is received.
     ///
     /// This is a convenience wrapper around [`on_receiving_result`](Self::on_receiving_result)
@@ -6829,7 +6898,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "unstable_protocol_v2")]
     fn connection_for_response_hook_tests() -> (
         ConnectionTo<crate::role::UntypedRole>,
         mpsc::UnboundedReceiver<OutgoingMessage>,
@@ -6989,17 +7057,15 @@ mod tests {
         assert_eq!(error.data, Some(serde_json::json!("response hook failed")));
     }
 
-    #[cfg(feature = "unstable_protocol_v2")]
     #[test]
-    fn outgoing_request_waits_for_readiness_before_publication() {
+    fn ordered_request_waits_for_readiness_before_publication() {
         let (connection, message_rx, pending_replies) = connection_for_response_hook_tests();
         let (ready_tx, ready_rx) = oneshot::channel();
-        let sent = connection.send_request_to_with_response_hook_after(
+        let sent = connection.send_ordered_request_to_after(
             crate::role::UntypedRole,
             UntypedMessage::new("after-ready", serde_json::json!({}))
                 .expect("test request should serialize"),
             async move { ready_rx.await.map_err(crate::Error::into_internal_error) },
-            |_| Ok(()),
         );
 
         let (transport_tx, mut transport_rx) = mpsc::unbounded();
@@ -7037,6 +7103,62 @@ mod tests {
         ));
 
         drop(sent);
+    }
+
+    #[test]
+    fn ordered_blocking_transform_precedes_response_acknowledgment() {
+        let (connection, _message_rx, pending_replies) = connection_for_response_hook_tests();
+        let sent = connection.send_ordered_request_to(
+            crate::role::UntypedRole,
+            UntypedMessage::new("ordered-transform", serde_json::json!({}))
+                .expect("test request should serialize"),
+        );
+        let request_id = sent.id().clone();
+        let pending_reply = pending_replies
+            .remove(&request_id)
+            .expect("the request should have a pending reply");
+        let (dispatch, response_dispatch) = incoming_actor::dispatch_from_response(
+            request_id,
+            pending_reply,
+            Err(crate::Error::invalid_params()),
+        );
+        let Dispatch::Response(result, router) = dispatch else {
+            panic!("expected a response dispatch");
+        };
+        router
+            .route_with_result(result)
+            .expect("response should route to the pending request");
+        let acknowledgment = response_dispatch
+            .complete()
+            .expect("an ordered response should wait for acknowledgment");
+        let acknowledgment = Arc::new(Mutex::new(Some(acknowledgment)));
+        let acknowledgment_probe = acknowledgment.clone();
+
+        let error =
+            futures::executor::block_on(sent.block_task_with_ordered_result(move |result| {
+                assert_eq!(
+                    acknowledgment_probe
+                        .lock()
+                        .expect("acknowledgment mutex poisoned")
+                        .as_mut()
+                        .expect("acknowledgment receiver should remain available")
+                        .try_recv()
+                        .expect("acknowledgment sender should remain open"),
+                    None,
+                    "the ordered response was acknowledged before its transform"
+                );
+                result
+            }))
+            .expect_err("the peer error should survive the ordered transform");
+        assert_eq!(error.code, crate::ErrorCode::InvalidParams);
+
+        let acknowledgment = acknowledgment
+            .lock()
+            .expect("acknowledgment mutex poisoned")
+            .take()
+            .expect("acknowledgment receiver should remain available");
+        futures::executor::block_on(acknowledgment)
+            .expect("the transform should release the ordered response");
     }
 
     #[cfg(feature = "unstable_protocol_v2")]
@@ -7248,7 +7370,6 @@ mod tests {
         assert!(matches!(handled, Handled::No { retry: false, .. }));
     }
 
-    #[cfg(feature = "unstable_protocol_v2")]
     #[test]
     fn dynamic_handler_barrier_acknowledges_prior_messages() {
         let (connection, mut receiver) = connection_with_dynamic_handler_receiver();

--- a/src/agent-client-protocol/src/jsonrpc/dynamic_handler.rs
+++ b/src/agent-client-protocol/src/jsonrpc/dynamic_handler.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "unstable_protocol_v2")]
 use futures::channel::oneshot;
 use futures::future::BoxFuture;
 use uuid::Uuid;
@@ -39,11 +38,10 @@ impl<Counterpart: Role, H: HandleDispatchFrom<Counterpart>> DynHandleDispatchFro
 pub(crate) enum DynamicHandlerMessage<Counterpart: Role> {
     AddDynamicHandler(Uuid, Box<dyn DynHandleDispatchFrom<Counterpart>>),
     RemoveDynamicHandler(Uuid),
-    /// Marks the end of the registrations queued by an ordered response callback.
+    /// Marks the end of updates queued during ordered response processing.
     Barrier,
     /// Acknowledges after every preceding dynamic-handler message has been
     /// applied by the incoming protocol actor.
-    #[cfg(feature = "unstable_protocol_v2")]
     AcknowledgedBarrier(oneshot::Sender<()>),
 }
 
@@ -59,7 +57,6 @@ impl<Counterpart: Role> std::fmt::Debug for DynamicHandlerMessage<Counterpart> {
                 f.debug_tuple("RemoveDynamicHandler").field(arg0).finish()
             }
             Self::Barrier => f.write_str("Barrier"),
-            #[cfg(feature = "unstable_protocol_v2")]
             Self::AcknowledgedBarrier(_) => f.write_str("AcknowledgedBarrier"),
         }
     }

--- a/src/agent-client-protocol/src/jsonrpc/incoming_actor.rs
+++ b/src/agent-client-protocol/src/jsonrpc/incoming_actor.rs
@@ -347,7 +347,6 @@ async fn handle_dynamic_handler_message<Counterpart: Role>(
             dynamic_handlers.remove(&uuid);
         }
         DynamicHandlerMessage::Barrier => {}
-        #[cfg(feature = "unstable_protocol_v2")]
         DynamicHandlerMessage::AcknowledgedBarrier(acknowledgment) => {
             let _ = acknowledgment.send(());
         }

--- a/src/agent-client-protocol/src/session.rs
+++ b/src/agent-client-protocol/src/session.rs
@@ -3,16 +3,18 @@ use std::{future::Future, marker::PhantomData, path::Path};
 use futures::channel::{mpsc, oneshot};
 
 use crate::{
-    Agent, Client, ConnectionTo, Dispatch, HandleDispatchFrom, Handled, Responder, Role,
+    Agent, Client, ConnectionTo, Dispatch, HandleDispatchFrom, Handled, JsonRpcRequest, Responder,
+    Role,
     jsonrpc::{
         DynamicHandlerGuard,
         run::{NullRun, RunWithConnectionTo},
     },
     role::{HasPeer, acp::ProxySessionMessages},
     schema::v1::{
-        ContentBlock, ContentChunk, NewSessionRequest, NewSessionResponse, PromptRequest,
-        PromptResponse, SessionConfigOption, SessionId, SessionModeState, SessionNotification,
-        SessionUpdate, StopReason,
+        ContentBlock, ContentChunk, LoadSessionRequest, LoadSessionResponse, Meta,
+        NewSessionRequest, NewSessionResponse, PromptRequest, PromptResponse, ResumeSessionRequest,
+        ResumeSessionResponse, SessionConfigOption, SessionId, SessionModeState,
+        SessionNotification, SessionUpdate, StopReason,
     },
     util::{MatchDispatch, MatchDispatchFrom, run_until},
 };
@@ -75,6 +77,60 @@ where
         SessionBuilder::new(self, request)
     }
 
+    /// Stable protocol v1 session builder that loads an existing session.
+    ///
+    /// The returned builder installs session routing before publishing
+    /// `session/load`, so replay notifications sent before the response are
+    /// available through the restored [`ActiveSession`].
+    ///
+    /// Call this only when the initialization response advertises
+    /// `agentCapabilities.loadSession`.
+    pub fn load_session(
+        &self,
+        session_id: impl Into<SessionId>,
+        cwd: impl AsRef<Path>,
+    ) -> RestoreSessionBuilder<Counterpart, LoadSessionRequest> {
+        self.load_session_from(LoadSessionRequest::new(session_id, cwd.as_ref()))
+    }
+
+    /// Stable protocol v1 session builder from an existing `session/load`
+    /// request.
+    ///
+    /// Use this to send a typed request assembled or intercepted elsewhere
+    /// without rebuilding it.
+    pub fn load_session_from(
+        &self,
+        request: LoadSessionRequest,
+    ) -> RestoreSessionBuilder<Counterpart, LoadSessionRequest> {
+        RestoreSessionBuilder::new(self, request)
+    }
+
+    /// Stable protocol v1 session builder that resumes an existing session.
+    ///
+    /// This is the `session/resume` counterpart of
+    /// [`load_session`](Self::load_session), but continues without replaying
+    /// conversation history. Call this only when the initialization response
+    /// advertises `agentCapabilities.sessionCapabilities.resume`.
+    pub fn resume_session(
+        &self,
+        session_id: impl Into<SessionId>,
+        cwd: impl AsRef<Path>,
+    ) -> RestoreSessionBuilder<Counterpart, ResumeSessionRequest> {
+        self.resume_session_from(ResumeSessionRequest::new(session_id, cwd.as_ref()))
+    }
+
+    /// Stable protocol v1 session builder from an existing `session/resume`
+    /// request.
+    ///
+    /// Use this to send a typed request assembled or intercepted elsewhere
+    /// without rebuilding it.
+    pub fn resume_session_from(
+        &self,
+        request: ResumeSessionRequest,
+    ) -> RestoreSessionBuilder<Counterpart, ResumeSessionRequest> {
+        RestoreSessionBuilder::new(self, request)
+    }
+
     /// Given a session response received from the agent,
     /// attach a handler to process messages related to this session
     /// and let you access them.
@@ -98,22 +154,395 @@ where
             ..
         } = response;
 
-        let (update_tx, update_rx) = mpsc::unbounded();
-        let handler = ActiveSessionHandler::new(session_id.clone(), update_tx.clone());
-        let session_handler_registration = self.add_dynamic_handler(handler)?;
-
-        Ok(ActiveSession {
+        let prepared = self.prepare_session_routing(&session_id)?;
+        Ok(prepared.into_active_session(
+            self.clone(),
             session_id,
             modes,
             config_options,
             meta,
+            mcp_handler_registrations,
+        ))
+    }
+
+    /// Install the update channel and handler for `session_id`.
+    ///
+    /// Restore requests call this before request publication. Dropping the
+    /// returned value deactivates and removes the route.
+    fn prepare_session_routing(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<PreparedSession<Counterpart>, crate::Error> {
+        let (update_tx, update_rx) = mpsc::unbounded();
+        let handler = ActiveSessionHandler::new(session_id.clone(), update_tx.clone());
+        let session_handler_registration = self.add_dynamic_handler(handler)?;
+
+        Ok(PreparedSession {
             update_rx,
             update_tx,
-            connection: self.clone(),
             session_handler_registration,
+        })
+    }
+}
+
+/// Session-routing state installed before a restore request is published.
+struct PreparedSession<Counterpart: Role>
+where
+    Counterpart: HasPeer<Agent>,
+{
+    update_rx: mpsc::UnboundedReceiver<SessionMessage>,
+    update_tx: mpsc::UnboundedSender<SessionMessage>,
+    session_handler_registration: DynamicHandlerGuard<Counterpart>,
+}
+
+impl<Counterpart> PreparedSession<Counterpart>
+where
+    Counterpart: HasPeer<Agent>,
+{
+    fn into_active_session<'runner>(
+        self,
+        connection: ConnectionTo<Counterpart>,
+        session_id: SessionId,
+        modes: Option<SessionModeState>,
+        config_options: Option<Vec<SessionConfigOption>>,
+        meta: Option<Meta>,
+        mcp_handler_registrations: Vec<DynamicHandlerGuard<Counterpart>>,
+    ) -> ActiveSession<'runner, Counterpart> {
+        ActiveSession {
+            session_id,
+            modes,
+            config_options,
+            meta,
+            update_rx: self.update_rx,
+            update_tx: self.update_tx,
+            connection,
+            session_handler_registration: self.session_handler_registration,
             mcp_handler_registrations,
             _runner: PhantomData,
+        }
+    }
+}
+
+/// Internal behavior shared by the two stable restore operations.
+trait RestoreRequest: JsonRpcRequest {
+    fn session_id(&self) -> &SessionId;
+    fn response_modes(response: &Self::Response) -> Option<SessionModeState>;
+    fn response_config_options(response: &Self::Response) -> Option<Vec<SessionConfigOption>>;
+    fn response_meta(response: &Self::Response) -> Option<Meta>;
+}
+
+impl RestoreRequest for LoadSessionRequest {
+    fn session_id(&self) -> &SessionId {
+        &self.session_id
+    }
+
+    fn response_modes(response: &Self::Response) -> Option<SessionModeState> {
+        response.modes.clone()
+    }
+
+    fn response_config_options(response: &Self::Response) -> Option<Vec<SessionConfigOption>> {
+        response.config_options.clone()
+    }
+
+    fn response_meta(response: &Self::Response) -> Option<Meta> {
+        response.meta.clone()
+    }
+}
+
+impl RestoreRequest for ResumeSessionRequest {
+    fn session_id(&self) -> &SessionId {
+        &self.session_id
+    }
+
+    fn response_modes(response: &Self::Response) -> Option<SessionModeState> {
+        response.modes.clone()
+    }
+
+    fn response_config_options(response: &Self::Response) -> Option<Vec<SessionConfigOption>> {
+        response.config_options.clone()
+    }
+
+    fn response_meta(response: &Self::Response) -> Option<Meta> {
+        response.meta.clone()
+    }
+}
+
+/// Stable protocol v1 builder for `session/load` or `session/resume`.
+///
+/// Use [`ConnectionTo::load_session`] or [`ConnectionTo::resume_session`] to
+/// construct this builder. Use the matching `_from` method to send an existing
+/// typed request without rebuilding it.
+///
+/// The `BlockState` parameter mirrors [`SessionBuilder`]:
+/// - [`NonBlocking`] exposes `on_session_start` on each concrete operation.
+/// - [`Blocking`], selected with [`Self::block_task`], exposes
+///   `start_session`.
+///
+/// Session routing is acknowledged before the request can reach the peer.
+/// Dropping a pending blocking start removes that routing and applies the
+/// standard [`SentRequest`](crate::SentRequest) drop-time cancellation
+/// behavior. Error responses remove the route before later entries in the same
+/// transport frame are dispatched.
+#[must_use = "use `start_session` or `on_session_start` to restore the session"]
+#[derive(Debug)]
+pub struct RestoreSessionBuilder<Counterpart, Request, BlockState = NonBlocking>
+where
+    Counterpart: HasPeer<Agent>,
+    BlockState: SessionBlockState,
+{
+    connection: ConnectionTo<Counterpart>,
+    request: Request,
+    block_state: PhantomData<BlockState>,
+}
+
+impl<Counterpart, Request> RestoreSessionBuilder<Counterpart, Request, NonBlocking>
+where
+    Counterpart: HasPeer<Agent>,
+{
+    fn new(connection: &ConnectionTo<Counterpart>, request: Request) -> Self {
+        Self {
+            connection: connection.clone(),
+            request,
+            block_state: PhantomData,
+        }
+    }
+
+    /// Mark this restore builder as able to block the current task.
+    ///
+    /// Do not use the resulting blocking methods inside a message handler.
+    pub fn block_task(self) -> RestoreSessionBuilder<Counterpart, Request, Blocking> {
+        RestoreSessionBuilder {
+            connection: self.connection,
+            request: self.request,
+            block_state: PhantomData,
+        }
+    }
+}
+
+fn restored_session<Counterpart, Request>(
+    connection: ConnectionTo<Counterpart>,
+    session_id: SessionId,
+    prepared: PreparedSession<Counterpart>,
+    response: Request::Response,
+) -> RestoredSession<'static, Counterpart, Request::Response>
+where
+    Counterpart: HasPeer<Agent>,
+    Request: RestoreRequest,
+{
+    let session = prepared.into_active_session(
+        connection,
+        session_id,
+        Request::response_modes(&response),
+        Request::response_config_options(&response),
+        Request::response_meta(&response),
+        Vec::new(),
+    );
+
+    RestoredSession { session, response }
+}
+
+fn on_restore_session_start<Counterpart, Request, F, Fut>(
+    builder: RestoreSessionBuilder<Counterpart, Request>,
+    op: F,
+) -> Result<(), crate::Error>
+where
+    Counterpart: HasPeer<Agent>,
+    Request: RestoreRequest,
+    F: FnOnce(RestoredSession<'static, Counterpart, Request::Response>) -> Fut + Send + 'static,
+    Fut: Future<Output = Result<(), crate::Error>> + Send,
+{
+    ensure_v1_session_protocol(&builder.connection)?;
+
+    let RestoreSessionBuilder {
+        connection,
+        request,
+        block_state: _,
+    } = builder;
+    let session_id = request.session_id().clone();
+    let prepared = connection.prepare_session_routing(&session_id)?;
+    let routing_ready = connection.dynamic_handler_barrier();
+
+    connection
+        .send_ordered_request_to_after(Agent, request, routing_ready)
+        .on_receiving_result({
+            let connection = connection.clone();
+            async move |result| {
+                let response = result?;
+                let restored = restored_session::<_, Request>(
+                    connection.clone(),
+                    session_id,
+                    prepared,
+                    response,
+                );
+                connection.spawn(async move { op(restored).await })
+            }
         })
+}
+
+async fn start_restored_session<Counterpart, Request>(
+    builder: RestoreSessionBuilder<Counterpart, Request, Blocking>,
+) -> Result<RestoredSession<'static, Counterpart, Request::Response>, crate::Error>
+where
+    Counterpart: HasPeer<Agent>,
+    Request: RestoreRequest,
+{
+    ensure_v1_session_protocol(&builder.connection)?;
+
+    let RestoreSessionBuilder {
+        connection,
+        request,
+        block_state: _,
+    } = builder;
+    let session_id = request.session_id().clone();
+    let prepared = connection.prepare_session_routing(&session_id)?;
+    let routing_ready = connection.dynamic_handler_barrier();
+    let session_connection = connection.clone();
+
+    connection
+        .send_ordered_request_to_after(Agent, request, routing_ready)
+        .block_task_with_ordered_result(move |result| {
+            let response = result?;
+            Ok(restored_session::<_, Request>(
+                session_connection,
+                session_id,
+                prepared,
+                response,
+            ))
+        })
+        .await
+}
+
+impl<Counterpart> RestoreSessionBuilder<Counterpart, LoadSessionRequest>
+where
+    Counterpart: HasPeer<Agent>,
+{
+    /// Restore with `session/load` in the background and run `op` once its
+    /// exact response and active session are available.
+    ///
+    /// This returns immediately and is safe to call from a message handler.
+    /// Replay notifications can arrive before the response and are retained by
+    /// the returned session.
+    pub fn on_session_start<F, Fut>(self, op: F) -> Result<(), crate::Error>
+    where
+        F: FnOnce(RestoredSession<'static, Counterpart, LoadSessionResponse>) -> Fut
+            + Send
+            + 'static,
+        Fut: Future<Output = Result<(), crate::Error>> + Send,
+    {
+        on_restore_session_start(self, op)
+    }
+}
+
+impl<Counterpart> RestoreSessionBuilder<Counterpart, ResumeSessionRequest>
+where
+    Counterpart: HasPeer<Agent>,
+{
+    /// Restore with `session/resume` in the background and run `op` once its
+    /// exact response and active session are available.
+    ///
+    /// This returns immediately and is safe to call from a message handler.
+    /// The returned session receives subsequent session traffic.
+    pub fn on_session_start<F, Fut>(self, op: F) -> Result<(), crate::Error>
+    where
+        F: FnOnce(RestoredSession<'static, Counterpart, ResumeSessionResponse>) -> Fut
+            + Send
+            + 'static,
+        Fut: Future<Output = Result<(), crate::Error>> + Send,
+    {
+        on_restore_session_start(self, op)
+    }
+}
+
+impl<Counterpart> RestoreSessionBuilder<Counterpart, LoadSessionRequest, Blocking>
+where
+    Counterpart: HasPeer<Agent>,
+{
+    /// Publish `session/load`, wait on the current task, and return an
+    /// [`ActiveSession`] together with the exact [`LoadSessionResponse`].
+    ///
+    /// Requires [`block_task`](RestoreSessionBuilder::block_task). Dropping
+    /// this future while it is pending cancels the request and removes the
+    /// provisional session route.
+    pub async fn start_session(
+        self,
+    ) -> Result<RestoredSession<'static, Counterpart, LoadSessionResponse>, crate::Error> {
+        start_restored_session(self).await
+    }
+}
+
+impl<Counterpart> RestoreSessionBuilder<Counterpart, ResumeSessionRequest, Blocking>
+where
+    Counterpart: HasPeer<Agent>,
+{
+    /// Publish `session/resume`, wait on the current task, and return an
+    /// [`ActiveSession`] together with the exact [`ResumeSessionResponse`].
+    ///
+    /// Requires [`block_task`](RestoreSessionBuilder::block_task). Dropping
+    /// this future while it is pending cancels the request and removes the
+    /// provisional session route.
+    pub async fn start_session(
+        self,
+    ) -> Result<RestoredSession<'static, Counterpart, ResumeSessionResponse>, crate::Error> {
+        start_restored_session(self).await
+    }
+}
+
+/// A restored stable-v1 session and the exact operation response that opened
+/// it.
+///
+/// The session ID comes from the load or resume request because stable-v1
+/// restore responses do not repeat it. Keeping the response separate preserves
+/// every operation-specific field without reconstructing it from session
+/// state.
+pub struct RestoredSession<'runner, Link, Response>
+where
+    Link: HasPeer<Agent>,
+{
+    session: ActiveSession<'runner, Link>,
+    response: Response,
+}
+
+impl<'runner, Link, Response> RestoredSession<'runner, Link, Response>
+where
+    Link: HasPeer<Agent>,
+{
+    /// Access the active session.
+    pub fn session(&self) -> &ActiveSession<'runner, Link> {
+        &self.session
+    }
+
+    /// Mutably access the active session, for example to consume replay.
+    pub fn session_mut(&mut self) -> &mut ActiveSession<'runner, Link> {
+        &mut self.session
+    }
+
+    /// Access the complete load or resume response.
+    pub fn response(&self) -> &Response {
+        &self.response
+    }
+
+    /// Split the restored value into its active session and exact response.
+    pub fn into_parts(self) -> (ActiveSession<'runner, Link>, Response) {
+        (self.session, self.response)
+    }
+
+    /// Consume this value and return only the active session.
+    pub fn into_session(self) -> ActiveSession<'runner, Link> {
+        self.session
+    }
+}
+
+impl<Link, Response> std::fmt::Debug for RestoredSession<'_, Link, Response>
+where
+    Link: HasPeer<Agent>,
+    Response: std::fmt::Debug,
+{
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RestoredSession")
+            .field("session_id", self.session.session_id())
+            .field("response", &self.response)
+            .finish()
     }
 }
 
@@ -832,7 +1261,7 @@ fn ensure_v1_session_protocol<Counterpart: Role>(
     }
 
     Err(crate::Error::invalid_request().data(
-        "`build_session` uses ACP protocol v1 types, but this is a protocol v2 connection; \
+        "stable session builders use ACP protocol v1 types, but this is a protocol v2 connection; \
          use the `V2ConnectionTo` supplied to `Client.v2()` callbacks",
     ))
 }

--- a/src/agent-client-protocol/tests/session_restore.rs
+++ b/src/agent-client-protocol/tests/session_restore.rs
@@ -1,0 +1,538 @@
+//! Stable protocol v1 direct-client restore lifecycle (`session/load` and
+//! `session/resume`).
+
+use std::{future::pending, path::PathBuf, time::Duration};
+
+use agent_client_protocol::{
+    Agent, Channel, Client, ConnectionTo, Error, ErrorCode, JsonRpcMessage, JsonRpcNotification,
+    RawJsonRpcMessage, Responder, SessionMessage, TransportBatch, TransportFrame, UntypedMessage,
+    schema::v1::{
+        CancelRequestNotification, ContentBlock, ContentChunk, LoadSessionRequest,
+        LoadSessionResponse, RequestId, ResumeSessionRequest, ResumeSessionResponse,
+        SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOption, SessionId,
+        SessionMode, SessionModeId, SessionModeState, SessionNotification, SessionUpdate,
+        TextContent,
+    },
+};
+use futures::{
+    StreamExt as _,
+    channel::{mpsc, oneshot},
+    future::{self, Either},
+};
+use serde::{Deserialize, Serialize};
+
+const TIMEOUT: Duration = Duration::from_secs(10);
+const DISPATCH_BARRIER_METHOD: &str = "_test/session-restore-dispatch-barrier";
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcNotification)]
+#[notification(method = "_test/session-restore-dispatch-barrier")]
+struct DispatchBarrierNotification {}
+
+fn modes_state() -> SessionModeState {
+    SessionModeState::new(
+        SessionModeId::new("default"),
+        vec![SessionMode::new(SessionModeId::new("default"), "Default")],
+    )
+}
+
+fn config_options() -> Vec<SessionConfigOption> {
+    vec![
+        SessionConfigOption::select(
+            "thinking",
+            "Thinking",
+            "standard",
+            vec![
+                SessionConfigSelectOption::new("standard", "Standard"),
+                SessionConfigSelectOption::new("extended", "Extended"),
+            ],
+        )
+        .category(SessionConfigOptionCategory::ThoughtLevel),
+    ]
+}
+
+fn meta(trace: &str) -> serde_json::Map<String, serde_json::Value> {
+    serde_json::json!({ "trace": trace })
+        .as_object()
+        .expect("test metadata should be an object")
+        .clone()
+}
+
+fn update_notification(session_id: SessionId, text: &str) -> RawJsonRpcMessage {
+    RawJsonRpcMessage::notification(
+        "session/update".to_owned(),
+        serde_json::to_value(SessionNotification::new(
+            session_id,
+            SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::Text(
+                TextContent::new(text),
+            ))),
+        ))
+        .expect("session notification should serialize"),
+    )
+    .expect("session notification should form valid JSON-RPC parameters")
+}
+
+fn dispatch_barrier_notification() -> RawJsonRpcMessage {
+    RawJsonRpcMessage::notification(DISPATCH_BARRIER_METHOD.to_owned(), serde_json::json!({}))
+        .expect("dispatch barrier should form valid JSON-RPC parameters")
+}
+
+fn session_message_text(message: SessionMessage) -> String {
+    let SessionMessage::SessionMessage(dispatch) = message else {
+        panic!("expected a session notification")
+    };
+    let untyped = dispatch
+        .to_untyped_message()
+        .expect("session dispatch should convert to an untyped message");
+    let notification = SessionNotification::parse_message(untyped.method(), untyped.params())
+        .expect("session notification should parse");
+    let SessionUpdate::AgentMessageChunk(ContentChunk {
+        content: ContentBlock::Text(text),
+        ..
+    }) = notification.update
+    else {
+        panic!("expected an agent text chunk")
+    };
+    text.text
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn load_session_preserves_pre_response_replay_and_exact_response() {
+    let session_id = SessionId::new("restore-load");
+    let client_session_id = session_id.clone();
+    let peer_session_id = session_id.clone();
+    let expected = LoadSessionResponse::new()
+        .modes(modes_state())
+        .config_options(config_options())
+        .meta(meta("load"));
+    let wire_response = expected.clone();
+    let (transport, mut peer) = Channel::duplex();
+    let (done_tx, done_rx) = oneshot::channel();
+
+    let client = Client
+        .builder()
+        .connect_with(transport, async move |connection| {
+            connection
+                .load_session(client_session_id.clone(), "/restore/load")
+                .on_session_start(async move |mut restored| {
+                    assert_eq!(restored.session().session_id(), &client_session_id);
+                    assert_eq!(restored.session().modes(), expected.modes.as_ref());
+                    assert_eq!(
+                        restored.session().config_options(),
+                        expected.config_options.as_deref()
+                    );
+                    assert_eq!(restored.session().meta(), expected.meta.as_ref());
+                    assert_eq!(restored.response(), &expected);
+                    assert_eq!(
+                        session_message_text(restored.session_mut().read_update().await?),
+                        "first replay"
+                    );
+                    assert_eq!(
+                        session_message_text(restored.session_mut().read_update().await?),
+                        "second replay"
+                    );
+                    done_tx.send(()).map_err(|()| Error::internal_error())
+                })?;
+
+            done_rx.await.map_err(Error::into_internal_error)
+        });
+
+    let peer = async move {
+        let Some(TransportFrame::Single(RawJsonRpcMessage::Request(request))) =
+            peer.rx.next().await
+        else {
+            panic!("expected session/load")
+        };
+        let parsed = LoadSessionRequest::parse_message(&request.method, &request.params)?;
+        assert_eq!(parsed.session_id, peer_session_id);
+        assert_eq!(parsed.cwd, PathBuf::from("/restore/load"));
+
+        let batch = TransportBatch::from_messages([
+            update_notification(parsed.session_id.clone(), "first replay"),
+            update_notification(parsed.session_id, "second replay"),
+            RawJsonRpcMessage::response(request.id, Ok(serde_json::to_value(wire_response)?)),
+        ])
+        .expect("restore batch should be non-empty");
+        peer.tx
+            .unbounded_send(TransportFrame::Batch(batch))
+            .expect("client should accept replay and response");
+
+        while peer.rx.next().await.is_some() {}
+        Ok::<(), Error>(())
+    };
+
+    tokio::time::timeout(TIMEOUT, async { futures::try_join!(client, peer) })
+        .await
+        .expect("load restore timed out")
+        .expect("load restore failed");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn resume_session_returns_exact_response_and_an_active_session() {
+    let session_id = SessionId::new("restore-resume");
+    let client_session_id = session_id.clone();
+    let expected = ResumeSessionResponse::new()
+        .modes(modes_state())
+        .config_options(config_options())
+        .meta(meta("resume"));
+    let wire_response = expected.clone();
+    let (transport, mut peer) = Channel::duplex();
+
+    let client = Client
+        .builder()
+        .connect_with(transport, async move |connection| {
+            let mut restored = connection
+                .resume_session(client_session_id.clone(), "/restore/resume")
+                .block_task()
+                .start_session()
+                .await?;
+            assert_eq!(restored.session().session_id(), &client_session_id);
+            assert_eq!(restored.session().modes(), expected.modes.as_ref());
+            assert_eq!(
+                restored.session().config_options(),
+                expected.config_options.as_deref()
+            );
+            assert_eq!(restored.session().meta(), expected.meta.as_ref());
+            assert_eq!(restored.response(), &expected);
+            assert_eq!(
+                session_message_text(restored.session_mut().read_update().await?),
+                "resume update"
+            );
+
+            let (session, response) = restored.into_parts();
+            assert_eq!(session.session_id(), &client_session_id);
+            assert_eq!(response, expected);
+            Ok(())
+        });
+
+    let peer = async move {
+        let Some(TransportFrame::Single(RawJsonRpcMessage::Request(request))) =
+            peer.rx.next().await
+        else {
+            panic!("expected session/resume")
+        };
+        let parsed = ResumeSessionRequest::parse_message(&request.method, &request.params)?;
+        assert_eq!(parsed.session_id, session_id);
+
+        let batch = TransportBatch::from_messages([
+            RawJsonRpcMessage::response(request.id, Ok(serde_json::to_value(wire_response)?)),
+            update_notification(parsed.session_id, "resume update"),
+        ])
+        .expect("resume batch should be non-empty");
+        peer.tx
+            .unbounded_send(TransportFrame::Batch(batch))
+            .expect("client should accept update and response");
+
+        while peer.rx.next().await.is_some() {}
+        Ok::<(), Error>(())
+    };
+
+    tokio::time::timeout(TIMEOUT, async { futures::try_join!(client, peer) })
+        .await
+        .expect("resume restore timed out")
+        .expect("resume restore failed");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn resume_session_from_preserves_the_existing_request() {
+    let session_id = SessionId::new("restore-from");
+    let expected_request = ResumeSessionRequest::new(session_id.clone(), "/restore/from")
+        .additional_directories(vec![PathBuf::from("/restore/extra")])
+        .meta(meta("request"));
+    let client_request = expected_request.clone();
+    let peer_request = expected_request.clone();
+    let (transport, mut peer) = Channel::duplex();
+
+    let client = Client
+        .builder()
+        .connect_with(transport, async move |connection| {
+            let restored = connection
+                .resume_session_from(client_request)
+                .block_task()
+                .start_session()
+                .await?;
+            assert_eq!(restored.session().session_id(), &session_id);
+            Ok(())
+        });
+
+    let peer = async move {
+        let Some(TransportFrame::Single(RawJsonRpcMessage::Request(request))) =
+            peer.rx.next().await
+        else {
+            panic!("expected session/resume")
+        };
+        assert_eq!(
+            ResumeSessionRequest::parse_message(&request.method, &request.params)?,
+            peer_request
+        );
+        peer.tx
+            .unbounded_send(TransportFrame::Single(RawJsonRpcMessage::response(
+                request.id,
+                Ok(serde_json::to_value(ResumeSessionResponse::new())?),
+            )))
+            .expect("client should accept resume response");
+        while peer.rx.next().await.is_some() {}
+        Ok::<(), Error>(())
+    };
+
+    tokio::time::timeout(TIMEOUT, async { futures::try_join!(client, peer) })
+        .await
+        .expect("restore-from timed out")
+        .expect("restore-from failed");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn restore_waits_for_routing_acknowledgment_before_publication() {
+    let (handler_started_tx, mut handler_started_rx) = mpsc::unbounded();
+    let client = Client.builder().on_receive_request(
+        async move |_request: UntypedMessage,
+                    _responder: Responder<serde_json::Value>,
+                    _connection: ConnectionTo<Agent>| {
+            handler_started_tx
+                .unbounded_send(())
+                .map_err(Error::into_internal_error)?;
+            pending::<Result<(), Error>>().await
+        },
+        agent_client_protocol::on_receive_request!(),
+    );
+    let (transport, mut peer) = Channel::duplex();
+    let (restore_called_tx, restore_called_rx) = oneshot::channel();
+    let (checked_tx, checked_rx) = oneshot::channel();
+
+    let client = client.connect_with(transport, async move |connection| {
+        handler_started_rx
+            .next()
+            .await
+            .ok_or_else(Error::internal_error)?;
+        connection
+            .load_session("routing-barrier", "/restore/barrier")
+            .on_session_start(async |_restored| Ok(()))?;
+        restore_called_tx
+            .send(())
+            .map_err(|()| Error::internal_error())?;
+        checked_rx.await.map_err(Error::into_internal_error)
+    });
+
+    let peer = async move {
+        peer.tx
+            .unbounded_send(TransportFrame::Single(RawJsonRpcMessage::request(
+                "test/block-incoming".to_owned(),
+                serde_json::json!({}),
+                RequestId::Number(1),
+            )?))
+            .expect("client should accept the blocking request");
+        restore_called_rx
+            .await
+            .map_err(Error::into_internal_error)?;
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(200), peer.rx.next())
+                .await
+                .is_err(),
+            "restore request was published before the incoming actor acknowledged its route"
+        );
+        checked_tx.send(()).map_err(|()| Error::internal_error())?;
+        Ok::<(), Error>(())
+    };
+
+    tokio::time::timeout(TIMEOUT, async { futures::try_join!(client, peer) })
+        .await
+        .expect("routing-barrier test timed out")
+        .expect("routing-barrier test failed");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn failed_restore_removes_routing_before_later_batch_entries() {
+    let session_id = SessionId::new("restore-failed");
+    let client_session_id = session_id.clone();
+    let (transport, mut peer) = Channel::duplex();
+    let (barrier_tx, mut barrier_rx) = mpsc::unbounded();
+
+    let client = Client.builder().on_receive_notification(
+        async move |_notification: DispatchBarrierNotification,
+                    _connection: ConnectionTo<Agent>| {
+            barrier_tx
+                .unbounded_send(())
+                .map_err(Error::into_internal_error)
+        },
+        agent_client_protocol::on_receive_notification!(),
+    );
+
+    let client = client.connect_with(transport, async move |connection| {
+        let error = connection
+            .load_session(client_session_id.clone(), "/restore/fail")
+            .block_task()
+            .start_session()
+            .await
+            .expect_err("agent should reject session/load");
+        assert_eq!(error.code, ErrorCode::InvalidParams);
+        barrier_rx.next().await.ok_or_else(Error::internal_error)?;
+
+        let mut restored = connection
+            .load_session(client_session_id, "/restore/retry")
+            .block_task()
+            .start_session()
+            .await?;
+        assert_eq!(
+            session_message_text(restored.session_mut().read_update().await?),
+            "after failed restore"
+        );
+        Ok(())
+    });
+
+    let peer = async move {
+        let Some(TransportFrame::Single(RawJsonRpcMessage::Request(request))) =
+            peer.rx.next().await
+        else {
+            panic!("expected session/load")
+        };
+        let batch = TransportBatch::from_messages([
+            RawJsonRpcMessage::response(
+                request.id,
+                Err(Error::invalid_params().data("restore refused")),
+            ),
+            update_notification(session_id, "after failed restore"),
+            dispatch_barrier_notification(),
+        ])
+        .expect("failure batch should be non-empty");
+        peer.tx
+            .unbounded_send(TransportFrame::Batch(batch))
+            .expect("client should accept failure, probe, and barrier");
+
+        let Some(TransportFrame::Single(RawJsonRpcMessage::Request(retry))) = peer.rx.next().await
+        else {
+            panic!("expected retry session/load")
+        };
+        peer.tx
+            .unbounded_send(TransportFrame::Single(RawJsonRpcMessage::response(
+                retry.id,
+                Ok(serde_json::to_value(LoadSessionResponse::new())?),
+            )))
+            .expect("client should accept retry response");
+        while peer.rx.next().await.is_some() {}
+        Ok::<(), Error>(())
+    };
+
+    tokio::time::timeout(TIMEOUT, async { futures::try_join!(client, peer) })
+        .await
+        .expect("failure cleanup timed out")
+        .expect("failure cleanup failed");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn cancelling_restore_cancels_request_and_removes_routing() {
+    let session_id = SessionId::new("restore-cancelled");
+    let client_session_id = session_id.clone();
+    let (transport, mut peer) = Channel::duplex();
+    let (request_seen_tx, request_seen_rx) = oneshot::channel();
+    let (future_dropped_tx, future_dropped_rx) = oneshot::channel();
+    let (barrier_tx, mut barrier_rx) = mpsc::unbounded();
+    let (barrier_observed_tx, barrier_observed_rx) = oneshot::channel();
+
+    let client = Client.builder().on_receive_notification(
+        async move |_notification: DispatchBarrierNotification,
+                    _connection: ConnectionTo<Agent>| {
+            barrier_tx
+                .unbounded_send(())
+                .map_err(Error::into_internal_error)
+        },
+        agent_client_protocol::on_receive_notification!(),
+    );
+
+    let client = client.connect_with(transport, async move |connection| {
+        let pending_restore = Box::pin(
+            connection
+                .resume_session(client_session_id.clone(), "/restore/cancel")
+                .block_task()
+                .start_session(),
+        );
+
+        match future::select(pending_restore, request_seen_rx).await {
+            Either::Right((seen, pending_restore)) => {
+                seen.map_err(Error::into_internal_error)?;
+                drop(pending_restore);
+            }
+            Either::Left((result, _)) => {
+                panic!("restore completed before cancellation: {result:?}")
+            }
+        }
+        future_dropped_tx
+            .send(())
+            .map_err(|()| Error::internal_error())?;
+        barrier_rx.next().await.ok_or_else(Error::internal_error)?;
+        barrier_observed_tx
+            .send(())
+            .map_err(|()| Error::internal_error())?;
+
+        let mut restored = connection
+            .resume_session(client_session_id, "/restore/after-cancel")
+            .block_task()
+            .start_session()
+            .await?;
+        assert_eq!(
+            session_message_text(restored.session_mut().read_update().await?),
+            "after cancelled restore"
+        );
+        Ok(())
+    });
+
+    let peer = async move {
+        let Some(TransportFrame::Single(RawJsonRpcMessage::Request(request))) =
+            peer.rx.next().await
+        else {
+            panic!("expected session/resume")
+        };
+        let restore_request_id = request.id.clone();
+        request_seen_tx
+            .send(())
+            .map_err(|()| Error::internal_error())?;
+        future_dropped_rx
+            .await
+            .map_err(Error::into_internal_error)?;
+
+        let Some(TransportFrame::Single(RawJsonRpcMessage::Notification(notification))) =
+            peer.rx.next().await
+        else {
+            panic!("dropping the restore future should send $/cancel_request")
+        };
+        let cancellation =
+            CancelRequestNotification::parse_message(&notification.method, &notification.params)?;
+        assert_eq!(cancellation.request_id, restore_request_id);
+
+        let probe_batch = TransportBatch::from_messages([
+            update_notification(session_id, "after cancelled restore"),
+            dispatch_barrier_notification(),
+        ])
+        .expect("cancellation probe batch should be non-empty");
+        peer.tx
+            .unbounded_send(TransportFrame::Batch(probe_batch))
+            .expect("client should accept cancellation probe and barrier");
+        barrier_observed_rx
+            .await
+            .map_err(Error::into_internal_error)?;
+
+        peer.tx
+            .unbounded_send(TransportFrame::Single(RawJsonRpcMessage::response(
+                request.id,
+                Err(Error::request_cancelled()),
+            )))
+            .expect("client should accept the cancelled request's response");
+
+        let Some(TransportFrame::Single(RawJsonRpcMessage::Request(retry))) = peer.rx.next().await
+        else {
+            panic!("expected retry session/resume")
+        };
+        peer.tx
+            .unbounded_send(TransportFrame::Single(RawJsonRpcMessage::response(
+                retry.id,
+                Ok(serde_json::to_value(ResumeSessionResponse::new())?),
+            )))
+            .expect("client should accept retry response");
+        while peer.rx.next().await.is_some() {}
+        Ok::<(), Error>(())
+    };
+
+    tokio::time::timeout(TIMEOUT, async { futures::try_join!(client, peer) })
+        .await
+        .expect("cancellation cleanup timed out")
+        .expect("cancellation cleanup failed");
+}


### PR DESCRIPTION
## Summary

- add stable-v1 direct-client builders for loading and resuming sessions
- return both the active session and the exact operation response
- establish session routing before publishing restore requests, preserving load replay and cleaning up routes on failure or cancellation
- add integration coverage and update the changelog, migration guide, concepts, and cookbook documentation

Closes #323.

## Test plan

- `RUSTC_WRAPPER= just test`
- formatting, typos, and Clippy with warnings denied
- Rustdoc and mdBook builds
- semver compatibility checks
- Rust 1.88 native and WASI checks
- all core feature combinations
- repeated session-restore regression tests
- `git diff --check`